### PR TITLE
feat(audit): swarm:audit:status summary command (#37)

### DIFF
--- a/src/Commands/SwarmAuditStatusCommand.php
+++ b/src/Commands/SwarmAuditStatusCommand.php
@@ -1,0 +1,292 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Commands;
+
+use BuiltByBerry\LaravelSwarm\Contracts\AuditOutbox;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Carbon;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'swarm:audit:status')]
+class SwarmAuditStatusCommand extends Command
+{
+    protected $signature = 'swarm:audit:status
+                            {--json : Output machine-readable summary results}';
+
+    protected $description = 'Summarize the audit outbox — counts, age distribution, dead-letter categories, and retention';
+
+    public function handle(AuditOutbox $outbox, ConfigRepository $config, Connection $connection): int
+    {
+        if (! $outbox->isAvailable()) {
+            return $this->renderUnavailable();
+        }
+
+        $outboxTable = (string) $config->get('swarm.tables.audit_outbox', 'swarm_audit_outbox');
+        $reservationTimeoutSeconds = (int) $config->get('swarm.durable.relay.reservation_timeout_seconds', 60);
+        $retentionDays = $config->get('swarm.audit.outbox.dead_letter_retention_days');
+        $retentionDays = is_int($retentionDays) && $retentionDays > 0 ? $retentionDays : null;
+
+        $now = Carbon::now('UTC');
+        $staleThreshold = $now->copy()->subSeconds($reservationTimeoutSeconds * 2);
+
+        $counts = $this->collectCounts($connection, $outboxTable, $staleThreshold);
+        $ageDistribution = [
+            'pending' => $this->ageBuckets($connection, $outboxTable, 'pending', $now),
+            'dead_letter' => $this->ageBuckets($connection, $outboxTable, 'dead_letter', $now),
+        ];
+        $topDeadLetterCategories = $this->topDeadLetterCategories($connection, $outboxTable);
+        $oldest = [
+            'pending' => $this->oldestRow($connection, $outboxTable, 'pending', $now),
+            'dead_letter' => $this->oldestRow($connection, $outboxTable, 'dead_letter', $now),
+        ];
+        $retention = [
+            'dead_letter_retention_days' => $retentionDays,
+            'next_prune_count' => $this->nextPruneCount($connection, $outboxTable, $retentionDays, $now),
+        ];
+
+        $summary = [
+            'ok' => true,
+            'store' => 'database',
+            'available' => true,
+            'counts' => $counts,
+            'age_distribution' => $ageDistribution,
+            'top_dead_letter_categories' => $topDeadLetterCategories,
+            'oldest' => $oldest,
+            'retention' => $retention,
+        ];
+
+        if ($this->option('json') === true) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return self::SUCCESS;
+        }
+
+        $this->renderHuman($summary, $reservationTimeoutSeconds);
+
+        return self::SUCCESS;
+    }
+
+    protected function renderUnavailable(): int
+    {
+        if ($this->option('json') === true) {
+            $this->line((string) json_encode([
+                'ok' => true,
+                'store' => 'cache',
+                'available' => false,
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return self::SUCCESS;
+        }
+
+        $this->components->info('Audit outbox is not available on the current persistence driver — switch swarm.persistence.driver to "database" to enable it.');
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array{pending: int, reserved: int, stale_reserved: int, dead_letter: int}
+     */
+    protected function collectCounts(Connection $connection, string $outboxTable, Carbon $staleThreshold): array
+    {
+        $pending = $this->outboxQuery($connection, $outboxTable)
+            ->where('status', 'pending')
+            ->whereNull('reserved_at')
+            ->count();
+
+        $reserved = $this->outboxQuery($connection, $outboxTable)
+            ->where('status', 'pending')
+            ->whereNotNull('reserved_at')
+            ->count();
+
+        $staleReserved = $this->outboxQuery($connection, $outboxTable)
+            ->where('status', 'pending')
+            ->whereNotNull('reserved_at')
+            ->where('reserved_at', '<', $staleThreshold)
+            ->count();
+
+        $deadLetter = $this->outboxQuery($connection, $outboxTable)
+            ->where('status', 'dead_letter')
+            ->count();
+
+        return [
+            'pending' => $pending,
+            'reserved' => $reserved,
+            'stale_reserved' => $staleReserved,
+            'dead_letter' => $deadLetter,
+        ];
+    }
+
+    /**
+     * @return array{lt_1h: int, h1_24: int, d1_7: int, gt_7d: int}
+     */
+    protected function ageBuckets(Connection $connection, string $outboxTable, string $status, Carbon $now): array
+    {
+        $oneHour = $now->copy()->subHour();
+        $oneDay = $now->copy()->subDay();
+        $sevenDays = $now->copy()->subDays(7);
+
+        $base = fn (): Builder => $this->outboxQuery($connection, $outboxTable)->where('status', $status);
+
+        return [
+            'lt_1h' => (clone $base())->where('created_at', '>=', $oneHour)->count(),
+            'h1_24' => (clone $base())->where('created_at', '<', $oneHour)->where('created_at', '>=', $oneDay)->count(),
+            'd1_7' => (clone $base())->where('created_at', '<', $oneDay)->where('created_at', '>=', $sevenDays)->count(),
+            'gt_7d' => (clone $base())->where('created_at', '<', $sevenDays)->count(),
+        ];
+    }
+
+    /**
+     * @return array<int, array{category: string, count: int}>
+     */
+    protected function topDeadLetterCategories(Connection $connection, string $outboxTable): array
+    {
+        return $this->outboxQuery($connection, $outboxTable)
+            ->where('status', 'dead_letter')
+            ->groupBy('category')
+            ->selectRaw('category, COUNT(*) as aggregate')
+            ->orderByDesc('aggregate')
+            ->orderBy('category')
+            ->limit(5)
+            ->get()
+            ->map(fn (object $row): array => [
+                'category' => (string) $row->category,
+                'count' => (int) $row->aggregate,
+            ])
+            ->all();
+    }
+
+    /**
+     * @return array{id: int, age: string}|null
+     */
+    protected function oldestRow(Connection $connection, string $outboxTable, string $status, Carbon $now): ?array
+    {
+        $row = $this->outboxQuery($connection, $outboxTable)
+            ->where('status', $status)
+            ->orderBy('created_at')
+            ->orderBy('id')
+            ->first(['id', 'created_at']);
+
+        if ($row === null) {
+            return null;
+        }
+
+        $createdAt = Carbon::parse($row->created_at, 'UTC');
+
+        return [
+            'id' => (int) $row->id,
+            'age' => $createdAt->diffForHumans($now, [
+                'parts' => 2,
+                'short' => true,
+                'syntax' => Carbon::DIFF_ABSOLUTE,
+            ]),
+        ];
+    }
+
+    protected function nextPruneCount(Connection $connection, string $outboxTable, ?int $retentionDays, Carbon $now): int
+    {
+        if ($retentionDays === null) {
+            return 0;
+        }
+
+        return $this->outboxQuery($connection, $outboxTable)
+            ->where('status', 'dead_letter')
+            ->where('last_attempted_at', '<', $now->copy()->subDays($retentionDays))
+            ->count();
+    }
+
+    /**
+     * @param  array{ok: bool, store: string, available: bool, counts: array<string, int>, age_distribution: array<string, array<string, int>>, top_dead_letter_categories: array<int, array{category: string, count: int}>, oldest: array<string, array{id: int, age: string}|null>, retention: array{dead_letter_retention_days: int|null, next_prune_count: int}}  $summary
+     */
+    protected function renderHuman(array $summary, int $reservationTimeoutSeconds): void
+    {
+        $counts = $summary['counts'];
+        $staleWindow = $reservationTimeoutSeconds * 2;
+
+        $this->components->info('Audit outbox summary');
+
+        $this->table(
+            ['Status', 'Count'],
+            [
+                ['pending (unclaimed)', (string) $counts['pending']],
+                ['reserved', (string) $counts['reserved']],
+                ["  stale (> {$staleWindow}s)", (string) $counts['stale_reserved']],
+                ['dead_letter', (string) $counts['dead_letter']],
+            ],
+        );
+
+        $this->line('');
+        $this->components->info('Age distribution');
+        $this->table(
+            ['Status', '< 1h', '1-24h', '1-7d', '> 7d'],
+            [
+                [
+                    'pending',
+                    (string) $summary['age_distribution']['pending']['lt_1h'],
+                    (string) $summary['age_distribution']['pending']['h1_24'],
+                    (string) $summary['age_distribution']['pending']['d1_7'],
+                    (string) $summary['age_distribution']['pending']['gt_7d'],
+                ],
+                [
+                    'dead_letter',
+                    (string) $summary['age_distribution']['dead_letter']['lt_1h'],
+                    (string) $summary['age_distribution']['dead_letter']['h1_24'],
+                    (string) $summary['age_distribution']['dead_letter']['d1_7'],
+                    (string) $summary['age_distribution']['dead_letter']['gt_7d'],
+                ],
+            ],
+        );
+
+        $this->line('');
+        $this->components->info('Top dead-letter categories');
+
+        if ($summary['top_dead_letter_categories'] === []) {
+            $this->components->bulletList(['no dead-letter rows']);
+        } else {
+            $this->table(
+                ['Category', 'Count'],
+                array_map(
+                    fn (array $row): array => [$row['category'], (string) $row['count']],
+                    $summary['top_dead_letter_categories'],
+                ),
+            );
+        }
+
+        $this->line('');
+        $this->components->info('Oldest rows');
+        $this->table(
+            ['Status', 'ID', 'Age'],
+            [
+                [
+                    'pending',
+                    $summary['oldest']['pending']['id'] ?? 'n/a',
+                    $summary['oldest']['pending']['age'] ?? 'n/a',
+                ],
+                [
+                    'dead_letter',
+                    $summary['oldest']['dead_letter']['id'] ?? 'n/a',
+                    $summary['oldest']['dead_letter']['age'] ?? 'n/a',
+                ],
+            ],
+        );
+
+        $this->line('');
+        $this->components->info('Retention');
+        $retentionDays = $summary['retention']['dead_letter_retention_days'];
+        $this->components->bulletList([
+            $retentionDays === null
+                ? 'dead_letter_retention_days: not configured (rows retained indefinitely)'
+                : "dead_letter_retention_days: {$retentionDays}",
+            "next-prune count: {$summary['retention']['next_prune_count']}",
+        ]);
+    }
+
+    protected function outboxQuery(Connection $connection, string $outboxTable): Builder
+    {
+        return $connection->table($outboxTable);
+    }
+}

--- a/src/SwarmServiceProvider.php
+++ b/src/SwarmServiceProvider.php
@@ -12,6 +12,7 @@ use BuiltByBerry\LaravelSwarm\Audit\NoOpSwarmAuditSink;
 use BuiltByBerry\LaravelSwarm\Audit\RunAuditEmitter;
 use BuiltByBerry\LaravelSwarm\Audit\SwarmAuditDispatcher;
 use BuiltByBerry\LaravelSwarm\Commands\MakeSwarmCommand;
+use BuiltByBerry\LaravelSwarm\Commands\SwarmAuditStatusCommand;
 use BuiltByBerry\LaravelSwarm\Commands\SwarmCancelCommand;
 use BuiltByBerry\LaravelSwarm\Commands\SwarmHealthCommand;
 use BuiltByBerry\LaravelSwarm\Commands\SwarmHistoryCommand;
@@ -280,6 +281,7 @@ class SwarmServiceProvider extends ServiceProvider
                 SwarmCancelCommand::class,
                 SwarmRecoverCommand::class,
                 SwarmRelayCommand::class,
+                SwarmAuditStatusCommand::class,
                 SwarmSignalCommand::class,
                 SwarmInspectCommand::class,
                 SwarmProgressCommand::class,

--- a/tests/Feature/SwarmAuditStatusCommandTest.php
+++ b/tests/Feature/SwarmAuditStatusCommandTest.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Contracts\AuditOutbox;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+
+beforeEach(function (): void {
+    config()->set('swarm.persistence.driver', 'database');
+    app()->forgetInstance(AuditOutbox::class);
+});
+
+function seedAuditStatusRow(array $attributes): int
+{
+    $now = Carbon::now('UTC');
+
+    return (int) DB::table('swarm_audit_outbox')->insertGetId(array_merge([
+        'category' => 'run.failed',
+        'run_id' => 'r-test',
+        'payload' => json_encode(['run_id' => 'r-test', 'category' => 'run.failed']),
+        'attempts' => 0,
+        'status' => 'pending',
+        'last_error' => null,
+        'last_attempted_at' => null,
+        'reserved_at' => null,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ], $attributes));
+}
+
+test('swarm:audit:status reports zeroed summary against an empty outbox', function (): void {
+    $exitCode = Artisan::call('swarm:audit:status', ['--json' => true]);
+
+    expect($exitCode)->toBe(0);
+
+    $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($payload['ok'])->toBeTrue();
+    expect($payload['store'])->toBe('database');
+    expect($payload['available'])->toBeTrue();
+    expect($payload['counts'])->toBe([
+        'pending' => 0,
+        'reserved' => 0,
+        'stale_reserved' => 0,
+        'dead_letter' => 0,
+    ]);
+    expect($payload['age_distribution']['pending'])->toBe([
+        'lt_1h' => 0,
+        'h1_24' => 0,
+        'd1_7' => 0,
+        'gt_7d' => 0,
+    ]);
+    expect($payload['top_dead_letter_categories'])->toBe([]);
+    expect($payload['oldest']['pending'])->toBeNull();
+    expect($payload['oldest']['dead_letter'])->toBeNull();
+    expect($payload['retention']['dead_letter_retention_days'])->toBeNull();
+    expect($payload['retention']['next_prune_count'])->toBe(0);
+});
+
+test('swarm:audit:status counts pending, reserved, stale_reserved, and dead_letter', function (): void {
+    config()->set('swarm.durable.relay.reservation_timeout_seconds', 60);
+    $now = Carbon::now('UTC');
+
+    seedAuditStatusRow(['status' => 'pending', 'reserved_at' => null]);
+    seedAuditStatusRow(['status' => 'pending', 'reserved_at' => null]);
+    seedAuditStatusRow(['status' => 'pending', 'reserved_at' => $now->copy()->subSeconds(30)]);
+    seedAuditStatusRow(['status' => 'pending', 'reserved_at' => $now->copy()->subSeconds(300)]);
+    seedAuditStatusRow(['status' => 'dead_letter']);
+    seedAuditStatusRow(['status' => 'dead_letter']);
+    seedAuditStatusRow(['status' => 'dead_letter']);
+
+    Artisan::call('swarm:audit:status', ['--json' => true]);
+    $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($payload['counts'])->toBe([
+        'pending' => 2,
+        'reserved' => 2,
+        'stale_reserved' => 1,
+        'dead_letter' => 3,
+    ]);
+});
+
+test('swarm:audit:status buckets pending and dead_letter rows by created_at age', function (): void {
+    $now = Carbon::now('UTC');
+
+    seedAuditStatusRow(['status' => 'pending', 'created_at' => $now->copy()->subMinutes(10)]);
+    seedAuditStatusRow(['status' => 'pending', 'created_at' => $now->copy()->subHours(4)]);
+    seedAuditStatusRow(['status' => 'pending', 'created_at' => $now->copy()->subDays(3)]);
+    seedAuditStatusRow(['status' => 'pending', 'created_at' => $now->copy()->subDays(20)]);
+
+    seedAuditStatusRow(['status' => 'dead_letter', 'created_at' => $now->copy()->subMinutes(5)]);
+    seedAuditStatusRow(['status' => 'dead_letter', 'created_at' => $now->copy()->subDays(2)]);
+    seedAuditStatusRow(['status' => 'dead_letter', 'created_at' => $now->copy()->subDays(40)]);
+    seedAuditStatusRow(['status' => 'dead_letter', 'created_at' => $now->copy()->subDays(40)]);
+
+    Artisan::call('swarm:audit:status', ['--json' => true]);
+    $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($payload['age_distribution']['pending'])->toBe([
+        'lt_1h' => 1,
+        'h1_24' => 1,
+        'd1_7' => 1,
+        'gt_7d' => 1,
+    ]);
+    expect($payload['age_distribution']['dead_letter'])->toBe([
+        'lt_1h' => 1,
+        'h1_24' => 0,
+        'd1_7' => 1,
+        'gt_7d' => 2,
+    ]);
+});
+
+test('swarm:audit:status reports top dead_letter categories sorted by count desc then category', function (): void {
+    foreach (range(1, 4) as $_) {
+        seedAuditStatusRow(['status' => 'dead_letter', 'category' => 'run.failed']);
+    }
+    foreach (range(1, 2) as $_) {
+        seedAuditStatusRow(['status' => 'dead_letter', 'category' => 'tool.invoked']);
+    }
+    seedAuditStatusRow(['status' => 'dead_letter', 'category' => 'guardrail.blocked']);
+    seedAuditStatusRow(['status' => 'dead_letter', 'category' => 'command.relay']);
+    seedAuditStatusRow(['status' => 'dead_letter', 'category' => 'agent.invoked']);
+    seedAuditStatusRow(['status' => 'dead_letter', 'category' => 'something.else']);
+
+    seedAuditStatusRow(['status' => 'pending', 'category' => 'should.not.appear']);
+
+    Artisan::call('swarm:audit:status', ['--json' => true]);
+    $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+    $categories = array_map(fn (array $row): string => $row['category'], $payload['top_dead_letter_categories']);
+    $counts = array_map(fn (array $row): int => $row['count'], $payload['top_dead_letter_categories']);
+
+    expect($categories[0])->toBe('run.failed');
+    expect($counts[0])->toBe(4);
+    expect($categories[1])->toBe('tool.invoked');
+    expect($counts[1])->toBe(2);
+    expect(count($payload['top_dead_letter_categories']))->toBe(5);
+
+    $tail = array_slice($categories, 2);
+    expect($tail)->toBe(['agent.invoked', 'command.relay', 'guardrail.blocked']);
+});
+
+test('swarm:audit:status reports oldest pending and dead_letter row id + age', function (): void {
+    $now = Carbon::now('UTC');
+
+    $newerPending = seedAuditStatusRow(['status' => 'pending', 'created_at' => $now->copy()->subMinutes(5)]);
+    $olderPending = seedAuditStatusRow(['status' => 'pending', 'created_at' => $now->copy()->subDays(3)]);
+
+    $newerDead = seedAuditStatusRow(['status' => 'dead_letter', 'created_at' => $now->copy()->subHours(2)]);
+    $olderDead = seedAuditStatusRow(['status' => 'dead_letter', 'created_at' => $now->copy()->subDays(10)]);
+
+    Artisan::call('swarm:audit:status', ['--json' => true]);
+    $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($payload['oldest']['pending']['id'])->toBe($olderPending);
+    expect($payload['oldest']['pending']['age'])->toBeString();
+    expect($payload['oldest']['dead_letter']['id'])->toBe($olderDead);
+    expect($payload['oldest']['dead_letter']['age'])->toBeString();
+
+    expect($payload['oldest']['pending']['id'])->not->toBe($newerPending);
+    expect($payload['oldest']['dead_letter']['id'])->not->toBe($newerDead);
+});
+
+test('swarm:audit:status reports retention next_prune_count under the configured window', function (): void {
+    config()->set('swarm.audit.outbox.dead_letter_retention_days', 7);
+
+    $now = Carbon::now('UTC');
+
+    seedAuditStatusRow(['status' => 'dead_letter', 'last_attempted_at' => $now->copy()->subDays(10)]);
+    seedAuditStatusRow(['status' => 'dead_letter', 'last_attempted_at' => $now->copy()->subDays(30)]);
+    seedAuditStatusRow(['status' => 'dead_letter', 'last_attempted_at' => $now->copy()->subDays(2)]);
+    seedAuditStatusRow(['status' => 'dead_letter', 'last_attempted_at' => null]);
+
+    Artisan::call('swarm:audit:status', ['--json' => true]);
+    $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($payload['retention']['dead_letter_retention_days'])->toBe(7);
+    expect($payload['retention']['next_prune_count'])->toBe(2);
+});
+
+test('swarm:audit:status reports zero next_prune_count when retention is unconfigured', function (): void {
+    config()->set('swarm.audit.outbox.dead_letter_retention_days', null);
+
+    seedAuditStatusRow(['status' => 'dead_letter', 'last_attempted_at' => Carbon::now('UTC')->subYear()]);
+
+    Artisan::call('swarm:audit:status', ['--json' => true]);
+    $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($payload['retention']['dead_letter_retention_days'])->toBeNull();
+    expect($payload['retention']['next_prune_count'])->toBe(0);
+});
+
+test('swarm:audit:status --json shape stays stable', function (): void {
+    seedAuditStatusRow(['status' => 'pending']);
+    seedAuditStatusRow(['status' => 'dead_letter']);
+
+    Artisan::call('swarm:audit:status', ['--json' => true]);
+    $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+    expect(array_keys($payload))->toBe([
+        'ok',
+        'store',
+        'available',
+        'counts',
+        'age_distribution',
+        'top_dead_letter_categories',
+        'oldest',
+        'retention',
+    ]);
+    expect(array_keys($payload['counts']))->toBe(['pending', 'reserved', 'stale_reserved', 'dead_letter']);
+    expect(array_keys($payload['age_distribution']))->toBe(['pending', 'dead_letter']);
+    expect(array_keys($payload['age_distribution']['pending']))->toBe(['lt_1h', 'h1_24', 'd1_7', 'gt_7d']);
+    expect(array_keys($payload['oldest']))->toBe(['pending', 'dead_letter']);
+    expect(array_keys($payload['retention']))->toBe(['dead_letter_retention_days', 'next_prune_count']);
+});
+
+test('swarm:audit:status degrades on cache persistence without touching the database', function (): void {
+    config()->set('swarm.persistence.driver', 'cache');
+    app()->forgetInstance(AuditOutbox::class);
+
+    DB::enableQueryLog();
+    DB::flushQueryLog();
+
+    $exitCode = Artisan::call('swarm:audit:status', ['--json' => true]);
+
+    expect($exitCode)->toBe(0);
+
+    $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+    expect($payload)->toBe([
+        'ok' => true,
+        'store' => 'cache',
+        'available' => false,
+    ]);
+
+    $queries = collect(DB::getQueryLog())
+        ->reject(fn (array $entry): bool => str_contains(strtolower($entry['query']), 'sqlite_master'))
+        ->filter(fn (array $entry): bool => str_contains(strtolower($entry['query']), 'swarm_audit_outbox'));
+
+    expect($queries)->toBeEmpty();
+
+    DB::disableQueryLog();
+});
+
+test('swarm:audit:status non-JSON output renders Laravel-native sections without errors', function (): void {
+    seedAuditStatusRow(['status' => 'pending']);
+    seedAuditStatusRow(['status' => 'dead_letter', 'category' => 'run.failed']);
+
+    $exitCode = Artisan::call('swarm:audit:status');
+
+    expect($exitCode)->toBe(0);
+
+    $output = Artisan::output();
+    expect($output)->toContain('Audit outbox summary');
+    expect($output)->toContain('Age distribution');
+    expect($output)->toContain('Top dead-letter categories');
+    expect($output)->toContain('Oldest rows');
+    expect($output)->toContain('Retention');
+});


### PR DESCRIPTION
## Summary

New `php artisan swarm:audit:status` read-only operator surface for the v0.5 audit outbox. Closes #37.

The command reports a richer view than `swarm:health`'s binary signals:

- **Counts**: `pending` (unclaimed), `reserved`, `stale_reserved` (subset where `reserved_at` is older than 2x `swarm.durable.relay.reservation_timeout_seconds`), `dead_letter`.
- **Age distribution** for both pending and dead-letter rows by `created_at`: `<1h`, `1-24h`, `1-7d`, `>7d`.
- **Top 5 categories** by dead-letter count (tiebreak by category name).
- **Oldest pending** and **oldest dead_letter**: id + human age string.
- **Retention**: current `swarm.audit.outbox.dead_letter_retention_days` plus the next-prune count (rows whose `last_attempted_at` is older than the configured window; 0 when retention is unconfigured).

Output mirrors `SwarmHealthCommand`'s `--json` shape with stable top-level keys. On `NoOpAuditOutbox` (cache driver) the command emits a single degraded line / `{ ok: true, store: "cache", available: false }` JSON payload and exits 0 without hitting the database.

## What changed

- `src/Commands/SwarmAuditStatusCommand.php` (new) — the command itself; helpers are protected, no new public surface.
- `src/SwarmServiceProvider.php` — registered alongside the other `swarm:*` commands, next to `SwarmRelayCommand`.
- `tests/Feature/SwarmAuditStatusCommandTest.php` (new) — Pest feature coverage.

No new indexes, migrations, or config keys. No row mutations.

## Test plan

- [x] `composer test` — 772 passed (10 new in `SwarmAuditStatusCommandTest`)
- [x] `composer lint` (pint --test) clean
- [x] `composer analyse` (phpstan) clean

Test scenarios covered:

- [x] Empty table: counts all zero, oldest null, top-categories empty, retention configured and unconfigured paths.
- [x] Populated mixed-status seeding asserts `pending` / `reserved` / `stale_reserved` / `dead_letter` counts using direct `DB::table('swarm_audit_outbox')->insert(...)` (mirrors `AuditOutboxRetentionTest`).
- [x] Age bucket boundaries for both `pending` and `dead_letter`.
- [x] Top-5 dead-letter categories sorted by count desc then category asc; non-dead-letter rows excluded.
- [x] Oldest row selection by `created_at` for both statuses.
- [x] Retention `next_prune_count` honors `dead_letter_retention_days` and is zero when unconfigured.
- [x] `--json` shape stability snapshot against top-level + nested keys.
- [x] Cache-driver skip path: degraded payload, exit 0, zero queries against `swarm_audit_outbox`.
- [x] Non-JSON output renders the expected human sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)