### PR TITLE
feat(health): swarm:health --durable checks SWARM_CAPTURE_ACTIVE_CONTEXT (#11)

### DIFF
--- a/src/Commands/SwarmHealthCommand.php
+++ b/src/Commands/SwarmHealthCommand.php
@@ -42,6 +42,7 @@ class SwarmHealthCommand extends Command
         );
 
         if ($this->option('durable') === true) {
+            $results[] = $this->runActiveContextCaptureCheck($config);
             $results[] = [
                 'component' => 'Relay scheduling',
                 'driver' => 'n/a',
@@ -74,6 +75,32 @@ class SwarmHealthCommand extends Command
         return collect($results)->contains(fn (array $result): bool => $result['status'] === 'failed')
             ? self::FAILURE
             : self::SUCCESS;
+    }
+
+    /**
+     * @return array{component: string, driver: string, store: string, status: string, details: string}
+     */
+    protected function runActiveContextCaptureCheck(ConfigRepository $config): array
+    {
+        $enabled = (bool) $config->get('swarm.capture.active_context', false);
+
+        if ($enabled) {
+            return [
+                'component' => 'Active context capture',
+                'driver' => 'n/a',
+                'store' => 'n/a',
+                'status' => 'ok',
+                'details' => 'swarm.capture.active_context is enabled',
+            ];
+        }
+
+        return [
+            'component' => 'Active context capture',
+            'driver' => 'n/a',
+            'store' => 'n/a',
+            'status' => 'failed',
+            'details' => 'Queued and durable swarms require active runtime context persistence so workers can continue or recover the run. Enable [swarm.capture.active_context] (SWARM_CAPTURE_ACTIVE_CONTEXT=true) or use synchronous execution.',
+        ];
     }
 
     /**

--- a/tests/Feature/SwarmHealthCommandTest.php
+++ b/tests/Feature/SwarmHealthCommandTest.php
@@ -132,6 +132,43 @@ test('swarm health identifies failing cache component', function (): void {
 });
 
 // ---------------------------------------------------------------------------
+// swarm:health --durable active context capture check (issue #11)
+// ---------------------------------------------------------------------------
+
+describe('active context capture check', function (): void {
+    test('reports ok when swarm.capture.active_context is enabled', function (): void {
+        config()->set('swarm.capture.active_context', true);
+
+        $exitCode = Artisan::call('swarm:health', ['--durable' => true]);
+
+        expect($exitCode)->toBe(0);
+        expect(Artisan::output())
+            ->toContain('Active context capture')
+            ->toContain('swarm.capture.active_context is enabled');
+    });
+
+    test('reports failed when swarm.capture.active_context is disabled under --durable', function (): void {
+        config()->set('swarm.capture.active_context', false);
+
+        $exitCode = Artisan::call('swarm:health', ['--durable' => true]);
+
+        expect($exitCode)->toBe(1);
+        expect(Artisan::output())
+            ->toContain('Active context capture')
+            ->toContain('SWARM_CAPTURE_ACTIVE_CONTEXT=true');
+    });
+
+    test('does not run without --durable', function (): void {
+        config()->set('swarm.capture.active_context', false);
+
+        $exitCode = Artisan::call('swarm:health');
+
+        expect($exitCode)->toBe(0);
+        expect(Artisan::output())->not->toContain('Active context capture');
+    });
+});
+
+// ---------------------------------------------------------------------------
 // swarm:health --durable outbox staleness checks (Plan 1 — graduated states)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Adds a proactive durable-mode preflight check so a misconfigured `SWARM_CAPTURE_ACTIVE_CONTEXT` surfaces at `swarm:health --durable` rather than at first dispatch.

## Summary

- `swarm:health --durable` now runs `runActiveContextCaptureCheck()` at the top of its durable section. Reports `ok` when `swarm.capture.active_context` is enabled, `failed` (exit 1) otherwise.
- Severity matches existing hard-stop runtime checks (missing outbox table, failing cache probe). The runtime currently throws `SwarmException` and aborts dispatch when the env is unset — a `failed` status keeps the health command honest as a CI/preflight gate.
- Detail string echoes the runner's exception message so users see the same remediation in either place.

No new abstractions — inline like the other durable checks, returning the same `array{component, driver, store, status, details}` shape.

## Test plan

- [ ] Pint clean (verified: ✅)
- [ ] PHPStan clean (verified: ✅)
- [ ] New tests pass (3 added, 18 existing): enabled → ok/exit 0; disabled under `--durable` → failed/exit 1; check is absent without `--durable`
- [ ] DurableSwarmTest and QueuedSwarmTest regression suites pass (134 tests)

Closes #11