### PR TITLE
feat(audit): swarm:audit:reconcile forensic CLI (#36)

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -305,6 +305,43 @@ lifecycle). `swarm.retention.prevent_prune=true` overrides as usual.
 See [Audit Evidence Contract](audit-evidence-contract.md) for the full
 retry, encryption-at-rest, and signer-rotation behavior.
 
+### Forensic triage: `swarm:audit:reconcile`
+
+`swarm:audit:reconcile` is the operator command for inspecting and
+reconciling rows that the relay has either failed or dead-lettered. It
+requires the database persistence driver; on cache the command exits
+non-zero with a clear error.
+
+Four sub-modes (mutually exclusive):
+
+```bash
+# List pending and dead_letter rows (capped at --limit, default 50)
+php artisan swarm:audit:reconcile
+php artisan swarm:audit:reconcile --status=dead_letter --limit=200
+
+# Inspect a single row, including unsealed payload and last_error
+php artisan swarm:audit:reconcile --show=42
+
+# Reset a dead_letter row to pending so the relay re-attempts emission.
+# attempts is zeroed; last_error is preserved as forensic evidence.
+php artisan swarm:audit:reconcile --requeue=42 --reason="sink restored"
+
+# Permanently delete a dead_letter row. --reason is REQUIRED — audit
+# evidence cannot be discarded without a chain-of-custody justification.
+php artisan swarm:audit:reconcile --dismiss=42 --reason="duplicate of r-7"
+```
+
+Pending rows can be listed and shown but cannot be requeued or
+dismissed; the relay owns their lifecycle. Both `--requeue` and
+`--dismiss` prompt for confirmation; use `--force` for scripted
+recovery. Every sub-mode accepts `--json` for automation.
+
+Every requeue or dismiss emits a `command.audit_reconcile` audit record
+carrying `action`, `target_id`, `target_category`, `target_run_id`,
+`prior_attempts`, and `reason` **before** mutating the row. If the
+audit emit fails the row is left untouched, so reconciliation cannot
+silently erase evidence.
+
 ## High-volume dashboards
 
 Swarm database tables are sized for operational throughput. List and aggregation

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,3 +19,4 @@ parameters:
                 - src/Persistence/DatabaseRunHistoryStore.php
                 - src/Persistence/DatabaseContextStore.php
                 - src/Pulse/Livewire/SwarmSteps.php
+                - src/Commands/SwarmAuditReconcileCommand.php

--- a/src/Commands/SwarmAuditReconcileCommand.php
+++ b/src/Commands/SwarmAuditReconcileCommand.php
@@ -1,0 +1,519 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Commands;
+
+use BuiltByBerry\LaravelSwarm\Audit\Actor;
+use BuiltByBerry\LaravelSwarm\Audit\SwarmAuditDispatcher;
+use BuiltByBerry\LaravelSwarm\Commands\Concerns\ResolvesStringConsoleInput;
+use BuiltByBerry\LaravelSwarm\Contracts\AuditOutbox;
+use BuiltByBerry\LaravelSwarm\Persistence\SwarmPersistenceCipher;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Database\Connection;
+use Illuminate\Support\Carbon;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Throwable;
+
+#[AsCommand(name: 'swarm:audit:reconcile')]
+class SwarmAuditReconcileCommand extends Command
+{
+    use ResolvesStringConsoleInput;
+
+    protected $signature = 'swarm:audit:reconcile
+                            {--show= : Print full metadata and unsealed payload for the given outbox id.}
+                            {--requeue= : Reset a dead_letter row to pending so the relay re-attempts emission.}
+                            {--dismiss= : Permanently delete a dead_letter row (requires --reason).}
+                            {--status= : Filter the list view by status (pending or dead_letter).}
+                            {--limit=50 : Cap the list view row count.}
+                            {--reason= : Operator-supplied reason recorded on the command.audit_reconcile audit record. Required for --dismiss.}
+                            {--force : Skip the interactive confirmation prompt.}
+                            {--json : Emit machine-readable output (works for list, show, requeue, dismiss).}';
+
+    protected $description = 'Forensic triage for the swarm audit outbox (list, inspect, requeue, dismiss dead-letter rows)';
+
+    protected $help = <<<'HELP'
+        Operator command for the swarm_audit_outbox table. Sub-modes are mutually
+        exclusive:
+
+          (no flags)         List pending and dead_letter rows.
+          --show=<id>        Print full row metadata and unsealed payload.
+          --requeue=<id>     Reset a dead_letter row to pending (relay re-attempts).
+          --dismiss=<id>     Permanently delete a dead_letter row. Requires --reason.
+
+        Pending rows can be listed and shown but cannot be requeued or dismissed;
+        the relay owns their lifecycle.
+
+        Every requeue/dismiss emits a command.audit_reconcile audit record before
+        mutating the row. If the audit emit fails, the row is left untouched.
+
+        Examples:
+          php artisan swarm:audit:reconcile
+          php artisan swarm:audit:reconcile --status=dead_letter --limit=200
+          php artisan swarm:audit:reconcile --show=42
+          php artisan swarm:audit:reconcile --requeue=42 --reason="downstream sink restored"
+          php artisan swarm:audit:reconcile --dismiss=42 --reason="duplicate of run.failed for r-7" --force
+        HELP;
+
+    public function handle(
+        AuditOutbox $outbox,
+        ConfigRepository $config,
+        Connection $connection,
+        SwarmPersistenceCipher $cipher,
+        SwarmAuditDispatcher $audit,
+    ): int {
+        if (! $outbox->isAvailable()) {
+            $message = 'swarm:audit:reconcile requires the database-backed audit outbox. Set swarm.persistence.driver=database and run the package migrations.';
+
+            if ($this->option('json') === true) {
+                $this->writeJson(['ok' => false, 'error' => $message]);
+            } else {
+                $this->components->error($message);
+            }
+
+            return self::FAILURE;
+        }
+
+        $modes = array_filter([
+            'show' => $this->optionalOptionString('show'),
+            'requeue' => $this->optionalOptionString('requeue'),
+            'dismiss' => $this->optionalOptionString('dismiss'),
+        ], static fn (?string $v): bool => $v !== null && $v !== '');
+
+        if (count($modes) > 1) {
+            return $this->failWith('Use only one of --show, --requeue, --dismiss per invocation.');
+        }
+
+        if ($modes === []) {
+            return $this->runList($config, $connection);
+        }
+
+        $mode = array_key_first($modes);
+        $id = $this->resolveId($modes[$mode], $mode);
+
+        if ($id === null) {
+            return self::FAILURE;
+        }
+
+        return match ($mode) {
+            'show' => $this->runShow($config, $connection, $cipher, $id),
+            'requeue' => $this->runRequeue($config, $connection, $audit, $id),
+            'dismiss' => $this->runDismiss($config, $connection, $audit, $id),
+            default => self::FAILURE,
+        };
+    }
+
+    protected function runList(ConfigRepository $config, Connection $connection): int
+    {
+        $statusFilter = $this->optionalOptionString('status');
+
+        if ($statusFilter !== null && ! in_array($statusFilter, ['pending', 'dead_letter'], true)) {
+            return $this->failWith('Unknown --status value. Use "pending" or "dead_letter".');
+        }
+
+        $limit = $this->optionInt('limit', 50);
+        $limit = max(1, min($limit, 10_000));
+
+        $table = $this->tableName($config);
+        $query = $connection->table($table);
+
+        if ($statusFilter !== null) {
+            $query->where('status', $statusFilter);
+        } else {
+            $query->whereIn('status', ['pending', 'dead_letter']);
+        }
+
+        $rows = $query->orderBy('id')->limit($limit + 1)->get();
+        $truncated = $rows->count() > $limit;
+        $rows = $rows->take($limit);
+
+        $now = Carbon::now('UTC');
+        $records = $rows->map(fn (object $row): array => [
+            'id' => (int) $row->id,
+            'status' => (string) $row->status,
+            'category' => (string) $row->category,
+            'run_id' => $row->run_id !== null ? (string) $row->run_id : null,
+            'attempts' => (int) $row->attempts,
+            'last_attempted_at' => $this->formatTimestamp($row->last_attempted_at),
+            'age' => $this->ageHuman($row->created_at, $now),
+        ])->all();
+
+        if ($this->option('json') === true) {
+            $this->writeJson([
+                'ok' => true,
+                'count' => count($records),
+                'truncated' => $truncated,
+                'limit' => $limit,
+                'status_filter' => $statusFilter,
+                'rows' => $records,
+            ]);
+
+            return self::SUCCESS;
+        }
+
+        if ($records === []) {
+            $this->components->info('No audit outbox rows match.');
+
+            return self::SUCCESS;
+        }
+
+        $this->table(
+            ['ID', 'Status', 'Category', 'Run ID', 'Attempts', 'Last attempted', 'Age'],
+            array_map(fn (array $r): array => [
+                (string) $r['id'],
+                $r['status'],
+                $r['category'],
+                $r['run_id'] ?? '-',
+                (string) $r['attempts'],
+                $r['last_attempted_at'] ?? '-',
+                $r['age'],
+            ], $records),
+        );
+
+        if ($truncated) {
+            $this->components->warn("Output capped at {$limit} rows. Filter with --status or raise --limit.");
+        }
+
+        return self::SUCCESS;
+    }
+
+    protected function runShow(ConfigRepository $config, Connection $connection, SwarmPersistenceCipher $cipher, int $id): int
+    {
+        $row = $this->findRow($config, $connection, $id);
+
+        if ($row === null) {
+            return $this->failWith("Audit outbox row [{$id}] not found.");
+        }
+
+        $payload = $this->decodePayload($cipher, $row);
+        $lastError = $this->decodeLastError($cipher, $row);
+
+        $detail = [
+            'id' => (int) $row->id,
+            'status' => (string) $row->status,
+            'category' => (string) $row->category,
+            'run_id' => $row->run_id !== null ? (string) $row->run_id : null,
+            'attempts' => (int) $row->attempts,
+            'created_at' => $this->formatTimestamp($row->created_at),
+            'updated_at' => $this->formatTimestamp($row->updated_at),
+            'last_attempted_at' => $this->formatTimestamp($row->last_attempted_at),
+            'reserved_at' => $this->formatTimestamp($row->reserved_at),
+            'last_error' => $lastError,
+            'payload' => $payload,
+        ];
+
+        if ($this->option('json') === true) {
+            $this->writeJson(['ok' => true, 'row' => $detail]);
+
+            return self::SUCCESS;
+        }
+
+        $this->table(['Field', 'Value'], [
+            ['ID', (string) $detail['id']],
+            ['Status', $detail['status']],
+            ['Category', $detail['category']],
+            ['Run ID', $detail['run_id'] ?? '-'],
+            ['Attempts', (string) $detail['attempts']],
+            ['Created', $detail['created_at'] ?? '-'],
+            ['Updated', $detail['updated_at'] ?? '-'],
+            ['Last attempted', $detail['last_attempted_at'] ?? '-'],
+            ['Reserved', $detail['reserved_at'] ?? '-'],
+        ]);
+
+        $this->line('');
+        $this->components->info('Last error');
+        $this->line($lastError ?? '-');
+
+        $this->line('');
+        $this->components->info('Payload');
+        $this->line($this->prettyJson($payload));
+
+        return self::SUCCESS;
+    }
+
+    protected function runRequeue(ConfigRepository $config, Connection $connection, SwarmAuditDispatcher $audit, int $id): int
+    {
+        $row = $this->findRow($config, $connection, $id);
+
+        if ($row === null) {
+            return $this->failWith("Audit outbox row [{$id}] not found.");
+        }
+
+        if ((string) $row->status !== 'dead_letter') {
+            return $this->failWith("Audit outbox row [{$id}] has status [{$row->status}]; only dead_letter rows can be requeued. Pending rows are owned by the relay.");
+        }
+
+        $reason = $this->optionalOptionString('reason');
+
+        if (! $this->confirmAction("Requeue audit outbox row [{$id}] (category={$row->category}, attempts={$row->attempts})?")) {
+            return $this->aborted();
+        }
+
+        $priorAttempts = (int) $row->attempts;
+
+        if (! $this->emitReconcileAudit($audit, 'requeue', $row, $priorAttempts, $reason)) {
+            return self::FAILURE;
+        }
+
+        $connection->table($this->tableName($config))
+            ->where('id', $id)
+            ->update([
+                'status' => 'pending',
+                'attempts' => 0,
+                'reserved_at' => null,
+                'updated_at' => Carbon::now('UTC'),
+            ]);
+
+        if ($this->option('json') === true) {
+            $this->writeJson([
+                'ok' => true,
+                'action' => 'requeue',
+                'id' => $id,
+                'prior_attempts' => $priorAttempts,
+                'reason' => $reason,
+            ]);
+
+            return self::SUCCESS;
+        }
+
+        $this->components->info("Audit outbox row [{$id}] requeued. Status=pending, attempts=0. last_error preserved for forensics.");
+
+        return self::SUCCESS;
+    }
+
+    protected function runDismiss(ConfigRepository $config, Connection $connection, SwarmAuditDispatcher $audit, int $id): int
+    {
+        $reason = $this->optionalOptionString('reason');
+
+        if ($reason === null || trim($reason) === '') {
+            return $this->failWith('--dismiss requires --reason="<text>". Audit evidence cannot be discarded without a chain-of-custody reason.');
+        }
+
+        $row = $this->findRow($config, $connection, $id);
+
+        if ($row === null) {
+            return $this->failWith("Audit outbox row [{$id}] not found.");
+        }
+
+        if ((string) $row->status !== 'dead_letter') {
+            return $this->failWith("Audit outbox row [{$id}] has status [{$row->status}]; only dead_letter rows can be dismissed. Pending rows are owned by the relay.");
+        }
+
+        if (! $this->confirmAction("Permanently delete audit outbox row [{$id}] (category={$row->category}, run_id=".($row->run_id ?? '-').')?')) {
+            return $this->aborted();
+        }
+
+        $priorAttempts = (int) $row->attempts;
+
+        if (! $this->emitReconcileAudit($audit, 'dismiss', $row, $priorAttempts, $reason)) {
+            return self::FAILURE;
+        }
+
+        $connection->table($this->tableName($config))->where('id', $id)->delete();
+
+        if ($this->option('json') === true) {
+            $this->writeJson([
+                'ok' => true,
+                'action' => 'dismiss',
+                'id' => $id,
+                'prior_attempts' => $priorAttempts,
+                'reason' => $reason,
+            ]);
+
+            return self::SUCCESS;
+        }
+
+        $this->components->info("Audit outbox row [{$id}] dismissed. A command.audit_reconcile evidence record preserves the deletion.");
+
+        return self::SUCCESS;
+    }
+
+    protected function emitReconcileAudit(SwarmAuditDispatcher $audit, string $action, object $row, int $priorAttempts, ?string $reason): bool
+    {
+        $actorMetadata = ['actor' => Actor::system('artisan')->toArray()];
+        $now = Carbon::now('UTC');
+
+        $payload = [
+            'action' => $action,
+            'target_id' => (int) $row->id,
+            'target_category' => (string) $row->category,
+            'target_run_id' => $row->run_id !== null ? (string) $row->run_id : null,
+            'prior_attempts' => $priorAttempts,
+            'reason' => $reason,
+            'target_created_at' => $this->formatTimestamp($row->created_at),
+            'target_age_seconds' => $this->ageSeconds($row->created_at, $now),
+            ...$audit->metadata($actorMetadata),
+        ];
+
+        try {
+            $audit->emit('command.audit_reconcile', $payload);
+
+            return true;
+        } catch (Throwable $exception) {
+            $this->failWith(
+                "Failed to emit command.audit_reconcile evidence: {$exception->getMessage()}. "
+                .'The outbox row was NOT modified.',
+            );
+
+            return false;
+        }
+    }
+
+    protected function confirmAction(string $prompt): bool
+    {
+        if ($this->option('force') === true) {
+            return true;
+        }
+
+        if ($this->option('json') === true) {
+            return false;
+        }
+
+        if (! $this->input->isInteractive()) {
+            return false;
+        }
+
+        return $this->confirm($prompt, false);
+    }
+
+    protected function findRow(ConfigRepository $config, Connection $connection, int $id): ?object
+    {
+        $row = $connection->table($this->tableName($config))->where('id', $id)->first();
+
+        return is_object($row) ? $row : null;
+    }
+
+    /**
+     * @return array<string, mixed>|string|null
+     */
+    protected function decodePayload(SwarmPersistenceCipher $cipher, object $row): array|string|null
+    {
+        $raw = is_string($row->payload) ? $cipher->open($row->payload) : null;
+
+        if ($raw === null) {
+            return null;
+        }
+
+        try {
+            $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return $raw;
+        }
+
+        return is_array($decoded) ? $decoded : $raw;
+    }
+
+    protected function decodeLastError(SwarmPersistenceCipher $cipher, object $row): ?string
+    {
+        if (! is_string($row->last_error) || $row->last_error === '') {
+            return null;
+        }
+
+        return $cipher->open($row->last_error);
+    }
+
+    protected function resolveId(string $raw, string $mode): ?int
+    {
+        if (! is_numeric($raw) || (int) $raw < 1) {
+            $this->failWith("--{$mode} must be a positive integer id.");
+
+            return null;
+        }
+
+        return (int) $raw;
+    }
+
+    protected function tableName(ConfigRepository $config): string
+    {
+        return (string) $config->get('swarm.tables.audit_outbox', 'swarm_audit_outbox');
+    }
+
+    protected function formatTimestamp(mixed $value): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        try {
+            return Carbon::parse((string) $value, 'UTC')->toIso8601String();
+        } catch (Throwable) {
+            return is_scalar($value) ? (string) $value : null;
+        }
+    }
+
+    protected function ageHuman(mixed $createdAt, Carbon $now): string
+    {
+        $seconds = $this->ageSeconds($createdAt, $now);
+
+        if ($seconds === null) {
+            return '-';
+        }
+
+        if ($seconds < 60) {
+            return "{$seconds}s";
+        }
+
+        if ($seconds < 3600) {
+            return floor($seconds / 60).'m';
+        }
+
+        if ($seconds < 86400) {
+            return floor($seconds / 3600).'h';
+        }
+
+        return floor($seconds / 86400).'d';
+    }
+
+    protected function ageSeconds(mixed $createdAt, Carbon $now): ?int
+    {
+        if ($createdAt === null || $createdAt === '') {
+            return null;
+        }
+
+        try {
+            $parsed = Carbon::parse((string) $createdAt, 'UTC');
+        } catch (Throwable) {
+            return null;
+        }
+
+        return max(0, (int) abs($now->diffInSeconds($parsed, false)));
+    }
+
+    protected function prettyJson(mixed $value): string
+    {
+        $encoded = json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        return $encoded !== false ? $encoded : '{}';
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    protected function writeJson(array $payload): void
+    {
+        $this->line($this->prettyJson($payload));
+    }
+
+    protected function failWith(string $message): int
+    {
+        if ($this->option('json') === true) {
+            $this->writeJson(['ok' => false, 'error' => $message]);
+        } else {
+            $this->components->error($message);
+        }
+
+        return self::FAILURE;
+    }
+
+    protected function aborted(): int
+    {
+        if ($this->option('json') === true) {
+            $this->writeJson(['ok' => false, 'error' => 'aborted by operator']);
+        } else {
+            $this->components->warn('Aborted.');
+        }
+
+        return self::FAILURE;
+    }
+}

--- a/src/SwarmServiceProvider.php
+++ b/src/SwarmServiceProvider.php
@@ -12,6 +12,7 @@ use BuiltByBerry\LaravelSwarm\Audit\NoOpSwarmAuditSink;
 use BuiltByBerry\LaravelSwarm\Audit\RunAuditEmitter;
 use BuiltByBerry\LaravelSwarm\Audit\SwarmAuditDispatcher;
 use BuiltByBerry\LaravelSwarm\Commands\MakeSwarmCommand;
+use BuiltByBerry\LaravelSwarm\Commands\SwarmAuditReconcileCommand;
 use BuiltByBerry\LaravelSwarm\Commands\SwarmAuditStatusCommand;
 use BuiltByBerry\LaravelSwarm\Commands\SwarmCancelCommand;
 use BuiltByBerry\LaravelSwarm\Commands\SwarmHealthCommand;
@@ -282,6 +283,7 @@ class SwarmServiceProvider extends ServiceProvider
                 SwarmRecoverCommand::class,
                 SwarmRelayCommand::class,
                 SwarmAuditStatusCommand::class,
+                SwarmAuditReconcileCommand::class,
                 SwarmSignalCommand::class,
                 SwarmInspectCommand::class,
                 SwarmProgressCommand::class,

--- a/tests/Feature/SwarmAuditReconcileCommandTest.php
+++ b/tests/Feature/SwarmAuditReconcileCommandTest.php
@@ -1,0 +1,419 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Audit\SwarmAuditDispatcher;
+use BuiltByBerry\LaravelSwarm\Contracts\AuditOutbox;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
+use BuiltByBerry\LaravelSwarm\Persistence\SwarmPersistenceCipher;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\RecordingSwarmAuditSink;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+
+beforeEach(function (): void {
+    config()->set('swarm.persistence.driver', 'database');
+    app()->forgetInstance(AuditOutbox::class);
+});
+
+function seedReconcileRow(string $status, array $overrides = []): int
+{
+    $payload = $overrides['payload'] ?? ['run_id' => 'r-test', 'category' => 'run.failed', 'secret' => 'top-secret'];
+    $cipher = app(SwarmPersistenceCipher::class);
+    $encoded = json_encode($payload, JSON_THROW_ON_ERROR);
+
+    return (int) DB::table('swarm_audit_outbox')->insertGetId([
+        'category' => $overrides['category'] ?? 'run.failed',
+        'run_id' => $overrides['run_id'] ?? ($payload['run_id'] ?? null),
+        'payload' => $cipher->seal($encoded),
+        'attempts' => $overrides['attempts'] ?? 3,
+        'status' => $status,
+        'last_error' => isset($overrides['last_error']) ? $cipher->seal($overrides['last_error']) : null,
+        'last_attempted_at' => $overrides['last_attempted_at'] ?? Carbon::now('UTC'),
+        'reserved_at' => null,
+        'created_at' => $overrides['created_at'] ?? Carbon::now('UTC')->subMinutes(5),
+        'updated_at' => Carbon::now('UTC'),
+    ]);
+}
+
+function reconcileRecordingSink(): RecordingSwarmAuditSink
+{
+    $sink = new RecordingSwarmAuditSink;
+    app()->instance(SwarmAuditSink::class, $sink);
+    app()->forgetInstance(SwarmAuditDispatcher::class);
+
+    return $sink;
+}
+
+// -----------------------------------------------------------------------------
+// Cache-driver guard
+// -----------------------------------------------------------------------------
+
+test('swarm:audit:reconcile exits non-zero with a clear error when the cache driver is in use', function (): void {
+    config()->set('swarm.persistence.driver', 'cache');
+    app()->forgetInstance(AuditOutbox::class);
+
+    $exit = Artisan::call('swarm:audit:reconcile');
+
+    expect($exit)->toBe(1);
+    expect(Artisan::output())->toContain('database-backed audit outbox');
+});
+
+// -----------------------------------------------------------------------------
+// List
+// -----------------------------------------------------------------------------
+
+test('list mode prints info when the outbox is empty', function (): void {
+    $exit = Artisan::call('swarm:audit:reconcile');
+
+    expect($exit)->toBe(0);
+    expect(Artisan::output())->toContain('No audit outbox rows match.');
+});
+
+test('list mode tabulates pending and dead_letter rows', function (): void {
+    seedReconcileRow('pending');
+    seedReconcileRow('dead_letter');
+
+    $exit = Artisan::call('swarm:audit:reconcile');
+
+    expect($exit)->toBe(0);
+    $output = Artisan::output();
+    expect($output)->toContain('pending');
+    expect($output)->toContain('dead_letter');
+    expect($output)->toContain('run.failed');
+});
+
+test('list mode --status filter only returns matching rows', function (): void {
+    seedReconcileRow('pending', ['run_id' => 'r-pending']);
+    seedReconcileRow('dead_letter', ['run_id' => 'r-dead']);
+
+    Artisan::call('swarm:audit:reconcile', ['--status' => 'dead_letter', '--json' => true]);
+    $decoded = json_decode(Artisan::output(), true);
+
+    expect($decoded['ok'])->toBeTrue();
+    expect($decoded['rows'])->toHaveCount(1);
+    expect($decoded['rows'][0]['status'])->toBe('dead_letter');
+});
+
+test('list mode rejects an unknown --status value', function (): void {
+    $exit = Artisan::call('swarm:audit:reconcile', ['--status' => 'made-up']);
+
+    expect($exit)->toBe(1);
+    expect(Artisan::output())->toContain('--status');
+});
+
+test('list mode --limit caps rows and reports truncation', function (): void {
+    seedReconcileRow('dead_letter');
+    seedReconcileRow('dead_letter');
+    seedReconcileRow('dead_letter');
+
+    Artisan::call('swarm:audit:reconcile', ['--limit' => 2, '--json' => true]);
+    $decoded = json_decode(Artisan::output(), true);
+
+    expect($decoded['rows'])->toHaveCount(2);
+    expect($decoded['truncated'])->toBeTrue();
+    expect($decoded['limit'])->toBe(2);
+});
+
+test('list --json output shape includes the documented fields', function (): void {
+    $id = seedReconcileRow('dead_letter', ['run_id' => 'r-1', 'attempts' => 4]);
+
+    Artisan::call('swarm:audit:reconcile', ['--json' => true]);
+    $decoded = json_decode(Artisan::output(), true);
+
+    expect($decoded['rows'][0])
+        ->toHaveKey('id')
+        ->toHaveKey('status')
+        ->toHaveKey('category')
+        ->toHaveKey('run_id')
+        ->toHaveKey('attempts')
+        ->toHaveKey('last_attempted_at')
+        ->toHaveKey('age');
+    expect($decoded['rows'][0]['id'])->toBe($id);
+    expect($decoded['rows'][0]['attempts'])->toBe(4);
+});
+
+// -----------------------------------------------------------------------------
+// Show
+// -----------------------------------------------------------------------------
+
+test('--show prints metadata and unsealed payload + last_error for a dead_letter row', function (): void {
+    config()->set('swarm.persistence.encrypt_at_rest', true);
+    $id = seedReconcileRow('dead_letter', [
+        'payload' => ['run_id' => 'r-x', 'category' => 'run.failed', 'secret' => 'visible-after-unseal'],
+        'last_error' => 'downstream rejected with 500',
+    ]);
+
+    Artisan::call('swarm:audit:reconcile', ['--show' => (string) $id]);
+    $output = Artisan::output();
+
+    expect($output)->toContain('visible-after-unseal');
+    expect($output)->toContain('downstream rejected with 500');
+    expect($output)->toContain('dead_letter');
+});
+
+test('--show works for pending rows', function (): void {
+    $id = seedReconcileRow('pending');
+
+    $exit = Artisan::call('swarm:audit:reconcile', ['--show' => (string) $id]);
+
+    expect($exit)->toBe(0);
+    expect(Artisan::output())->toContain('pending');
+});
+
+test('--show --json unseals payload into the response', function (): void {
+    config()->set('swarm.persistence.encrypt_at_rest', true);
+    $id = seedReconcileRow('dead_letter', [
+        'payload' => ['run_id' => 'r-x', 'category' => 'run.failed', 'secret' => 'unsealed-payload-x'],
+    ]);
+
+    Artisan::call('swarm:audit:reconcile', ['--show' => (string) $id, '--json' => true]);
+    $decoded = json_decode(Artisan::output(), true);
+
+    expect($decoded['ok'])->toBeTrue();
+    expect($decoded['row']['payload']['secret'])->toBe('unsealed-payload-x');
+});
+
+test('--show with an unknown id returns a clear error', function (): void {
+    $exit = Artisan::call('swarm:audit:reconcile', ['--show' => '99999']);
+
+    expect($exit)->toBe(1);
+    expect(Artisan::output())->toContain('not found');
+});
+
+// -----------------------------------------------------------------------------
+// Requeue
+// -----------------------------------------------------------------------------
+
+test('--requeue resets a dead_letter row to pending with attempts=0 and preserves last_error', function (): void {
+    $sink = reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter', ['attempts' => 5, 'last_error' => 'sink down for 24h']);
+
+    $exit = Artisan::call('swarm:audit:reconcile', ['--requeue' => (string) $id, '--force' => true]);
+
+    expect($exit)->toBe(0);
+
+    $row = DB::table('swarm_audit_outbox')->where('id', $id)->first();
+    expect($row->status)->toBe('pending');
+    expect($row->attempts)->toBe(0);
+    expect($row->reserved_at)->toBeNull();
+    expect($row->last_error)->not->toBeNull();
+
+    $records = $sink->recordsForCategory('command.audit_reconcile');
+    expect($records)->toHaveCount(1);
+    expect($records[0]['action'])->toBe('requeue');
+    expect($records[0]['target_id'])->toBe($id);
+    expect($records[0]['target_category'])->toBe('run.failed');
+    expect($records[0]['prior_attempts'])->toBe(5);
+});
+
+test('--requeue with --reason records the reason on the command.audit_reconcile evidence', function (): void {
+    $sink = reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter');
+
+    Artisan::call('swarm:audit:reconcile', [
+        '--requeue' => (string) $id,
+        '--reason' => 'sink restored after maintenance window',
+        '--force' => true,
+    ]);
+
+    $records = $sink->recordsForCategory('command.audit_reconcile');
+    expect($records[0]['reason'])->toBe('sink restored after maintenance window');
+});
+
+test('--requeue rejects pending rows with a clear error', function (): void {
+    reconcileRecordingSink();
+    $id = seedReconcileRow('pending');
+
+    $exit = Artisan::call('swarm:audit:reconcile', ['--requeue' => (string) $id, '--force' => true]);
+
+    expect($exit)->toBe(1);
+    expect(Artisan::output())->toContain('only dead_letter rows can be requeued');
+
+    $row = DB::table('swarm_audit_outbox')->where('id', $id)->first();
+    expect($row->status)->toBe('pending');
+});
+
+test('--requeue rejects unknown ids', function (): void {
+    reconcileRecordingSink();
+
+    $exit = Artisan::call('swarm:audit:reconcile', ['--requeue' => '99999', '--force' => true]);
+
+    expect($exit)->toBe(1);
+    expect(Artisan::output())->toContain('not found');
+});
+
+test('--requeue without --force aborts when no operator confirms (non-interactive)', function (): void {
+    $sink = reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter');
+
+    $exit = Artisan::call('swarm:audit:reconcile', ['--requeue' => (string) $id]);
+
+    expect($exit)->toBe(1);
+
+    $row = DB::table('swarm_audit_outbox')->where('id', $id)->first();
+    expect($row->status)->toBe('dead_letter');
+    expect($sink->recordsForCategory('command.audit_reconcile'))->toHaveCount(0);
+});
+
+test('--requeue proceeds when confirmation is given interactively', function (): void {
+    $sink = reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter');
+
+    $this->artisan('swarm:audit:reconcile', ['--requeue' => (string) $id])
+        ->expectsConfirmation('Requeue audit outbox row ['.$id.'] (category=run.failed, attempts=3)?', 'yes')
+        ->assertSuccessful();
+
+    expect(DB::table('swarm_audit_outbox')->where('id', $id)->value('status'))->toBe('pending');
+    expect($sink->recordsForCategory('command.audit_reconcile'))->toHaveCount(1);
+});
+
+// -----------------------------------------------------------------------------
+// Dismiss
+// -----------------------------------------------------------------------------
+
+test('--dismiss deletes a dead_letter row and emits the audit record with reason snapshot', function (): void {
+    $sink = reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter', ['attempts' => 7, 'run_id' => 'r-dismiss']);
+
+    $exit = Artisan::call('swarm:audit:reconcile', [
+        '--dismiss' => (string) $id,
+        '--reason' => 'duplicate of run.failed for r-7',
+        '--force' => true,
+    ]);
+
+    expect($exit)->toBe(0);
+    expect(DB::table('swarm_audit_outbox')->where('id', $id)->exists())->toBeFalse();
+
+    $records = $sink->recordsForCategory('command.audit_reconcile');
+    expect($records)->toHaveCount(1);
+    expect($records[0]['action'])->toBe('dismiss');
+    expect($records[0]['target_id'])->toBe($id);
+    expect($records[0]['target_run_id'])->toBe('r-dismiss');
+    expect($records[0]['target_category'])->toBe('run.failed');
+    expect($records[0]['prior_attempts'])->toBe(7);
+    expect($records[0]['reason'])->toBe('duplicate of run.failed for r-7');
+});
+
+test('--dismiss requires --reason and refuses without it', function (): void {
+    $sink = reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter');
+
+    $exit = Artisan::call('swarm:audit:reconcile', ['--dismiss' => (string) $id, '--force' => true]);
+
+    expect($exit)->toBe(1);
+    expect(Artisan::output())->toContain('--reason');
+
+    expect(DB::table('swarm_audit_outbox')->where('id', $id)->exists())->toBeTrue();
+    expect($sink->recordsForCategory('command.audit_reconcile'))->toHaveCount(0);
+});
+
+test('--dismiss rejects pending rows', function (): void {
+    reconcileRecordingSink();
+    $id = seedReconcileRow('pending');
+
+    $exit = Artisan::call('swarm:audit:reconcile', [
+        '--dismiss' => (string) $id,
+        '--reason' => 'wrong row',
+        '--force' => true,
+    ]);
+
+    expect($exit)->toBe(1);
+    expect(Artisan::output())->toContain('only dead_letter rows can be dismissed');
+    expect(DB::table('swarm_audit_outbox')->where('id', $id)->exists())->toBeTrue();
+});
+
+test('--dismiss without --force aborts when no operator confirms (non-interactive)', function (): void {
+    $sink = reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter');
+
+    $exit = Artisan::call('swarm:audit:reconcile', [
+        '--dismiss' => (string) $id,
+        '--reason' => 'duplicate',
+    ]);
+
+    expect($exit)->toBe(1);
+    expect(DB::table('swarm_audit_outbox')->where('id', $id)->exists())->toBeTrue();
+    expect($sink->recordsForCategory('command.audit_reconcile'))->toHaveCount(0);
+});
+
+test('--dismiss proceeds when confirmation is given interactively', function (): void {
+    $sink = reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter');
+
+    $this->artisan('swarm:audit:reconcile', [
+        '--dismiss' => (string) $id,
+        '--reason' => 'duplicate',
+    ])
+        ->expectsConfirmation('Permanently delete audit outbox row ['.$id.'] (category=run.failed, run_id=r-test)?', 'yes')
+        ->assertSuccessful();
+
+    expect(DB::table('swarm_audit_outbox')->where('id', $id)->exists())->toBeFalse();
+    expect($sink->recordsForCategory('command.audit_reconcile'))->toHaveCount(1);
+});
+
+function bindFailingDispatcher(): void
+{
+    $stub = new class extends SwarmAuditDispatcher
+    {
+        public function __construct() {}
+
+        public function emit(string $category, array $payload): void
+        {
+            throw new RuntimeException('emit blew up');
+        }
+
+        public function metadata(array $metadata): array
+        {
+            return ['metadata_keys' => [], 'metadata' => []];
+        }
+    };
+    app()->instance(SwarmAuditDispatcher::class, $stub);
+}
+
+test('dismiss does NOT delete the row when the audit emit fails', function (): void {
+    $id = seedReconcileRow('dead_letter');
+    bindFailingDispatcher();
+
+    $exit = Artisan::call('swarm:audit:reconcile', [
+        '--dismiss' => (string) $id,
+        '--reason' => 'attempted dismiss',
+        '--force' => true,
+    ]);
+
+    expect($exit)->toBe(1);
+    expect(Artisan::output())->toContain('command.audit_reconcile');
+    expect(DB::table('swarm_audit_outbox')->where('id', $id)->exists())->toBeTrue();
+});
+
+test('requeue does NOT mutate the row when the audit emit fails', function (): void {
+    $id = seedReconcileRow('dead_letter', ['attempts' => 4]);
+    bindFailingDispatcher();
+
+    $exit = Artisan::call('swarm:audit:reconcile', [
+        '--requeue' => (string) $id,
+        '--force' => true,
+    ]);
+
+    expect($exit)->toBe(1);
+    $row = DB::table('swarm_audit_outbox')->where('id', $id)->first();
+    expect($row->status)->toBe('dead_letter');
+    expect($row->attempts)->toBe(4);
+});
+
+// -----------------------------------------------------------------------------
+// Mutual exclusivity
+// -----------------------------------------------------------------------------
+
+test('combining --show with --requeue is rejected', function (): void {
+    $id = seedReconcileRow('dead_letter');
+
+    $exit = Artisan::call('swarm:audit:reconcile', [
+        '--show' => (string) $id,
+        '--requeue' => (string) $id,
+        '--force' => true,
+    ]);
+
+    expect($exit)->toBe(1);
+    expect(Artisan::output())->toContain('Use only one of');
+});


### PR DESCRIPTION
Closes #36

## Summary
- New `php artisan swarm:audit:reconcile` Artisan command for forensic triage of the audit outbox dead-letter lane. Four mutually exclusive sub-modes (default list, `--show`, `--requeue`, `--dismiss`), with `--json` machine-readable output, `--force` to skip confirmation, and `--reason` recorded on every mutation.
- New `command.audit_reconcile` audit category emitted via the existing `SwarmAuditDispatcher`, mirroring the `command.relay` pattern in `SwarmRelayCommand`. The emit happens **before** the row is mutated; if it fails, the row is left untouched so audit evidence cannot be silently erased.
- Pending rows can be listed and shown but cannot be requeued or dismissed — the relay owns their lifecycle. `--dismiss` requires `--reason` as a chain-of-custody guard; the audit record carries a metadata snapshot of the deleted row.
- Cache-driver installs exit non-zero with a clear error (the command requires the database-backed outbox).
- Docs: new "Forensic triage: swarm:audit:reconcile" subsection in `docs/maintenance.md` under the existing Audit outbox section.

## Implementation notes
- Command registered alongside the other `swarm:*` commands in `SwarmServiceProvider`.
- Sealed `payload` and `last_error` columns are unsealed via `SwarmPersistenceCipher::open()` (handles plaintext fallback already).
- `command.audit_reconcile` payload carries `action`, `target_id`, `target_category`, `target_run_id`, `prior_attempts`, `reason`, plus actor metadata via `SwarmAuditDispatcher::metadata()` and an `Actor::system('artisan')` envelope — same shape family as `command.relay`.
- `phpstan.neon` ignored-paths list extended for `property.notFound` on the command (query-builder rows are stdClass; same exemption pattern as the Database* persistence stores).

## Test plan
- [x] List: empty / populated / `--status=...` filter / `--limit=N` truncation / `--json` field shape
- [x] Show: existing dead_letter row (unseals payload and last_error end-to-end) / existing pending row / unknown id / `--json`
- [x] Requeue: dead_letter -> pending + attempts=0 + last_error preserved + `command.audit_reconcile` emitted with `prior_attempts` and `reason` / pending row rejected / unknown id rejected / non-interactive abort / interactive confirmation flow / **audit emit failure leaves row untouched**
- [x] Dismiss: dead_letter row deleted + `command.audit_reconcile` emitted with reason and metadata snapshot / missing `--reason` rejected / pending row rejected / non-interactive abort / interactive confirmation flow / **audit emit failure leaves row untouched**
- [x] Cache-driver path: clear error, exit non-zero
- [x] Mutual exclusivity of `--show` / `--requeue` / `--dismiss`
- [x] `composer test` (787 passed, 2990 assertions)
- [x] `composer lint`
- [x] `composer analyse`

🤖 Generated with [Claude Code](https://claude.com/claude-code)