### PR TITLE
docs: 0.3.x patches (#4-#8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,16 @@ For background execution, streaming, and durable workflows, see [Choosing An Exe
 - Laravel **13+**
 - `laravel/ai` **^0.6**
 
-This package declares `"minimum-stability": "dev"` with `"prefer-stable": true`. Keep `prefer-stable` enabled in consuming applications unless you intentionally want Composer to resolve unstable transitive releases.
+This package declares `"minimum-stability": "dev"` with `"prefer-stable": true` because `laravel/ai` is still pre-1.0 and ships dev-tagged releases. Composer will not resolve a pre-stable transitive dependency from a stable consuming project, so your application's `composer.json` must also set:
+
+```json
+{
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}
+```
+
+`prefer-stable` keeps Composer biased toward tagged releases — only dependencies without a stable release (today, `laravel/ai`) resolve to a `dev-` constraint. This requirement will be dropped when `laravel/ai` reaches 1.0; the package will then move to `"minimum-stability": "stable"` and consuming applications will be free to do the same.
 
 Laravel Swarm orchestrates the same Laravel AI agents, providers, and streams as your application. Treat Composer updates to Laravel or `laravel/ai` as integration-test events: run your test suite and any queued, streamed, or durable swarm smoke paths after dependency changes. This package's [changelog](CHANGELOG.md) covers Swarm-owned changes; it does not replace verification against upstream Laravel or Laravel AI releases.
 
@@ -475,9 +484,9 @@ Use [Persistence And History](docs/persistence-and-history.md), [Maintenance](do
 - Use database persistence for durable execution, long-lived history, active-run pruning protection, or operational dashboards.
 - Set `SWARM_CAPTURE_ACTIVE_CONTEXT=true` for queued and durable swarms.
 - Size queue worker timeouts and queue `retry_after` above the longest expected provider call.
-- Schedule `swarm:relay` every minute for durable execution — without it, durable runs stall after the first checkpoint.
-- Schedule `swarm:recover` for durable execution and coordinated multi-worker hierarchical queueing.
-- Schedule `swarm:prune` for database retention cleanup, or set `SWARM_PREVENT_PRUNE=true` when retention is managed outside the package.
+- Schedule `swarm:relay` every minute for durable execution. The relay drains the transactional outbox after each checkpoint — without it, durable runs stall after the first step. See [Durable Execution](docs/durable-execution.md) for the full relay reference.
+- Schedule `swarm:recover` every five minutes for durable execution and coordinated multi-worker hierarchical queueing. Recovery redispatches runs whose workers died between checkpoint and dispatch. See [Maintenance](docs/maintenance.md).
+- Schedule `swarm:prune` daily for database retention cleanup, or set `SWARM_PREVENT_PRUNE=true` when retention is managed outside the package.
 - Treat operational swarm tables as TTL-based runtime storage, not immutable compliance archives.
 - Bind `SwarmAuditSink` for regulated evidence export.
 - Bind `SwarmTelemetrySink` for logs, metrics, or tracing correlation.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -95,8 +95,22 @@ nested secrets inside JSON unless your application handles that separately.
 ## Composer minimum-stability
 
 The package uses `"minimum-stability": "dev"` with `"prefer-stable": true` in
-[`composer.json`](composer.json). Applications should keep **`prefer-stable` enabled**
-so Composer prefers stable releases for transitive dependencies where possible.
+[`composer.json`](composer.json) because `laravel/ai` is pre-1.0 and ships
+dev-tagged releases. Composer will not resolve a pre-stable transitive from a
+stable consuming project, so applications **must propagate the same setting**:
+
+```json
+{
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}
+```
+
+`prefer-stable` keeps Composer biased toward tagged releases — only
+dependencies without a stable release (today, `laravel/ai`) resolve to a `dev-`
+constraint. This requirement will be dropped when `laravel/ai` reaches 1.0; the
+package will then move to `"minimum-stability": "stable"` and consuming
+applications will be free to do the same.
 
 ## Durable Outbox: Queue Connection Rename Hazard
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,7 @@ The recommended reading path for new users.
 - [Logging & Tracing](observability-logging-tracing.md) — telemetry sink, structured logs, OTEL
 - [Correlation Contract](observability-correlation-contract.md)
 - [Audit Evidence](audit-evidence-contract.md)
+- [Metadata Allowlist Governance](metadata-allowlist-governance.md) — what belongs in metadata, named anti-patterns, and the allowlist review pattern
 - [Pulse](pulse.md) — Laravel Pulse cards for run counts and step latencies
 
 ---
@@ -77,6 +78,7 @@ The recommended reading path for new users.
 - [Configuration](configuration.md) — every config key, grouped and searchable
 - [Public Surface](public-surface.md)
 - [Maintenance](maintenance.md)
+- [APP_KEY Rotation](app-key-rotation.md) — runbook for rotating the application key alongside sealed swarm rows
 
 ---
 

--- a/docs/app-key-rotation.md
+++ b/docs/app-key-rotation.md
@@ -1,0 +1,150 @@
+# APP_KEY Rotation
+
+Laravel Swarm seals selected sensitive string columns with Laravel's encrypter
+when database persistence is active and `swarm.persistence.encrypt_at_rest` is
+`true` (the default). Sealing uses your application's `APP_KEY`. Rotating that
+key without a re-encryption plan leaves the existing sealed rows unreadable.
+
+This document covers the runbook: what is affected, what is not, how to
+re-encrypt live operational rows, and how rotation interacts with retention.
+
+## The Asymmetry
+
+Two classes of data flow through Laravel Swarm. They react to `APP_KEY`
+rotation in different ways:
+
+- **Operational rows** stored in `swarm_*` database tables (context input,
+  run history step I/O, durable branch input and output, hierarchical node
+  outputs, child durable run outputs). When `encrypt_at_rest` is on, the
+  sealed string columns are prefixed `sw0:` and decrypt with the active key.
+  **Rotating `APP_KEY` without re-encrypting these rows makes the sealed
+  fields unreadable.**
+- **Audit evidence payloads** emitted through `SwarmAuditSink`. Evidence
+  records never include raw prompt text or agent outputs and are not sealed
+  by the package — they are owned by your application's audit target.
+  **Rotating `APP_KEY` does not affect archived evidence.**
+
+The same applies to telemetry payloads emitted through `SwarmTelemetrySink`:
+they carry redacted or allowlisted fields only, and are not sealed by the
+package.
+
+## What Breaks After Rotation
+
+When `APP_KEY` no longer matches the key used to write the sealed rows,
+decrypt calls fail. The behavior is governed by
+`swarm.persistence.decrypt_failure_policy`:
+
+| Policy           | Behavior on the affected rows                                  |
+|------------------|----------------------------------------------------------------|
+| `null_with_log`  | Sealed field returns `null`; a warning is logged once per row. |
+| `legacy`         | Sealed field returns the raw `sw0:` ciphertext string.         |
+| `throw`          | Decrypt exception bubbles up. Reads fail loudly.               |
+
+The default is `null_with_log`, so rotation without a plan does not crash
+reads — it silently nulls out the sealed fields. Run history, durable
+inspection, and operator commands continue to operate; the redacted output is
+the only visible symptom. Audit evidence emissions and lifecycle events keep
+their full structure because they do not depend on reading old sealed rows.
+
+JSON columns (`data`, `metadata`, `artifacts`, persisted context payloads) are
+not sealed by `encrypt_at_rest`. They survive rotation as-is. If your
+application stores secrets inside those JSON payloads with its own encrypter,
+plan its rotation independently.
+
+## Recommended Strategy: Drain Then Rotate
+
+The simplest, safest sequence for most applications is to **drain old sealed
+rows out of the operational tables before you rotate**. The package already
+treats operational tables as TTL-based runtime storage, not immutable archives,
+so this aligns with the intended retention model.
+
+1. Schedule (or run on demand) `swarm:prune` until rows older than your
+   retention window are gone. The relevant categories are listed in
+   [Maintenance](maintenance.md).
+2. Drain the durable outbox so no in-flight runs are mid-checkpoint when you
+   cut over:
+
+   ```bash
+   php artisan swarm:relay --drain-until-empty
+   php artisan swarm:health --durable
+   ```
+
+3. Quiesce queue workers and let any active synchronous runs finish.
+4. Rotate `APP_KEY` and deploy.
+5. Resume workers. New runs will be sealed with the new key.
+
+This avoids re-encryption entirely. The cost is the wait for the retention
+window to clear.
+
+## Re-Encryption Strategy For Live Rows
+
+Some applications cannot wait for retention to drain — long-running durable
+runs, active waits, or longer retention windows make a flush impractical. In
+that case re-encrypt the sealed columns in place during a maintenance window:
+
+1. Take a backup of the swarm tables.
+2. Set the application to read-only (or block traffic that mutates swarm
+   state). Stop queue workers. Stop the scheduler so `swarm:relay` and
+   `swarm:recover` do not run mid-rotation.
+3. Add the new key to your environment but keep the old key available to
+   application code — for example by writing a small script that holds the
+   old `Encrypter` instance in memory.
+4. For each sealed column (see the schema reference in [Persistence And
+   History](persistence-and-history.md)), iterate rows where the column starts
+   with `sw0:`, decrypt with the old key, encrypt with the new key, and write
+   the re-prefixed value back. Process in bounded batches and commit each
+   batch.
+5. After every sealed column is rewritten, promote the new key to `APP_KEY`
+   and deploy.
+6. Resume workers and the scheduler.
+
+Test the script against a staging copy of the production database before
+running it for real. Keep `swarm.persistence.decrypt_failure_policy` at
+`null_with_log` during the migration so any column the script misses surfaces
+in logs rather than crashing reads.
+
+## Interaction With Retention Windows
+
+Retention is configured by `swarm.retention.*` (see
+[Configuration](configuration.md)) and enforced by `swarm:prune`. Rotation
+planning should account for the longest retention window across all swarm
+table categories:
+
+- **Run history** keeps step I/O for the configured retention.
+- **Durable runtime** keeps cursors and branch records until the run finishes
+  and retention expires.
+- **Persisted stream replay** keeps stream events for its own retention.
+
+A drain-then-rotate plan is only as fast as the longest active retention. If
+you keep durable run history for 90 days and a durable run is currently
+waiting on a signal that is 60 days old, the row will not prune until it
+terminates and then ages out. Either lower the relevant retention temporarily,
+finish or cancel the long-lived run, or use the in-place re-encryption path
+above.
+
+## Audit Evidence Is Not Re-Sealed
+
+Archived evidence is owned by your application sink — an append-only table, an
+object store bucket, a SIEM, or any equivalent. The package does not seal it,
+does not re-seal it, and does not retain a handle to it. Treat evidence as a
+separate encryption-at-rest concern (storage-level encryption on the
+destination, KMS rotation on the bucket, etc.) and plan that lifecycle
+independently of `APP_KEY`.
+
+The [Audit Evidence Contract](audit-evidence-contract.md) production checklist
+already calls this out:
+
+> Rotate `APP_KEY` in coordination with your encryption-at-rest plan for
+> database-persisted operational rows; archived evidence payloads are not
+> affected by key rotation.
+
+## Related Reading
+
+- [Persistence And History](persistence-and-history.md) — column-level
+  sealing scope and the `sw0:` prefix.
+- [Configuration](configuration.md) — `swarm.persistence.encrypt_at_rest`,
+  `swarm.persistence.decrypt_failure_policy`, and retention keys.
+- [Maintenance](maintenance.md) — `swarm:prune`, `swarm:relay`, and
+  `swarm:recover` reference.
+- [Audit Evidence Contract](audit-evidence-contract.md) — what evidence
+  contains and why it is unaffected by rotation.

--- a/docs/audit-evidence-contract.md
+++ b/docs/audit-evidence-contract.md
@@ -239,6 +239,8 @@ class S3AuditSink implements SwarmAuditSink
 
 Run metadata is developer-supplied and is not validated or sanitized by the package. By default, metadata values are excluded from audit and telemetry payloads — only key names are included. Use the controls below to decide exactly what reaches your sinks.
 
+> See [Metadata Allowlist Governance](metadata-allowlist-governance.md) for the policy guide — what belongs in metadata, named anti-patterns (raw user identifiers, regulated product names, authentication material), and the review checklist to apply when extending the allowlist.
+
 ### Allowlist approach
 
 Set a comma-separated list of allowed metadata key names. Only keys in the list will have their values included in the `metadata` field of sink payloads:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,7 +40,7 @@ Controls the primary persistence driver and at-rest encryption behavior. Changin
 
 > **Note:** JSON columns (context data, metadata, artifacts) remain structured JSON in the database; `encrypt_at_rest` seals designated string columns only. Do not store secrets inside JSON payloads unless your application encrypts them separately.
 
-> **Key rotation:** Rotating `APP_KEY` without re-encrypting existing rows leaves them undecipherable. Plan key rotation with your operational model.
+> **Key rotation:** Rotating `APP_KEY` without re-encrypting existing rows leaves them undecipherable. Plan key rotation with your operational model. See [APP_KEY Rotation](app-key-rotation.md) for the runbook.
 
 ---
 

--- a/docs/metadata-allowlist-governance.md
+++ b/docs/metadata-allowlist-governance.md
@@ -1,0 +1,146 @@
+# Metadata Allowlist Governance
+
+Run metadata is developer-supplied. Laravel Swarm does not validate, sanitize,
+or shape the values. When you allowlist a metadata key with
+`SWARM_AUDIT_METADATA_ALLOWLIST` or `SWARM_OBSERVABILITY_METADATA_ALLOWLIST`,
+the raw value flows verbatim into every audit evidence payload or telemetry
+emission for that run. The allowlist is the only line of defense between your
+application's metadata bag and your sinks.
+
+This document covers what should go in metadata, what should not, the named
+anti-patterns to avoid, and the review pattern to apply whenever the allowlist
+is extended.
+
+## Metadata vs Capture Payloads
+
+The two paths into Laravel Swarm's persistence and audit surfaces look similar
+but have different contracts.
+
+**Capture payloads** carry the substance of a swarm run — the input prompt,
+agent outputs, step I/O, artifact contents. They are governed by capture
+flags (`swarm.capture.inputs`, `outputs`, `artifacts`, `active_context`) and
+redacted to `[redacted]` when capture is off. Capture payloads are sealed
+at rest when database encryption is enabled. They are **never** included in
+audit evidence or telemetry. See [Persistence And History](persistence-and-history.md).
+
+**Metadata** is structured tagging supplied by the developer when a swarm is
+dispatched — `tenant_id`, `workflow_type`, internal correlation IDs, feature
+flags. It exists to **classify** runs so operators can filter dashboards,
+audit logs, and telemetry. Metadata values are excluded from sink payloads by
+default; only the allowlist lets a specific key's value through.
+
+The rule of thumb:
+
+> If the field describes **which run this is**, it is metadata. If it
+> describes **what the run is doing or saying**, it is capture.
+
+Metadata that belongs:
+
+- Tenant or organization identifiers used for partitioning and access control.
+- Workflow type, lifecycle stage, or feature-flag bucket.
+- Internal correlation IDs for cross-system tracing (job ID, request trace
+  ID, deploy hash).
+- Coarse routing labels (`region`, `priority`, `tier`).
+
+Metadata that does not belong:
+
+- Raw user prompts, agent outputs, document text, tool arguments. Use capture.
+- Customer-supplied free text (chat messages, support ticket bodies). Use
+  capture.
+- Anything you would not want to see verbatim in a SIEM query result.
+
+## Named Anti-Patterns
+
+Audit and telemetry sinks are typically wired to long-retention destinations
+(SIEMs, object storage, append-only tables). Allowlisted metadata values land
+there in plaintext, often outside the application's encryption-at-rest
+boundary. The following patterns should be rejected during review.
+
+### Raw User Identifiers
+
+Email addresses, phone numbers, government IDs, and unhashed customer IDs.
+Allowlisting `customer_email` puts every email address into the audit stream.
+
+**Prefer:** a tenant-scoped surrogate (`customer_uuid`, `account_id`) that
+does not directly identify the person. If the audit target legitimately needs
+the email, perform the lookup at query time rather than capturing it on every
+emission.
+
+### Regulated Product Or Account Names
+
+Health conditions, regulated financial product names, case identifiers from
+legal or HR systems. Anything that would make the bare metadata value
+sensitive on its own under HIPAA, GLBA, or analogous regimes.
+
+**Prefer:** an opaque token (`case_token`, `product_code`) plus a separate
+authoritative lookup the audit reviewer can reach.
+
+### Authentication Material
+
+Session tokens, API keys, signed URLs, OAuth state values. These should never
+be in metadata regardless of allowlist status; allowlisting them propagates
+the leak.
+
+**Prefer:** do not pass authentication material through metadata.
+
+### High-Cardinality Free Text
+
+User-supplied search queries, ticket subjects, document titles. Even if
+non-sensitive in isolation, high-cardinality free text bloats sink payloads
+and is hostile to dashboard filtering.
+
+**Prefer:** capture (with the appropriate flag) or a normalized category
+(`query_intent`, `ticket_category`).
+
+### Mutable PII Buckets
+
+`metadata['user']`, `metadata['customer']`, `metadata['attributes']` — nested
+objects whose shape evolves over time. Allowlisting `user` today emits a small
+struct; six months later it emits an address. Nested allowlisting is not
+supported, so the entire subtree flows.
+
+**Prefer:** flatten to top-level keys with stable contracts (`tenant_id`,
+`tier`, `region`).
+
+## Review Pattern For Allowlist Changes
+
+Treat any change to `SWARM_AUDIT_METADATA_ALLOWLIST` or
+`SWARM_OBSERVABILITY_METADATA_ALLOWLIST` as a security-relevant change. The
+package emits `metadata_keys` (the full set of original key names) in every
+payload regardless of the allowlist, so reviewers can see whether a proposed
+addition is even necessary before approving the value.
+
+Apply this checklist before merging an allowlist change:
+
+1. **State the use case.** Why does the sink need the value, not just the key?
+   Could a downstream join cover it instead?
+2. **Inspect a sample.** Pull a recent payload that already contains the key
+   in `metadata_keys`. Confirm the value's actual shape and cardinality, not
+   the assumed one.
+3. **Apply the anti-pattern checklist.** If the value matches any pattern
+   above, reject and ask for a surrogate.
+4. **Confirm sink retention.** Verify the destination's retention window and
+   access controls are appropriate for the value being added.
+5. **Record the decision.** Note the approver, the use case, and the expected
+   value shape in your change log so future reviewers see the precedent.
+
+When the new value is dynamic enough that none of the above gives confidence,
+implement a custom `SwarmAuditSink` that hashes or transforms the value
+before forwarding instead of allowlisting it raw. The
+[Audit Evidence Contract](audit-evidence-contract.md) covers the custom-sink
+pattern.
+
+> Laravel Swarm plans to add a validator hook in `0.4` that lets applications
+> reject or transform metadata at dispatch time. Until then, allowlist
+> discipline and custom sink redaction are the governance surface.
+
+## Related Reading
+
+- [Audit Evidence Contract](audit-evidence-contract.md) — payload schema and
+  the `metadata` vs `metadata_keys` fields.
+- [Observability Correlation Contract](observability-correlation-contract.md)
+  — telemetry payload contract and the parallel observability allowlist.
+- [Configuration](configuration.md) — `swarm.audit.metadata_allowlist` and
+  `swarm.observability.metadata_allowlist` reference.
+- [Persistence And History](persistence-and-history.md) — capture flags and
+  redaction model for non-metadata fields.

--- a/docs/observability-correlation-contract.md
+++ b/docs/observability-correlation-contract.md
@@ -39,7 +39,7 @@ $this->app->bind(SwarmTelemetrySink::class, MyAppTelemetrySink::class);
 | `swarm.observability.enabled` | `SWARM_OBSERVABILITY_ENABLED` | `true` | Master switch: when `false`, `SwarmTelemetryDispatcher::emit` is a no-op. |
 | `swarm.observability.listen_to_events` | `SWARM_OBSERVABILITY_LISTEN_EVENTS` | `true` | When `false`, the package does not subscribe `SwarmTelemetryEventListener` to lifecycle or queue events. Direct `stream.event` / `broadcast.event` hooks still respect `enabled`. |
 | `swarm.observability.failure_policy` | `SWARM_OBSERVABILITY_FAILURE_POLICY` | `swallow` | `swallow` or `log` when the sink throws. |
-| `swarm.observability.metadata_allowlist` | `SWARM_OBSERVABILITY_METADATA_ALLOWLIST` | `[]` | Comma-separated allowlist of top-level metadata keys whose values may appear in telemetry payloads (same pattern as audit). |
+| `swarm.observability.metadata_allowlist` | `SWARM_OBSERVABILITY_METADATA_ALLOWLIST` | `[]` | Comma-separated allowlist of top-level metadata keys whose values may appear in telemetry payloads (same pattern as audit). See [Metadata Allowlist Governance](metadata-allowlist-governance.md) before extending. |
 | `swarm.observability.categories.include` | — | `null` | When a non-empty array, only these categories are emitted. |
 | `swarm.observability.categories.exclude` | — | `null` | When a non-empty array, listed categories are suppressed. |
 

--- a/docs/persistence-and-history.md
+++ b/docs/persistence-and-history.md
@@ -269,6 +269,8 @@ Set `SWARM_ENCRYPT_AT_REST=false` only when you intentionally rely on
 database- or infrastructure-level encryption instead of application-layer
 sealing. Rotating `APP_KEY` without a re-encryption plan leaves existing sealed
 rows unreadable; treat key rotation like any other encrypted-at-rest data.
+See [APP_KEY Rotation](app-key-rotation.md) for the full runbook, including
+the asymmetry between operational rows and audit evidence.
 
 This feature does **not** replace transparent database encryption (TDE),
 volume encryption, or an immutable compliance archive. It reduces exposure if

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,11 @@
 # Laravel Swarm Examples
 
-These examples are copy-paste starting points for Laravel applications. They
-are not autoloaded by the package and are not a runnable demo app.
+These examples are reference-only. The files in this directory are **not
+autoloaded** by the package, are not registered with your service container,
+and are not a runnable demo app. Copy the swarm, agent, and supporting classes
+you want into your application's namespace (typically `app/Ai/Swarms` and
+`app/Ai/Agents`) before running them. Update the namespace declarations to
+match — every example uses `App\Ai\...` as the destination namespace.
 
 Examples assume your app has Laravel AI configured. When an example does not
 show `#[Provider]` and `#[Model]`, the agent uses your Laravel AI defaults. The


### PR DESCRIPTION
Batches the five documentation issues in the 0.3.x patch tier.

## Summary

- **#4** README production checklist: normalize `swarm:relay` alongside `swarm:recover` and `swarm:prune` with frequency, purpose, and cross-link to `docs/durable-execution.md`.
- **#5** `examples/README.md`: state plainly that examples are reference-only and must be copied into the consuming app's namespace.
- **#6** New `docs/app-key-rotation.md`: runbook covering the asymmetry between sealed operational rows and unaffected audit evidence, drain-then-rotate vs. in-place re-encryption strategies, and retention-window interaction.
- **#7** New `docs/metadata-allowlist-governance.md`: governance doc covering metadata vs. capture payloads, named anti-patterns, and the allowlist review checklist. Pairs with the 0.4 validator hook.
- **#8** README + UPGRADING: explicitly document the `minimum-stability: dev` propagation requirement, the laravel/ai rationale, and the plan to drop it at laravel/ai 1.0.

Cross-links added between new docs and the existing audit / configuration / persistence / observability docs and the docs index.

## Test plan

- [ ] Pint clean (verified: ✅)
- [ ] PHPStan clean (verified: ✅)
- [ ] Tests pass on CI
- [ ] New docs render correctly on the docs site

Closes #4
Closes #5
Closes #6
Closes #7
Closes #8