### PR TITLE
release: v0.6.0 — operator UX + DX + test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.6.0 - unreleased
+
+Operator UX, developer experience, and test coverage on top of the v0.5 audit outbox foundation. No new public-surface contracts. No migration changes. No breaking changes.
+
+### Added
+
+_To be filled in during release wrap-up._
+
+### Changed
+
+_To be filled in during release wrap-up._
+
 ## v0.5.0 - 2026-05-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@ Operator UX, developer experience, and test coverage on top of the v0.5 audit ou
 
 ## v0.5.0 - 2026-05-19
 
-## v0.5.0 - 2026-05-19
-
 ### Added
 
 - **Audit outbox + queue/dead-letter failure policies (#20).** Sink failures can now be persisted to the new `swarm_audit_outbox` table and retried via `swarm:relay --type=audit`. The relay command drains both the durable lane and the audit lane in a single pass (or each independently with `--type=step` / `--type=audit`). `SinkFailureDecision` gains `Queue` and `DeadLetter` cases. `ConfiguredSinkFailureHandler` recognizes `queue` and `dead_letter` failure-policy values in addition to the v0.4 `swallow` / `log` / `halt`. `swarm.audit.outbox.max_attempts` (default 5) controls how many retry passes a record gets before moving to the dead-letter status. `command.relay` evidence gains `audit_replayed_count` and `audit_dead_lettered_count` fields. Dead-letter transitions emit `Log::error` so monitoring stacks can alert on undelivered audit evidence. The `payload` and `last_error` columns are sealed when `swarm.persistence.encrypt_at_rest` is enabled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,20 @@
 # Changelog
 
-## v0.6.0 - unreleased
+## v0.6.0 - 2026-05-20
 
 Operator UX, developer experience, and test coverage on top of the v0.5 audit outbox foundation. No new public-surface contracts. No migration changes. No breaking changes.
 
 ### Added
 
-_To be filled in during release wrap-up._
+- **`swarm:audit:status` summary command (#37).** New read-only Artisan command that surfaces the audit outbox at a glance for operators triaging from the CLI; reports counts (pending / reserved / stale_reserved / dead_letter), an age-distribution histogram, the top-5 dead-letter categories, the oldest pending and dead-letter rows, and the configured retention window alongside the next-prune count. `--json` mirrors the `SwarmHealthCommand` shape so the same monitoring scrapers consume both. Degrades cleanly on cache persistence by skipping with an informational note instead of querying a table that does not exist.
+- **`swarm:audit:reconcile` forensic CLI (#36).** New operator-driven Artisan command for dead-letter triage; defaults to `list` mode and gains `--show=<id>` (display a single row with its sealed payload unsealed for human review), `--requeue=<id>` (re-enqueue a dead-letter record for one more relay pass), and `--dismiss=<id> --reason="..."` (permanently dismiss a record with a mandatory operator-supplied reason). Supports `--json`, `--force` (required for mutations under `--json`), `--limit`, and `--status` flags. Pending rows can be listed or shown but the relay owns their lifecycle — mutations are dead-letter-only.
+- **`command.audit_reconcile` audit category.** Emitted on every `swarm:audit:reconcile` requeue, dismiss, and show action so triage is itself chain-of-custody evidence; payload carries `action`, `target_id`, `target_category`, `target_run_id`, `prior_attempts`, `reason` (required on dismiss, optional on requeue, omitted on show), `target_created_at`, `target_age_seconds`, and `target_payload_digest` (sha256 hex over the stored payload bytes, present on dismiss only so a dismissal can be cross-checked against a forensic backup without unsealing). Enumerated in `docs/audit-evidence-contract.md` as a frozen category. Custom `SwarmAuditSink` implementations that allowlist categories or schema-validate payloads must add `command.audit_reconcile` to their allowlist — without it, operator triage actions are silently dropped, exactly the records that exist to survive scrutiny.
+- **`swarm.audit-outbox` Pulse Livewire card (#38).** New operator-facing dashboard card showing dead-letter count (red alarm if > 0), pending count, stale-pending count (amber alarm if > 0), oldest pending and dead-letter ages, and the configured retention setting; mirrors the `SwarmRuns` / `SwarmSteps` card layout already shipped by the package. Renders a neutral state with zero DB queries on cache persistence so dashboards do not error out under the unsupported driver. Documented in `docs/pulse.md` alongside the existing cards.
+- **Operator runbook at `docs/operator-runbook-audit-outbox.md` (#45).** Scenario-driven 3am-triage walkthrough across five sections: dead-letter triage decision tree, stale-pending decision tree, sink-permanently-broken procedure, retention decision tree per regulatory regime (21 CFR Part 11, SOC 2, HIPAA — deliberately defers regime-specific retention guidance to compliance officers rather than asserting it), and forensic reconstruction (forward marker for `swarm:trace` in v0.7). Cross-linked from the README Production Checklist, `docs/maintenance.md`, and the `docs/README.md` index so operators discovering the package from any entry point find the runbook.
+- **v0.5 audit-chain walkthroughs in `examples/durable-compliance-review/` and `examples/privacy-capture/` (#46).** `durable-compliance-review` gains a full simulated-outage scenario with baseline config, a `RecoveringSinkDemo` fixture that fails then heals, `swarm:audit:status` and `swarm:health --audit` output samples, recovery via `swarm:relay --type=audit`, and dead-letter triage via `swarm:audit:reconcile --show/--requeue/--dismiss`. `privacy-capture` gains a smaller "v0.5 Audit Chain For Redacted Evidence" section covering what `failure_policy=queue` means for redacted payloads and the privacy implications of `--show` on sealed outbox rows.
+- **Integration test coverage for the v0.5 audit outbox flow (#39).** New `tests/Feature/AuditOutboxIntegrationTest.php` covering three end-to-end scenarios: DB-backed failing-sink → outbox → replay → dead_letter; cache-backed log-and-swallow fallback; and cross-lane `swarm:relay` draining both durable and audit lanes in a single pass. Extracted the existing `CountingThrowingSink` fixture from `tests/Unit/Audit/SinkFailureHandlerTest.php` into `tests/Fixtures/CountingThrowingSink.php` for reuse across the suite.
 
-### Changed
-
-_To be filled in during release wrap-up._
+## v0.5.0 - 2026-05-19
 
 ## v0.5.0 - 2026-05-19
 

--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ Use [Persistence And History](docs/persistence-and-history.md), [Maintenance](do
 - Bind `SwarmTelemetrySink` for logs, metrics, or tracing correlation.
 - Avoid secrets in metadata. Capture redaction does not sanitize arbitrary developer-supplied metadata. Set `SWARM_MAX_METADATA_BYTES` to enforce a hard size cap.
 - Build run inspection around `run_id`, lifecycle events, `SwarmHistory`, and durable runtime state.
+- Bookmark the [Operator Runbook: Audit Outbox Triage](docs/operator-runbook-audit-outbox.md) before going live. It is the 3 a.m. decision tree for dead-letter rows, stale pending rows, and sink outages — and it assumes the reader has not just re-read the reference docs.
 
 ### Audit Extension Points
 
@@ -511,7 +512,7 @@ Two environment knobs control strict-mode behavior:
 
 The full `SWARM_AUDIT_FAILURE_POLICY` matrix (since v0.5): `swallow` (drop silently — v0.4 default), `log` (log and continue), `queue` (persist to `swarm_audit_outbox` for retry — v0.5 default), `dead_letter` (persist directly to dead-letter status, no retry), `halt` (fail the run). The audit outbox is monitored by default via `swarm:health` (or `swarm:health --audit` for focused investigation).
 
-See [Audit Evidence Contract](docs/audit-evidence-contract.md) for the full reference.
+See [Audit Evidence Contract](docs/audit-evidence-contract.md) for the full reference. When responding to an audit-outbox page, see the [Operator Runbook: Audit Outbox Triage](docs/operator-runbook-audit-outbox.md).
 
 ## Documentation
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -268,6 +268,88 @@ This package’s `composer.json` uses `"minimum-stability": "dev"` with
 still prefers tagged releases. Your application may need compatible Composer
 stability settings while Laravel AI remains pre-stable.
 
+## Upgrading to v0.6.0
+
+v0.6.0 is purely additive on top of v0.5.0 — no migrations, no env-var
+changes, no breaking surface. Existing v0.5 deployments can adopt v0.6
+surfaces incrementally.
+
+### High Impact Changes
+
+#### Custom `SwarmAuditSink` allowlists must add `command.audit_reconcile`
+
+v0.6.0 introduces a new audit category, `command.audit_reconcile`,
+emitted by the new `swarm:audit:reconcile` Artisan command on every
+operator triage action against the audit outbox (requeue, dismiss, and
+show). The category is enumerated in
+`docs/audit-evidence-contract.md` and behaves like every other
+`command.*` category — it carries `schema_version: "2"` and the
+standard `metadata.actor` envelope slot.
+
+**Required if you implement a custom `SwarmAuditSink` that allowlists
+categories or schema-validates payloads:** add `command.audit_reconcile`
+to your allowlist. Without this, operator triage actions are silently
+dropped — exactly the records that exist to survive scrutiny. A sink
+that rejects unknown categories will also reject these records, so
+either accept the new category or extend the strict-validation switch
+to cover it.
+
+The frozen payload fields, in order:
+
+- `action` (string, one of `requeue`, `dismiss`, `show`)
+- `target_id` (int) — the `swarm_audit_outbox` row id
+- `target_category` (string) — the category of the original failed emit
+- `target_run_id` (string&#124;null) — the run id from the original payload, if present
+- `prior_attempts` (int) — the outbox row's attempt count at the time of the action
+- `reason` (string) — required on `dismiss`, optional on `requeue`, omitted on `show`
+- `target_created_at` (ISO 8601 string) — when the outbox row was first written
+- `target_age_seconds` (int) — age at the time of the action
+- `target_payload_digest` (sha256 hex string) — **present on `dismiss` only**; a sha256 over the stored payload bytes so an auditor can verify the deletion against a forensic backup without unsealing
+
+Sinks that ignore unknown categories (or fall through to a generic
+`emit($category, $payload)` path) need no changes.
+
+### Medium Impact Changes
+
+#### Operator adoption — optional v0.6 surfaces
+
+The new dashboard card and the two new Artisan commands are
+opt-in operator surfaces. Adopt them where they fit; nothing about
+v0.5 stops working if you defer.
+
+- **Pulse card.** Register the new card by adding
+  `\BuiltByBerry\LaravelSwarm\Pulse\Livewire\AuditOutbox::class` to
+  your `pulse.cards` config, or place the `<livewire:swarm.audit-outbox />`
+  Blade tag directly in a custom dashboard view. The card renders a
+  neutral state with zero DB queries on cache persistence; no further
+  configuration is required.
+- **`swarm:audit:status`.** Read-only outbox summary; safe to run from
+  the CLI or wire into a monitoring scraper via `--json`.
+- **`swarm:audit:reconcile`.** Operator-on-demand forensic CLI. Treat
+  it like `swarm:recover` — invoke from the CLI when triaging, do not
+  schedule it. **Do not** add either of the new commands to the
+  scheduler. `swarm:relay` (already scheduled in v0.5) continues to
+  drain the audit lane on its existing cadence.
+
+### Low Impact Changes
+
+#### Compliance posture: dismissals are now digest-bound and reads are counted
+
+v0.6 strengthens the chain of custody on operator dismissals via the
+new `target_payload_digest` field — a sha256 over the stored payload
+bytes that lets an auditor verify a `--dismiss` action against a
+forensic backup of the outbox without unsealing. Payload **reads** are
+also now counted: `swarm:audit:reconcile --show` emits a
+`command.audit_reconcile` record with `action=show` (no payload
+contents in the audit record), so operator inspection of a dead-letter
+row is itself a tracked event.
+
+Operators with shell access to `swarm:audit:reconcile --show` should
+be treated the same as operators with direct database read access —
+the audit emit accounts for individual reads but does not authorize
+them. Gate shell access accordingly. The `docs/operator-runbook-audit-outbox.md`
+"Audit trail of reads" subsection covers the operational expectations.
+
 ## Upgrading to v0.5.0
 
 v0.5.0 settles the audit evidence envelope and lands the durability layer

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "0.5.x-dev"
+            "dev-main": "0.6.x-dev"
         },
         "laravel": {
             "providers": [

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,7 @@ The recommended reading path for new users.
 - [Logging & Tracing](observability-logging-tracing.md) — telemetry sink, structured logs, OTEL
 - [Correlation Contract](observability-correlation-contract.md)
 - [Audit Evidence](audit-evidence-contract.md)
+- [Operator Runbook: Audit Outbox Triage](operator-runbook-audit-outbox.md) — 3 a.m. decision trees for dead-letter and stale-pending pages
 - [Metadata Allowlist Governance](metadata-allowlist-governance.md) — what belongs in metadata, named anti-patterns, and the allowlist review pattern
 - [Pulse](pulse.md) — Laravel Pulse cards for run counts and step latencies
 

--- a/docs/audit-evidence-contract.md
+++ b/docs/audit-evidence-contract.md
@@ -204,6 +204,7 @@ advance execution.
 | `command.recover` | `swarm:recover` was invoked. Includes `recovered_count` and `recovered_run_ids`. |
 | `command.relay`   | `swarm:relay` completed or failed. Always includes `dispatched_count`, `skipped_count`, `failed_count`, `claimed_count` (rows reserved in phase 1), `reclaimed_count` (of those, rows with a stale prior reservation), `types`, `limit`, `drain_until_empty`, `max_attempts` (null when not set), and `attempts` (number of drain iterations executed). As of v0.5.0, also always includes `audit_replayed_count` (audit records successfully re-emitted through the bound sink during this drain) and `audit_dead_lettered_count` (audit records that exhausted `swarm.audit.outbox.max_attempts` during this drain and moved to dead-letter status). Status values: `dispatched` (at least one entry dispatched or audit record replayed, no transient failures at exit); `skipped` (only permanently invalid entries processed, none dispatched); `none_found` (both outboxes were empty); `transient_failure` (one or more entries could not be dispatched due to a transient queue error — `failed_count` is > 0, entries remain in the outbox for reclaim); `error` (an unhandled exception escaped the drain loop — includes `exception_class`). Note: `exception_class` is present only on `status: "error"` events. Individual `run_id`s of permanently deleted rows (counted in `skipped_count`) are not in the audit payload — they are in the application error tracker via `report()`, where the exception message includes the outbox entry ID. Cross-reference by entry ID for post-incident reconstruction. |
 | `command.prune`   | `swarm:prune` completed. Includes `dry_run`, `prevent_prune`, `status`, and `counts` (row counts per table). |
+| `command.audit_reconcile` | Emitted on every `--requeue`, `--dismiss`, or `--show` of an audit outbox row by `swarm:audit:reconcile` (v0.6.0+). Chain-of-custody for operator triage actions. `--show` emits with `action=show` and no `payload` contents — reads are at least counted. `--dismiss` includes `target_payload_digest` (sha256 of the stored payload bytes) so the deleted row can be tied back to a forensic backup of the table without unsealing it. |
 
 All command categories carry actor identity under `metadata.actor` as an
 `Actor` value object array — typically `{id: "artisan", type: "system"}`.
@@ -446,6 +447,7 @@ Additional frozen fields by category:
 | `command.recover` |
 | `command.relay`   |
 | `command.prune`   |
+| `command.audit_reconcile` |
 
 Every `command.*` event carries:
 
@@ -464,6 +466,7 @@ Additional frozen fields by category:
 | `command.recover` | `target_run_id` (string&#124;null), `target_swarm_class` (string&#124;null). On success: `recovered_count` (int), `recovered_run_ids` (array&lt;string&gt;). On failure: `exception_class` (string). |
 | `command.relay`   | `types` (array&lt;string&gt;), `limit` (int), `drain_until_empty` (bool), `max_attempts` (int&#124;null), `attempts` (int), `dispatched_count` (int), `skipped_count` (int), `failed_count` (int), `claimed_count` (int), `reclaimed_count` (int), `audit_replayed_count` (int, v0.5.0+), `audit_dead_lettered_count` (int, v0.5.0+). |
 | `command.prune`   | `dry_run` (bool), `prevent_prune` (bool), `counts` (array&lt;string, int&gt;).                                    |
+| `command.audit_reconcile` | `action` (string, one of `requeue`, `dismiss`, `show`), `target_id` (int), `target_category` (string), `target_run_id` (string&#124;null), `prior_attempts` (int), `target_created_at` (ISO 8601 string), `target_age_seconds` (int). `reason` (string) is required on `dismiss`, optional on `requeue`, and omitted on `show`. `target_payload_digest` (sha256 hex string) is present on `dismiss` only — computed over the stored (sealed or plaintext fallback) payload bytes so an auditor can verify the deletion against a forensic backup without unsealing. v0.6.0+. |
 
 #### Webhook Idempotency
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -342,9 +342,15 @@ recovery. Every sub-mode accepts `--json` for automation.
 
 Every requeue or dismiss emits a `command.audit_reconcile` audit record
 carrying `action`, `target_id`, `target_category`, `target_run_id`,
-`prior_attempts`, and `reason` **before** mutating the row. If the
-audit emit fails the row is left untouched, so reconciliation cannot
-silently erase evidence.
+`prior_attempts`, and `reason` **before** mutating the row. `--show`
+emits the same category with `action=show` and no payload contents so
+reads are counted in the audit chain. Dismiss emits also include a
+`target_payload_digest` (sha256 hex of the stored payload bytes) so the
+deleted row can be tied back to a forensic backup of the table without
+unsealing. If the audit emit fails outright (for example under
+`failure_policy=halt`), the row is left untouched. Under the default
+`queue` policy, the reconcile record is itself enqueued for retry —
+evidence is preserved in the outbox even when the sink is unavailable.
 
 ## High-volume dashboards
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -338,7 +338,10 @@ php artisan swarm:audit:reconcile --dismiss=42 --reason="duplicate of r-7"
 Pending rows can be listed and shown but cannot be requeued or
 dismissed; the relay owns their lifecycle. Both `--requeue` and
 `--dismiss` prompt for confirmation; use `--force` for scripted
-recovery. Every sub-mode accepts `--json` for automation.
+recovery. Every sub-mode accepts `--json` for automation. When
+scripting a loop with `--json`, also pass `--force` to confirm
+requeue/dismiss; without it the command exits with a `force_required`
+error envelope rather than silently aborting.
 
 Every requeue or dismiss emits a `command.audit_reconcile` audit record
 carrying `action`, `target_id`, `target_category`, `target_run_id`,

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -305,6 +305,43 @@ lifecycle). `swarm.retention.prevent_prune=true` overrides as usual.
 See [Audit Evidence Contract](audit-evidence-contract.md) for the full
 retry, encryption-at-rest, and signer-rotation behavior.
 
+### Forensic triage: `swarm:audit:reconcile`
+
+`swarm:audit:reconcile` is the operator command for inspecting and
+reconciling rows that the relay has either failed or dead-lettered. It
+requires the database persistence driver; on cache the command exits
+non-zero with a clear error.
+
+Four sub-modes (mutually exclusive):
+
+```bash
+# List pending and dead_letter rows (capped at --limit, default 50)
+php artisan swarm:audit:reconcile
+php artisan swarm:audit:reconcile --status=dead_letter --limit=200
+
+# Inspect a single row, including unsealed payload and last_error
+php artisan swarm:audit:reconcile --show=42
+
+# Reset a dead_letter row to pending so the relay re-attempts emission.
+# attempts is zeroed; last_error is preserved as forensic evidence.
+php artisan swarm:audit:reconcile --requeue=42 --reason="sink restored"
+
+# Permanently delete a dead_letter row. --reason is REQUIRED — audit
+# evidence cannot be discarded without a chain-of-custody justification.
+php artisan swarm:audit:reconcile --dismiss=42 --reason="duplicate of r-7"
+```
+
+Pending rows can be listed and shown but cannot be requeued or
+dismissed; the relay owns their lifecycle. Both `--requeue` and
+`--dismiss` prompt for confirmation; use `--force` for scripted
+recovery. Every sub-mode accepts `--json` for automation.
+
+Every requeue or dismiss emits a `command.audit_reconcile` audit record
+carrying `action`, `target_id`, `target_category`, `target_run_id`,
+`prior_attempts`, and `reason` **before** mutating the row. If the
+audit emit fails the row is left untouched, so reconciliation cannot
+silently erase evidence.
+
 ## High-volume dashboards
 
 Swarm database tables are sized for operational throughput. List and aggregation

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -246,6 +246,10 @@ When to use: parallel or hierarchical durable swarms in production.
 
 ## Audit outbox
 
+If you are responding to a page, see the
+[Operator Runbook: Audit Outbox Triage](operator-runbook-audit-outbox.md).
+This section is the reference; the runbook is the decision tree.
+
 Since v0.5.0, `SWARM_AUDIT_FAILURE_POLICY` defaults to `queue` and audit
 sink failures are persisted to a new `swarm_audit_outbox` table for retry
 through the same `swarm:relay` schedule that handles durable dispatches.

--- a/docs/operator-runbook-audit-outbox.md
+++ b/docs/operator-runbook-audit-outbox.md
@@ -116,8 +116,10 @@ Action:
 
    For more than a handful of rows, script the loop using
    `swarm:audit:reconcile --status=dead_letter --json --limit=200` and
-   feed the IDs into `--requeue=<id>` calls. Use `--force` to skip the
-   interactive confirm.
+   feed the IDs into `--requeue=<id>` calls. Pass `--force` on each
+   call to confirm requeue/dismiss; without it `--json` mutations exit
+   with a `force_required` error envelope rather than silently
+   aborting.
 
 #### Branch C — Evidence is legitimately undeliverable and not worth retrying
 

--- a/docs/operator-runbook-audit-outbox.md
+++ b/docs/operator-runbook-audit-outbox.md
@@ -52,6 +52,26 @@ php artisan swarm:audit:reconcile --show=<id>
 This unseals the payload and prints `last_error`. Read both. The error
 string is the sink's verbatim rejection.
 
+#### Audit trail of reads
+
+Every `--show` invocation emits a `command.audit_reconcile` evidence
+record with `action=show` so reads are counted in the audit chain. The
+emit carries `target_id`, `target_category`, `target_run_id`,
+`prior_attempts`, `target_created_at`, and `target_age_seconds` — but no
+payload contents and no `reason` (reads do not require justification,
+only accounting).
+
+Shell access to `swarm:audit:reconcile --show` is operator-trusted.
+Treat the command's reach the same way you treat database read access.
+The audit emit accounts for individual reads but does not authorize
+them — host-access controls are still where you gate who can run this
+in the first place.
+
+If the audit sink itself is unavailable when you run `--show`, the
+command still prints the row (read-only, already in memory) but exits
+non-zero with a clear warning so the broken audit chain is visible.
+Rerun once the sink recovers.
+
 ### Step 3 — Decide
 
 Match `last_error` (and, if needed, the sink's own logs) against the

--- a/docs/operator-runbook-audit-outbox.md
+++ b/docs/operator-runbook-audit-outbox.md
@@ -1,0 +1,296 @@
+# Operator Runbook: Audit Outbox Triage
+
+This is a 3 a.m. runbook. You were paged about the swarm audit outbox and need
+to know what to do, in order, without first re-reading the reference docs.
+
+For the design contract and full field reference, see
+[Audit Evidence Contract](audit-evidence-contract.md) and
+[Maintenance § Audit outbox](maintenance.md#audit-outbox). This page only
+covers the operator decision trees.
+
+The two operator commands referenced throughout — `swarm:audit:status` and
+`swarm:audit:reconcile` — require the database persistence driver. On the
+cache driver the audit outbox is not in use and these commands exit cleanly
+with a clear message.
+
+---
+
+## 1. Page received: dead-letter row exists
+
+You were paged by a Pulse alarm, log aggregator, or `swarm:health --audit`
+failure. At least one row in `swarm_audit_outbox` has status `dead_letter` —
+an audit event that was emitted, the sink rejected, the relay retried up to
+`swarm.audit.outbox.max_attempts`, and the row was moved to dead-letter.
+Without operator action, the evidence will not reach the sink.
+
+### Step 1 — Read the shape of the problem
+
+```bash
+php artisan swarm:audit:status
+```
+
+What to look for:
+
+- **`dead_letter` count** — how many rows you are triaging.
+- **Top dead-letter categories** — if everything is `run.failed`, the sink
+  probably handled `run.started` and broke later. If it is a single category
+  like `command.audit_reconcile`, that narrows root cause.
+- **Oldest dead-letter age** — anything older than the alarm window suggests
+  this is not a one-off transient.
+- **Retention** — confirm `dead_letter_retention_days` matches what you
+  expect. The audit-safe default is `null` (indefinite).
+
+### Step 2 — Inspect a representative row
+
+Pick an ID from `swarm:audit:status` (or list with
+`swarm:audit:reconcile --status=dead_letter`):
+
+```bash
+php artisan swarm:audit:reconcile --show=<id>
+```
+
+This unseals the payload and prints `last_error`. Read both. The error
+string is the sink's verbatim rejection.
+
+### Step 3 — Decide
+
+Match `last_error` (and, if needed, the sink's own logs) against the
+following branches.
+
+#### Branch A — Transient sink failure
+
+Signal: `last_error` looks like a network timeout, 5xx from a downstream
+API, transient DB error, or anything that would resolve on retry. The sink
+itself is healthy now.
+
+Action:
+
+```bash
+php artisan swarm:audit:reconcile --requeue=<id> --reason="sink restored"
+```
+
+The row goes back to `pending` with `attempts=0`; `last_error` is preserved
+for forensics. The next `swarm:relay --type=audit` re-attempts emission.
+
+#### Branch B — Permanent sink misconfiguration
+
+Signal: `last_error` shows wrong endpoint, expired credential, schema
+rejection, 4xx auth or validation. The sink will reject the next attempt
+identically until the misconfiguration is fixed.
+
+Action:
+
+1. **Fix the sink first** — rotate the credential, update the endpoint,
+   correct the schema, redeploy, whatever applies.
+2. Verify with a single drain:
+
+   ```bash
+   php artisan swarm:relay --type=audit --limit=1
+   ```
+
+3. Requeue the rest:
+
+   ```bash
+   php artisan swarm:audit:reconcile --requeue=<id> --reason="endpoint rotated"
+   ```
+
+   For more than a handful of rows, script the loop using
+   `swarm:audit:reconcile --status=dead_letter --json --limit=200` and
+   feed the IDs into `--requeue=<id>` calls. Use `--force` to skip the
+   interactive confirm.
+
+#### Branch C — Evidence is legitimately undeliverable and not worth retrying
+
+Signal: the row reflects an event that should not have been emitted in the
+first place (a test run, a known-orphaned import, a dev environment that
+was misrouted into the regulated sink). Retrying will keep failing or pollute
+the audit store.
+
+Action:
+
+```bash
+php artisan swarm:audit:reconcile --dismiss=<id> --reason="dev-env test run; sink scope is prod only"
+```
+
+`--reason` is required. The dismissal emits a `command.audit_reconcile`
+audit record (with `action`, `target_id`, `target_category`,
+`target_run_id`, `prior_attempts`, and `reason`) **before** deleting the
+row. If that audit emit fails, the row is left untouched — dismissal cannot
+silently erase evidence.
+
+For regulated workloads, document the dismissal in your operations log
+alongside the audit chain-of-custody record. "Consult your compliance
+officer" applies for anything where you are not certain the row was
+legitimately undeliverable.
+
+#### Branch D — Unknown root cause
+
+Signal: `last_error` is opaque, the category is unusual, or you cannot yet
+distinguish A from B from C.
+
+Action: **do nothing destructive.** The default
+`dead_letter_retention_days=null` exists exactly for this case — rows wait
+for an operator. Open an incident ticket, escalate, and only requeue or
+dismiss once you can name which branch you are on.
+
+---
+
+## 2. Page received: stale pending rows
+
+You were paged by `swarm:health` (or `swarm:health --audit`) reporting
+staleness — pending rows whose `reserved_at` aged past 2× the relay
+reservation timeout. This usually means the relay is not running, not that
+the outbox is broken.
+
+### Step 1 — Confirm the relay schedule
+
+```bash
+php artisan schedule:list
+```
+
+Look for `swarm:relay` running at the configured cadence (every minute is
+the documented default). If it is not in the list, the schedule is
+missing — see [Maintenance § Audit outbox](maintenance.md#audit-outbox)
+for the schedule snippet.
+
+### Step 2 — Confirm queue workers are running
+
+The relay is a scheduled Artisan command, but downstream emission goes
+through the same queue plumbing your application uses. Check:
+
+- That the scheduler process itself is up (`php artisan schedule:work` /
+  systemd unit / cron entry).
+- That at least one worker is running for the queues durable and audit
+  work lands on.
+
+### Step 3 — Try a manual drain
+
+```bash
+php artisan swarm:audit:status                 # baseline counts
+php artisan swarm:relay --type=audit           # drain only the audit lane
+php artisan swarm:audit:status                 # confirm counts dropped
+```
+
+Expected: pending drops toward zero, `Replayed N audit record(s).` prints,
+and no new `dead_letter` rows appear.
+
+### Step 4 — Decide
+
+- **Manual drain works, scheduled drain does not** → the scheduler or
+  worker is the problem, not the outbox. Fix the scheduler, watch
+  `swarm:audit:status` recover on the next tick.
+- **Manual drain fails too** → look at the sink. Inspect application logs
+  for the `Log::error` line emitted at dead-letter transition (it includes
+  the row id and last error). Confirm the sink's queue connection,
+  credentials, and downstream dependency. From here you are usually in
+  Section 1, Branch B.
+
+---
+
+## 3. Sink is permanently broken
+
+The worst case: the sink dependency is down indefinitely (a SIEM is being
+migrated, an upstream archive bucket is offline for hours, a downstream
+auth provider is in an extended outage). The relay will keep retrying, then
+dead-letter, and you cannot fix the underlying sink right now.
+
+### Rules
+
+1. **Don't lose evidence.** Default `swarm.audit.failure_policy=queue` is
+   the right setting. Let evidence accumulate in `swarm_audit_outbox`.
+   That is what the table is for.
+2. **Don't switch to `swallow` or `dead_letter` to silence the alarm.**
+   `swallow` drops evidence permanently and silently. `dead_letter` skips
+   the retry loop entirely. Both are the wrong move for regulated callers
+   and they will not survive a post-incident review.
+3. **Acceptable temporary mitigation** — set
+   `SWARM_AUDIT_FAILURE_POLICY=log` **only if** your compliance posture
+   permits a documented gap, and **only** for the duration of the outage.
+   `log` keeps the run executing, writes the failure to the application
+   logger, and does not persist evidence. The gap **must** be documented
+   in your operations log with start time, scope, and authorizing party.
+4. **Do not raise the alarm thresholds.** A growing outbox is the signal.
+   Raising the threshold hides the problem.
+
+### Procedure
+
+1. Confirm the failure mode is the sink, not the outbox (Section 2).
+2. If accumulating evidence is acceptable, leave `failure_policy=queue`
+   and disable the noisy page on `swarm:audit:status` dead-letter growth
+   for the documented outage window only.
+3. When the sink is restored:
+
+   ```bash
+   php artisan swarm:relay --type=audit --drain-until-empty
+   php artisan swarm:audit:status
+   ```
+
+   Expect pending to drain to zero. Dead-letter rows from the outage
+   period need explicit requeue per Section 1 — they are not picked up by
+   the relay automatically.
+4. Restore `SWARM_AUDIT_FAILURE_POLICY=queue` if you changed it.
+
+---
+
+## 4. Retention decision tree
+
+`swarm.audit.outbox.dead_letter_retention_days`
+(`SWARM_AUDIT_OUTBOX_DEAD_LETTER_RETENTION_DAYS`) controls how long
+dead-letter rows survive `swarm:prune`. The audit-safe default is `null`
+(indefinite). Use this section to choose a setting per regulatory regime.
+
+**This is not legal advice.** Retention windows are a compliance officer
+decision; the entries below are starting points for that conversation, not
+substitutes for one.
+
+| Regime / context | Suggested starting point | Notes |
+|---|---|---|
+| FDA 21 CFR Part 11 (electronic records) | `null` (indefinite) until compliance signs off on a specific window | Part 11 retention is typically multi-year and tied to the underlying record's retention. The package default never deletes; that is the safest baseline. Consult your compliance officer. |
+| SOC 2 | Match your in-scope retention policy (commonly 7 years for financial-control-relevant evidence) | The exact number depends on what your SOC 2 description commits to. Confirm with your auditor before setting a window. |
+| HIPAA | Typically 6 years from creation or last effective date | The standard HIPAA documentation retention window. Consult your compliance officer; some states layer additional requirements. |
+| No regulatory regime | Opt-in pruning is fine | Pick a window that balances disk space against your incident-investigation horizon. 90 days is a common starting point. |
+
+Whatever you choose, set it explicitly and document it. A retention
+decision that lives only in someone's head will be forgotten by the next
+operator who reads this runbook.
+
+---
+
+## 5. Forensic reconstruction (forward marker for v0.7)
+
+`swarm:trace <run_id>` is planned for v0.7
+([#44](https://github.com/builtbyberry/laravel-swarm/issues/44)) and will
+walk the full audit chain for a single run in one command. Until then,
+manual reconstruction works as follows.
+
+For a given `run_id`:
+
+1. **Outbox (pending or dead-letter evidence for this run):**
+
+   ```sql
+   SELECT id, status, category, attempts, created_at, last_attempted_at
+   FROM swarm_audit_outbox
+   WHERE run_id = '<run_id>'
+   ORDER BY created_at;
+   ```
+
+   For payloads, use `swarm:audit:reconcile --show=<id>` per row — it
+   unseals the payload for you.
+
+2. **Live audit log (what made it to the sink):** query your bound
+   `SwarmAuditSink` target (your application's audit table, SIEM, or
+   archive) by `run_id`. Cross-reference categories between the outbox
+   and the live audit log to identify gaps.
+
+3. **Durable runtime state:** for durable runs, join against
+   `swarm_durable_runs` and `swarm_durable_run_state` on `run_id` for
+   the route plan, current node, and lease history. See
+   [Maintenance § High-volume dashboards](maintenance.md#high-volume-dashboards)
+   for the operational query contract.
+
+4. **Run history:** `swarm_run_histories` and its companion tables give
+   per-step input/output and final status. `php artisan swarm:status` and
+   `php artisan swarm:history` are the read-only entry points.
+
+When `swarm:trace` ships, this section will be replaced with the
+walkthrough.

--- a/docs/operator-runbook-audit-outbox.md
+++ b/docs/operator-runbook-audit-outbox.md
@@ -134,9 +134,12 @@ php artisan swarm:audit:reconcile --dismiss=<id> --reason="dev-env test run; sin
 
 `--reason` is required. The dismissal emits a `command.audit_reconcile`
 audit record (with `action`, `target_id`, `target_category`,
-`target_run_id`, `prior_attempts`, and `reason`) **before** deleting the
-row. If that audit emit fails, the row is left untouched — dismissal cannot
-silently erase evidence.
+`target_run_id`, `prior_attempts`, `reason`, and `target_payload_digest`)
+**before** deleting the row. If the audit emit fails outright (for example
+under `failure_policy=halt`), the row is left untouched. Under the default
+`queue` policy, the reconcile record is itself enqueued for retry —
+evidence is preserved in the outbox even when the sink is unavailable, so
+dismissal never silently erases evidence.
 
 For regulated workloads, document the dismissal in your operations log
 alongside the audit chain-of-custody record. "Consult your compliance

--- a/docs/pulse.md
+++ b/docs/pulse.md
@@ -59,9 +59,10 @@ Then add the swarm cards to `resources/views/vendor/pulse/dashboard.blade.php`:
 ```blade
 <livewire:swarm.runs cols="6" />
 <livewire:swarm.steps cols="6" />
+<livewire:swarm.audit-outbox cols="6" />
 ```
 
-`<livewire:swarm.runs />` shows per-swarm totals, failures, failure rate, average run duration, and topology mix. `<livewire:swarm.steps />` shows the slowest average swarm steps by agent.
+`<livewire:swarm.runs />` shows per-swarm totals, failures, failure rate, average run duration, and topology mix. `<livewire:swarm.steps />` shows the slowest average swarm steps by agent. `<livewire:swarm.audit-outbox />` surfaces the live operational state of the audit outbox.
 
 ## What Pulse Aggregates
 
@@ -102,9 +103,25 @@ The card shows up to 25 entries sorted by average duration descending — the sl
 
 The `SwarmStepDurations` recorder fires on `SwarmStepCompleted`.
 
+### swarm.audit-outbox card
+
+The `swarm.audit-outbox` card surfaces the live operational state of the v0.5 audit outbox — the same signal an operator would see by running `php artisan swarm:audit:status`. Unlike `swarm.runs` and `swarm.steps`, this card does not depend on a Pulse recorder; the outbox is low-volume operational state, so the card queries the `swarm_audit_outbox` table directly (via the `AuditOutbox` contract / configured table name).
+
+The card surfaces:
+
+- **Dead-letter count** — number of rows in `dead_letter` status. The card renders this prominently in red whenever the count is greater than zero.
+- **Pending count** — total rows in `pending` status, claimed or not.
+- **Stale-pending count** — pending rows with a `reserved_at` older than `2 × swarm.durable.relay.reservation_timeout_seconds`, matching the same heuristic that `swarm:audit:status` and `swarm:health` use to flag a relay that may not be running.
+- **Oldest pending age** and **oldest dead-letter age** — short, human-readable ages for the longest-waiting row in each status.
+- **Dead-letter retention** — the configured `swarm.audit.outbox.dead_letter_retention_days`, or `indefinite` when no retention is configured.
+
+When `swarm.persistence.driver` is not `database`, the `AuditOutbox` contract resolves to `NoOpAuditOutbox::isAvailable() === false` and the card renders a neutral "Audit outbox unavailable on cache persistence driver." state without touching the database.
+
+When the card raises an alarm signal, follow the in-card hint: run `php artisan swarm:audit:status` for the full breakdown (age distribution, top dead-letter categories, oldest IDs), and `php artisan swarm:audit:reconcile` to triage. See [Maintenance](maintenance.md) and [Audit Evidence Contract](audit-evidence-contract.md) for the full operator workflow.
+
 ### Period selectors
 
-Both cards inherit Pulse's standard period controls (1h, 24h, 7d). The period applies to all aggregates on the card simultaneously. Pulse stores bucketed time-series data, so switching periods reloads pre-aggregated buckets rather than scanning raw events.
+The `swarm.runs` and `swarm.steps` cards inherit Pulse's standard period controls (1h, 24h, 7d). The period applies to all aggregates on the card simultaneously. Pulse stores bucketed time-series data, so switching periods reloads pre-aggregated buckets rather than scanning raw events. The `swarm.audit-outbox` card reflects live operational state — period selectors do not apply because the underlying counts are point-in-time queries against the outbox table.
 
 ## Relationship to Telemetry
 

--- a/examples/durable-compliance-review/README.md
+++ b/examples/durable-compliance-review/README.md
@@ -54,6 +54,403 @@ emit unsigned evidence or complete a run whose audit trail was discarded.
 See `docs/audit-evidence-contract.md` (Sink Failure Handler) for the full
 contract and custom `SinkFailureHandler` patterns.
 
+## v0.5 Audit Chain Walkthrough
+
+`halt` is still the right setting when you absolutely cannot let a run continue
+without proof of evidence emission. But most regulated workloads now want the
+**default** v0.5 policy, `queue`, which keeps the run moving while persisting
+the failed evidence record to `swarm_audit_outbox` for retry. The package then
+ships with `swarm:audit:status`, `swarm:audit:reconcile`, and the existing
+`swarm:relay --type=audit` lane so operators have a complete forensic loop.
+
+This section walks through that loop end-to-end against a simulated downstream
+sink outage. Everything below is **copy-pasteable** into a Tinker session
+against a database-backed install once you have a sink bound and migrations
+run.
+
+### Baseline Configuration
+
+For a regulated compliance review with the v0.5 default chain, your `.env`
+should look like:
+
+```bash
+SWARM_PERSISTENCE_DRIVER=database
+SWARM_CAPTURE_ACTIVE_CONTEXT=true
+
+# v0.5 defaults — listed explicitly so operators see them in one place
+SWARM_AUDIT_FAILURE_POLICY=queue
+SWARM_ENCRYPT_AT_REST=true
+SWARM_AUDIT_ACTOR_REQUIRED=true
+
+# Audit outbox tuning — keep the retention window inside your compliance
+# review SLA (90 days is a common Part 11-style starting point).
+SWARM_AUDIT_OUTBOX_MAX_ATTEMPTS=5
+SWARM_AUDIT_OUTBOX_DEAD_LETTER_RETENTION_DAYS=90
+```
+
+`failure_policy=queue` is the v0.5 default; `encrypt_at_rest=true` is the
+default on database persistence. They are listed here so the configuration
+surface for regulated callers is visible in one place.
+
+You also need a bound `SwarmAuditSink` (the no-op default does not emit
+anywhere) and a bound `SwarmAuditSigner` so emitted records carry a signature
+under your current key.
+
+### Bind The Sink And Signer
+
+```php
+// app/Providers/AppServiceProvider.php
+namespace App\Providers;
+
+use App\Audit\HmacAuditSigner;
+use App\Audit\HttpAuditSink;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSigner;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
+use Illuminate\Support\ServiceProvider;
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->bind(SwarmAuditSink::class, HttpAuditSink::class);
+
+        $this->app->singleton(
+            SwarmAuditSigner::class,
+            fn () => new HmacAuditSigner(config('audit.hmac_secret')),
+        );
+    }
+}
+```
+
+`HttpAuditSink` is your application's real sink — typically a thin wrapper that
+ships the payload to a SIEM, append-only object store, or signed log service.
+The signer pattern lives in
+[`privacy-capture/README.md`](../privacy-capture/README.md#sign-audit-evidence).
+
+### Simulated Sink Outage
+
+To demonstrate the recovery loop you can substitute a **test-only sink** that
+throws on its first N emit attempts, then succeeds. The package's test suite
+uses `tests/Fixtures/CountingThrowingSink.php` for the same purpose. Examples
+cannot import test fixtures, so define an example-side equivalent:
+
+```php
+// app/Audit/RecoveringSinkDemo.php
+namespace App\Audit;
+
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+
+/**
+ * WHY: This sink exists ONLY to demonstrate the v0.5 audit-outbox recovery
+ * loop. It is not a real sink. It deterministically fails its first N emit
+ * attempts and then begins succeeding — which is exactly the shape of a
+ * downstream incident (a few queued retries, then a recovered sink).
+ *
+ * In a real deployment, your bound sink should be backed by an actual
+ * append-only store; bind THIS class only inside a Tinker session, a feature
+ * test, or a dedicated demo environment.
+ */
+final class RecoveringSinkDemo implements SwarmAuditSink
+{
+    public int $attempts = 0;
+
+    public function __construct(private readonly int $failFirstN = 3) {}
+
+    public function emit(string $category, array $payload): void
+    {
+        $this->attempts++;
+
+        if ($this->attempts <= $this->failFirstN) {
+            Log::warning("RecoveringSinkDemo: simulated failure #{$this->attempts} for {$category}");
+            throw new RuntimeException("simulated sink outage #{$this->attempts}");
+        }
+
+        // After the simulated outage, succeed silently. A real sink would
+        // ship the payload here.
+    }
+}
+```
+
+Bind it in a Tinker session for the duration of the walkthrough:
+
+```php
+use App\Audit\RecoveringSinkDemo;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
+
+app()->singleton(SwarmAuditSink::class, fn () => new RecoveringSinkDemo(failFirstN: 3));
+```
+
+Now dispatch the compliance review:
+
+```php
+use App\Ai\Swarms\ComplianceReviewSwarm;
+use Illuminate\Support\Facades\Context;
+
+Context::add('swarm:actor', auth()->user()); // satisfies actor.required=true
+
+ComplianceReviewSwarm::make()->dispatchDurable([
+    'document_id' => 1234,
+    'document_type' => 'vendor contract',
+    'jurisdiction' => 'US',
+    'review_goal' => 'identify renewal and termination risk',
+]);
+```
+
+The run advances normally — `failure_policy=queue` means audit-sink failures
+**do not halt the swarm**. They land in `swarm_audit_outbox` instead.
+
+### Step 1 — Rows Accumulating During The Outage
+
+After a few lifecycle events have tried to emit (`run.started`,
+`step.completed`, etc.) and the sink has refused them, the outbox starts
+filling up. `swarm:audit:status` is your one-shot summary:
+
+```bash
+php artisan swarm:audit:status
+```
+
+```
+  INFO  Audit outbox summary.
+
+  ----------------------- -------
+   Status                  Count
+  ----------------------- -------
+   pending (unclaimed)     3
+   reserved                0
+     stale (> 120s)        0
+   dead_letter             0
+  ----------------------- -------
+
+  INFO  Age distribution.
+
+  ------------- ------ ------- ------ ------
+   Status        < 1h   1-24h   1-7d   > 7d
+  ------------- ------ ------- ------ ------
+   pending       3      0       0      0
+   dead_letter   0      0       0      0
+  ------------- ------ ------- ------ ------
+
+  INFO  Top dead-letter categories.
+
+  • no dead-letter rows
+
+  INFO  Oldest rows.
+
+  ------------- ----- -----
+   Status        ID    Age
+  ------------- ----- -----
+   pending       12    42s
+   dead_letter   n/a   n/a
+  ------------- ----- -----
+
+  INFO  Retention.
+
+  • dead_letter_retention_days: 90
+  • next-prune count: 0
+```
+
+`swarm:health --audit` raises the same signal in a format suited to a
+healthcheck endpoint or alerting integration:
+
+```bash
+php artisan swarm:health --audit
+```
+
+```
+  -------------------------- ---------- ------- --------- ------------------------------------
+   Component                  Driver     Store   Status    Details
+  -------------------------- ---------- ------- --------- ------------------------------------
+   Audit outbox staleness     database   n/a     ok        3 pending row(s), relay appears active
+   Audit outbox dead-letter   database   n/a     ok        0 dead-letter row(s)
+  -------------------------- ---------- ------- --------- ------------------------------------
+```
+
+If `swarm:relay` is not scheduled (or has stopped running for some reason),
+the staleness check escalates to `warning` after 2× the reservation timeout.
+For Part 11 / regulated callers, treat any staleness warning as page-worthy:
+it means evidence is queued but not draining.
+
+### Step 2 — Recovery Via The Relay
+
+The scheduled `swarm:relay` runs every minute by default. To trigger it
+immediately in the walkthrough:
+
+```bash
+php artisan swarm:relay --type=audit --drain-until-empty
+```
+
+```
+  INFO  Replayed 3 audit records.
+```
+
+The relay calls `RecoveringSinkDemo::emit()` for each pending row. With
+`failFirstN=3` already exhausted by the original synchronous attempts, every
+replay call now succeeds and the rows are deleted from `swarm_audit_outbox`.
+A follow-up `swarm:audit:status` shows an empty outbox.
+
+The `command.relay` audit record itself is emitted at the end of the run with
+`audit_replayed_count`, `audit_dead_lettered_count`, and a `status` field so
+you can audit the recovery action.
+
+### Step 3 — Dead-Letter Triage
+
+To demonstrate the dead-letter path, raise the failure window past
+`max_attempts`. With `SWARM_AUDIT_OUTBOX_MAX_ATTEMPTS=5`, a sink that fails
+six times will push at least one row into `dead_letter` status:
+
+```php
+app()->singleton(SwarmAuditSink::class, fn () => new RecoveringSinkDemo(failFirstN: 999));
+```
+
+Dispatch a run, then drain repeatedly (or wait for the scheduled relay to run
+through five attempts on the same row over its reservation-timeout cycles).
+After the row exceeds `max_attempts`:
+
+```bash
+php artisan swarm:audit:status
+```
+
+```
+  INFO  Audit outbox summary.
+
+  ----------------------- -------
+   Status                  Count
+  ----------------------- -------
+   pending (unclaimed)     0
+   reserved                0
+     stale (> 120s)        0
+   dead_letter             1
+  ----------------------- -------
+
+  INFO  Top dead-letter categories.
+
+  ------------- -------
+   Category      Count
+  ------------- -------
+   run.started   1
+  ------------- -------
+
+  INFO  Oldest rows.
+
+  ------------- ----- ------
+   Status        ID    Age
+  ------------- ----- ------
+   pending       n/a   n/a
+   dead_letter   18    4m
+  ------------- ----- ------
+```
+
+`swarm:health --audit` now warns:
+
+```
+  -------------------------- ---------- ------- ---------- -----------------------------------------------------------------
+   Component                  Driver     Store   Status     Details
+  -------------------------- ---------- ------- ---------- -----------------------------------------------------------------
+   Audit outbox staleness     database   n/a     ok         no pending rows
+   Audit outbox dead-letter   database   n/a     warning    1 dead-letter row(s) — undelivered audit evidence requires operator reconciliation
+  -------------------------- ---------- ------- ---------- -----------------------------------------------------------------
+```
+
+Inspect the row. `--show` unseals the payload from `swarm_audit_outbox`,
+which is normally encrypted at rest, and prints it for human review:
+
+```bash
+php artisan swarm:audit:reconcile --show=18
+```
+
+```
+  -------------- -------------------------------------
+   Field          Value
+  -------------- -------------------------------------
+   ID             18
+   Status         dead_letter
+   Category       run.started
+   Run ID         r-019035fa-b1d2-7c8a-...
+   Attempts       5
+   Created        2026-05-19T14:02:11+00:00
+   Updated        2026-05-19T14:06:48+00:00
+   Last attempted 2026-05-19T14:06:48+00:00
+   Reserved       -
+  -------------- -------------------------------------
+
+  INFO  Last error.
+
+  simulated sink outage #5
+
+  INFO  Payload.
+
+  {
+      "schema_version": "2",
+      "category": "run.started",
+      "occurred_at": "2026-05-19T14:02:11+00:00",
+      "run_id": "r-019035fa-b1d2-7c8a-...",
+      "swarm_class": "App\\Ai\\Swarms\\ComplianceReviewSwarm",
+      "topology": "sequential",
+      "execution_mode": "durable",
+      "actor": {
+          "type": "user",
+          "id": "u-42",
+          "name": "Daniel Berry"
+      },
+      "signature": "...",
+      "signature_algorithm": "HMAC-SHA256",
+      "signed_at": "2026-05-19T14:02:11+00:00"
+   }
+```
+
+Operators now have two choices, both backed by a forced `command.audit_reconcile`
+audit record that is emitted **before** the row is mutated. If that audit emit
+fails, the dead-letter row is left untouched, so reconciliation cannot silently
+erase evidence.
+
+**Requeue** — the downstream sink is restored and you want the relay to
+re-attempt emission. `attempts` is zeroed; `last_error` is preserved as
+forensic context:
+
+```bash
+php artisan swarm:audit:reconcile --requeue=18 --reason="downstream sink restored after vendor outage 2026-05-19"
+```
+
+```
+ Requeue audit outbox row [18] (category=run.started, attempts=5)? (yes/no) [no]:
+ > yes
+
+  INFO  Audit outbox row [18] requeued. Status=pending, attempts=0. last_error preserved for forensics.
+```
+
+**Dismiss** — the record is a verified duplicate, was emitted out-of-band, or
+otherwise cannot be delivered. `--reason` is required:
+
+```bash
+php artisan swarm:audit:reconcile --dismiss=18 --reason="duplicate of run.failed emitted manually via vendor support ticket SUP-4419"
+```
+
+```
+ Permanently delete audit outbox row [18] (category=run.started, run_id=r-019035fa-...)? (yes/no) [no]:
+ > yes
+
+  INFO  Audit outbox row [18] dismissed. A command.audit_reconcile evidence record preserves the deletion.
+```
+
+For scripted recovery (for example, a runbook automation), pass `--force` to
+skip the confirmation prompt. Both sub-modes accept `--json` for machine
+parsing.
+
+### Forward Reference: Operator Runbook
+
+This section is a **demonstration**, not a full runbook. The end-to-end
+operator decision tree for audit-outbox triage — incident playbooks, on-call
+escalation, retention-policy alignment, and chain-of-custody templates — lives
+in [`docs/operator-runbook-audit-outbox.md`](../../docs/operator-runbook-audit-outbox.md)
+(GitHub issue #45).
+
+See also:
+
+- [`docs/audit-evidence-contract.md`](../../docs/audit-evidence-contract.md) — frozen audit evidence and outbox contract.
+- [`docs/maintenance.md`](../../docs/maintenance.md) — `Audit outbox` and `Forensic triage` operations sections.
+
 ## What Durable Changes
 
 `queue()` runs one queued job for the whole swarm. `dispatchDurable()` runs one

--- a/examples/privacy-capture/README.md
+++ b/examples/privacy-capture/README.md
@@ -166,3 +166,96 @@ class HmacAuditSigner implements SwarmAuditSigner
 Implementations must not mutate or remove existing keys. See
 `docs/audit-evidence-contract.md` for the full envelope contract, signing
 scope guidance, and chain-signing patterns.
+
+## v0.5 Audit Chain For Redacted Evidence
+
+Privacy-sensitive workflows lean harder on the v0.5 audit chain than
+non-regulated callers do. With redaction enabled, the audit evidence emitted
+for each run is the **only** durable record of what happened — there is no raw
+prompt or output to fall back on. So the behavior of the bound `SwarmAuditSink`
+under failure becomes a privacy and compliance question, not just an operations
+one.
+
+In v0.5, `SWARM_AUDIT_FAILURE_POLICY` **defaults to `queue`**. That means:
+
+- A sink that throws no longer silently drops the redacted evidence record.
+- Instead, the failed record is persisted to the `swarm_audit_outbox` table
+  for retry via `swarm:relay --type=audit`.
+- When `swarm.persistence.encrypt_at_rest=true` (also the default on database
+  persistence), the persisted `payload` and `last_error` columns are sealed
+  with `SwarmPersistenceCipher` — the same encrypter-backed sealing used
+  elsewhere in the package, scoped to `APP_KEY`.
+
+For a privacy-capture deployment the recommended baseline is:
+
+```bash
+SWARM_PERSISTENCE_DRIVER=database
+SWARM_CAPTURE_INPUTS=false
+SWARM_CAPTURE_OUTPUTS=false
+
+# v0.5 defaults — listed explicitly for the audit chain
+SWARM_AUDIT_FAILURE_POLICY=queue
+SWARM_ENCRYPT_AT_REST=true
+SWARM_AUDIT_OUTBOX_DEAD_LETTER_RETENTION_DAYS=90
+```
+
+### Inspecting Redacted Payloads In The Outbox
+
+When a sink failure persists a record, the redacted shape is preserved. Input
+and output values are still `[redacted]`; the categories, run identifiers, and
+metadata stay queryable for triage:
+
+```bash
+php artisan swarm:audit:status
+```
+
+```
+  INFO  Audit outbox summary.
+
+  ----------------------- -------
+   Status                  Count
+  ----------------------- -------
+   pending (unclaimed)     2
+   reserved                0
+     stale (> 120s)        0
+   dead_letter             0
+  ----------------------- -------
+
+  INFO  Top dead-letter categories.
+
+  • no dead-letter rows
+```
+
+The summary tells operators **how much** redacted evidence is queued and
+**where it is in the lifecycle**, without exposing the payloads themselves —
+which is exactly the layer of indirection privacy-sensitive workloads want
+between routine monitoring and forensic inspection.
+
+### A Privacy Note On `swarm:audit:reconcile --show`
+
+`swarm:audit:reconcile --show=<id>` **unseals** the encrypted-at-rest payload
+and prints it to the terminal for human review:
+
+```bash
+php artisan swarm:audit:reconcile --show=42
+```
+
+In a privacy-capture deployment this command performs a **privileged
+re-disclosure**. The payload itself is already redacted at the field level, so
+input and output values remain `[redacted]`, but metadata, actor identity, and
+correlation IDs become visible. Treat access to `swarm:audit:reconcile --show`
+the same way you treat access to your application's audit-log viewer — log
+the operator who ran it, restrict it to the on-call audit reviewer role, and
+gate it behind your standard privileged-command controls.
+
+`swarm:audit:reconcile --requeue` and `--dismiss` are themselves audited: each
+sub-mode emits a `command.audit_reconcile` evidence record **before** the
+outbox row is mutated. If the audit emit fails the row is left untouched, so
+reconciliation can never silently erase redacted evidence.
+
+For the full forensic loop — including the simulated sink-outage walkthrough,
+recovery via the relay, and dead-letter triage — see
+[`durable-compliance-review/README.md`](../durable-compliance-review/README.md#v05-audit-chain-walkthrough).
+The operator decision tree for audit-outbox triage lives in
+[`docs/operator-runbook-audit-outbox.md`](../../docs/operator-runbook-audit-outbox.md)
+(GitHub issue #45).

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,3 +19,4 @@ parameters:
                 - src/Persistence/DatabaseRunHistoryStore.php
                 - src/Persistence/DatabaseContextStore.php
                 - src/Pulse/Livewire/SwarmSteps.php
+                - src/Commands/SwarmAuditReconcileCommand.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,4 +19,3 @@ parameters:
                 - src/Persistence/DatabaseRunHistoryStore.php
                 - src/Persistence/DatabaseContextStore.php
                 - src/Pulse/Livewire/SwarmSteps.php
-                - src/Commands/SwarmAuditReconcileCommand.php

--- a/resources/views/pulse/livewire/audit-outbox.blade.php
+++ b/resources/views/pulse/livewire/audit-outbox.blade.php
@@ -1,0 +1,96 @@
+<x-pulse::card :cols="$cols" :rows="$rows" :class="$class">
+    <x-pulse::card-header
+        name="Swarm Audit Outbox"
+        details="live operational state"
+    >
+        <x-slot:icon>
+            <x-pulse::icons.clipboard />
+        </x-slot:icon>
+    </x-pulse::card-header>
+
+    <x-pulse::scroll :expand="$expand" wire:poll.10s="">
+        @if (! $available)
+            <div class="p-4 text-sm text-gray-500 dark:text-gray-400">
+                Audit outbox unavailable on cache persistence driver.
+                <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                    Switch <code>swarm.persistence.driver</code> to <code>database</code> and run the package migrations to enable it.
+                </p>
+            </div>
+        @else
+            <div class="grid grid-cols-3 gap-3 p-4">
+                <div class="rounded-md p-3 {{ $snapshot->deadLetter > 0 ? 'bg-red-50 dark:bg-red-900/30 ring-1 ring-red-500/40' : 'bg-gray-50 dark:bg-gray-800' }}">
+                    <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Dead-letter</p>
+                    <p class="mt-1 text-2xl font-bold {{ $snapshot->deadLetter > 0 ? 'text-red-700 dark:text-red-300' : 'text-gray-700 dark:text-gray-200' }}">
+                        {{ number_format($snapshot->deadLetter) }}
+                    </p>
+                    @if ($snapshot->deadLetter > 0)
+                        <span class="inline-flex items-center gap-1 mt-1 rounded-full bg-red-100 dark:bg-red-900/60 px-2 py-0.5 text-xs font-medium text-red-700 dark:text-red-200">
+                            attention
+                        </span>
+                    @endif
+                </div>
+
+                <div class="rounded-md p-3 bg-gray-50 dark:bg-gray-800">
+                    <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Pending</p>
+                    <p class="mt-1 text-2xl font-bold text-gray-700 dark:text-gray-200">
+                        {{ number_format($snapshot->pending) }}
+                    </p>
+                </div>
+
+                <div class="rounded-md p-3 {{ $snapshot->stalePending > 0 ? 'bg-amber-50 dark:bg-amber-900/30 ring-1 ring-amber-500/40' : 'bg-gray-50 dark:bg-gray-800' }}">
+                    <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                        Stale pending
+                        <span class="text-[10px] normal-case text-gray-400 dark:text-gray-500">
+                            (&gt; {{ $snapshot->staleWindowSeconds }}s)
+                        </span>
+                    </p>
+                    <p class="mt-1 text-2xl font-bold {{ $snapshot->stalePending > 0 ? 'text-amber-700 dark:text-amber-300' : 'text-gray-700 dark:text-gray-200' }}">
+                        {{ number_format($snapshot->stalePending) }}
+                    </p>
+                    @if ($snapshot->stalePending > 0)
+                        <p class="mt-1 text-xs text-amber-700 dark:text-amber-300">
+                            relay may not be running
+                        </p>
+                    @endif
+                </div>
+            </div>
+
+            <x-pulse::table>
+                <colgroup>
+                    <col width="100%" />
+                    <col width="0%" />
+                </colgroup>
+                <x-pulse::thead>
+                    <tr>
+                        <x-pulse::th>Metric</x-pulse::th>
+                        <x-pulse::th class="text-right">Value</x-pulse::th>
+                    </tr>
+                </x-pulse::thead>
+                <tbody>
+                    <tr>
+                        <x-pulse::td class="text-gray-700 dark:text-gray-300">Oldest pending age</x-pulse::td>
+                        <x-pulse::td numeric class="text-gray-700 dark:text-gray-300">
+                            {{ $snapshot->oldestPendingAge ?? 'n/a' }}
+                        </x-pulse::td>
+                    </tr>
+                    <tr>
+                        <x-pulse::td class="text-gray-700 dark:text-gray-300">Oldest dead-letter age</x-pulse::td>
+                        <x-pulse::td numeric class="text-gray-700 dark:text-gray-300">
+                            {{ $snapshot->oldestDeadLetterAge ?? 'n/a' }}
+                        </x-pulse::td>
+                    </tr>
+                    <tr>
+                        <x-pulse::td class="text-gray-700 dark:text-gray-300">Dead-letter retention</x-pulse::td>
+                        <x-pulse::td numeric class="text-gray-700 dark:text-gray-300">
+                            {{ $snapshot->retentionDays === null ? 'indefinite' : $snapshot->retentionDays.' days' }}
+                        </x-pulse::td>
+                    </tr>
+                </tbody>
+            </x-pulse::table>
+
+            <div class="p-4 text-xs text-gray-500 dark:text-gray-400 border-t border-gray-100 dark:border-gray-800">
+                Run <code>php artisan swarm:audit:status</code> for detail, <code>swarm:audit:reconcile</code> to triage.
+            </div>
+        @endif
+    </x-pulse::scroll>
+</x-pulse::card>

--- a/src/Commands/SwarmAuditReconcileCommand.php
+++ b/src/Commands/SwarmAuditReconcileCommand.php
@@ -131,7 +131,7 @@ class SwarmAuditReconcileCommand extends Command
         $rows = $rows->take($limit);
 
         $now = Carbon::now('UTC');
-        $records = $rows->map(fn (object $row): array => [
+        $records = $rows->map(fn (\stdClass $row): array => [
             'id' => (int) $row->id,
             'status' => (string) $row->status,
             'category' => (string) $row->category,
@@ -357,7 +357,7 @@ class SwarmAuditReconcileCommand extends Command
         return self::SUCCESS;
     }
 
-    protected function emitReconcileAudit(SwarmAuditDispatcher $audit, string $action, object $row, int $priorAttempts, ?string $reason): bool
+    protected function emitReconcileAudit(SwarmAuditDispatcher $audit, string $action, \stdClass $row, int $priorAttempts, ?string $reason): bool
     {
         $this->reconcileAuditError = null;
 
@@ -420,17 +420,17 @@ class SwarmAuditReconcileCommand extends Command
         return self::FAILURE;
     }
 
-    protected function findRow(ConfigRepository $config, Connection $connection, int $id): ?object
+    protected function findRow(ConfigRepository $config, Connection $connection, int $id): ?\stdClass
     {
         $row = $connection->table($this->tableName($config))->where('id', $id)->first();
 
-        return is_object($row) ? $row : null;
+        return $row instanceof \stdClass ? $row : null;
     }
 
     /**
      * @return array<string, mixed>|string|null
      */
-    protected function decodePayload(SwarmPersistenceCipher $cipher, object $row): array|string|null
+    protected function decodePayload(SwarmPersistenceCipher $cipher, \stdClass $row): array|string|null
     {
         $raw = is_string($row->payload) ? $cipher->open($row->payload) : null;
 
@@ -447,7 +447,7 @@ class SwarmAuditReconcileCommand extends Command
         return is_array($decoded) ? $decoded : $raw;
     }
 
-    protected function decodeLastError(SwarmPersistenceCipher $cipher, object $row): ?string
+    protected function decodeLastError(SwarmPersistenceCipher $cipher, \stdClass $row): ?string
     {
         if (! is_string($row->last_error) || $row->last_error === '') {
             return null;

--- a/src/Commands/SwarmAuditReconcileCommand.php
+++ b/src/Commands/SwarmAuditReconcileCommand.php
@@ -1,0 +1,519 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Commands;
+
+use BuiltByBerry\LaravelSwarm\Audit\Actor;
+use BuiltByBerry\LaravelSwarm\Audit\SwarmAuditDispatcher;
+use BuiltByBerry\LaravelSwarm\Commands\Concerns\ResolvesStringConsoleInput;
+use BuiltByBerry\LaravelSwarm\Contracts\AuditOutbox;
+use BuiltByBerry\LaravelSwarm\Persistence\SwarmPersistenceCipher;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Database\Connection;
+use Illuminate\Support\Carbon;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Throwable;
+
+#[AsCommand(name: 'swarm:audit:reconcile')]
+class SwarmAuditReconcileCommand extends Command
+{
+    use ResolvesStringConsoleInput;
+
+    protected $signature = 'swarm:audit:reconcile
+                            {--show= : Print full metadata and unsealed payload for the given outbox id.}
+                            {--requeue= : Reset a dead_letter row to pending so the relay re-attempts emission.}
+                            {--dismiss= : Permanently delete a dead_letter row (requires --reason).}
+                            {--status= : Filter the list view by status (pending or dead_letter).}
+                            {--limit=50 : Cap the list view row count.}
+                            {--reason= : Operator-supplied reason recorded on the command.audit_reconcile audit record. Required for --dismiss.}
+                            {--force : Skip the interactive confirmation prompt.}
+                            {--json : Emit machine-readable output (works for list, show, requeue, dismiss).}';
+
+    protected $description = 'Forensic triage for the swarm audit outbox (list, inspect, requeue, dismiss dead-letter rows)';
+
+    protected $help = <<<'HELP'
+        Operator command for the swarm_audit_outbox table. Sub-modes are mutually
+        exclusive:
+
+          (no flags)         List pending and dead_letter rows.
+          --show=<id>        Print full row metadata and unsealed payload.
+          --requeue=<id>     Reset a dead_letter row to pending (relay re-attempts).
+          --dismiss=<id>     Permanently delete a dead_letter row. Requires --reason.
+
+        Pending rows can be listed and shown but cannot be requeued or dismissed;
+        the relay owns their lifecycle.
+
+        Every requeue/dismiss emits a command.audit_reconcile audit record before
+        mutating the row. If the audit emit fails, the row is left untouched.
+
+        Examples:
+          php artisan swarm:audit:reconcile
+          php artisan swarm:audit:reconcile --status=dead_letter --limit=200
+          php artisan swarm:audit:reconcile --show=42
+          php artisan swarm:audit:reconcile --requeue=42 --reason="downstream sink restored"
+          php artisan swarm:audit:reconcile --dismiss=42 --reason="duplicate of run.failed for r-7" --force
+        HELP;
+
+    public function handle(
+        AuditOutbox $outbox,
+        ConfigRepository $config,
+        Connection $connection,
+        SwarmPersistenceCipher $cipher,
+        SwarmAuditDispatcher $audit,
+    ): int {
+        if (! $outbox->isAvailable()) {
+            $message = 'swarm:audit:reconcile requires the database-backed audit outbox. Set swarm.persistence.driver=database and run the package migrations.';
+
+            if ($this->option('json') === true) {
+                $this->writeJson(['ok' => false, 'error' => $message]);
+            } else {
+                $this->components->error($message);
+            }
+
+            return self::FAILURE;
+        }
+
+        $modes = array_filter([
+            'show' => $this->optionalOptionString('show'),
+            'requeue' => $this->optionalOptionString('requeue'),
+            'dismiss' => $this->optionalOptionString('dismiss'),
+        ], static fn (?string $v): bool => $v !== null && $v !== '');
+
+        if (count($modes) > 1) {
+            return $this->failWith('Use only one of --show, --requeue, --dismiss per invocation.');
+        }
+
+        if ($modes === []) {
+            return $this->runList($config, $connection);
+        }
+
+        $mode = array_key_first($modes);
+        $id = $this->resolveId($modes[$mode], $mode);
+
+        if ($id === null) {
+            return self::FAILURE;
+        }
+
+        return match ($mode) {
+            'show' => $this->runShow($config, $connection, $cipher, $id),
+            'requeue' => $this->runRequeue($config, $connection, $audit, $id),
+            'dismiss' => $this->runDismiss($config, $connection, $audit, $id),
+            default => self::FAILURE,
+        };
+    }
+
+    protected function runList(ConfigRepository $config, Connection $connection): int
+    {
+        $statusFilter = $this->optionalOptionString('status');
+
+        if ($statusFilter !== null && ! in_array($statusFilter, ['pending', 'dead_letter'], true)) {
+            return $this->failWith('Unknown --status value. Use "pending" or "dead_letter".');
+        }
+
+        $limit = $this->optionInt('limit', 50);
+        $limit = max(1, min($limit, 10_000));
+
+        $table = $this->tableName($config);
+        $query = $connection->table($table);
+
+        if ($statusFilter !== null) {
+            $query->where('status', $statusFilter);
+        } else {
+            $query->whereIn('status', ['pending', 'dead_letter']);
+        }
+
+        $rows = $query->orderBy('id')->limit($limit + 1)->get();
+        $truncated = $rows->count() > $limit;
+        $rows = $rows->take($limit);
+
+        $now = Carbon::now('UTC');
+        $records = $rows->map(fn (object $row): array => [
+            'id' => (int) $row->id,
+            'status' => (string) $row->status,
+            'category' => (string) $row->category,
+            'run_id' => $row->run_id !== null ? (string) $row->run_id : null,
+            'attempts' => (int) $row->attempts,
+            'last_attempted_at' => $this->formatTimestamp($row->last_attempted_at),
+            'age' => $this->ageHuman($row->created_at, $now),
+        ])->all();
+
+        if ($this->option('json') === true) {
+            $this->writeJson([
+                'ok' => true,
+                'count' => count($records),
+                'truncated' => $truncated,
+                'limit' => $limit,
+                'status_filter' => $statusFilter,
+                'rows' => $records,
+            ]);
+
+            return self::SUCCESS;
+        }
+
+        if ($records === []) {
+            $this->components->info('No audit outbox rows match.');
+
+            return self::SUCCESS;
+        }
+
+        $this->table(
+            ['ID', 'Status', 'Category', 'Run ID', 'Attempts', 'Last attempted', 'Age'],
+            array_map(fn (array $r): array => [
+                (string) $r['id'],
+                $r['status'],
+                $r['category'],
+                $r['run_id'] ?? '-',
+                (string) $r['attempts'],
+                $r['last_attempted_at'] ?? '-',
+                $r['age'],
+            ], $records),
+        );
+
+        if ($truncated) {
+            $this->components->warn("Output capped at {$limit} rows. Filter with --status or raise --limit.");
+        }
+
+        return self::SUCCESS;
+    }
+
+    protected function runShow(ConfigRepository $config, Connection $connection, SwarmPersistenceCipher $cipher, int $id): int
+    {
+        $row = $this->findRow($config, $connection, $id);
+
+        if ($row === null) {
+            return $this->failWith("Audit outbox row [{$id}] not found.");
+        }
+
+        $payload = $this->decodePayload($cipher, $row);
+        $lastError = $this->decodeLastError($cipher, $row);
+
+        $detail = [
+            'id' => (int) $row->id,
+            'status' => (string) $row->status,
+            'category' => (string) $row->category,
+            'run_id' => $row->run_id !== null ? (string) $row->run_id : null,
+            'attempts' => (int) $row->attempts,
+            'created_at' => $this->formatTimestamp($row->created_at),
+            'updated_at' => $this->formatTimestamp($row->updated_at),
+            'last_attempted_at' => $this->formatTimestamp($row->last_attempted_at),
+            'reserved_at' => $this->formatTimestamp($row->reserved_at),
+            'last_error' => $lastError,
+            'payload' => $payload,
+        ];
+
+        if ($this->option('json') === true) {
+            $this->writeJson(['ok' => true, 'row' => $detail]);
+
+            return self::SUCCESS;
+        }
+
+        $this->table(['Field', 'Value'], [
+            ['ID', (string) $detail['id']],
+            ['Status', $detail['status']],
+            ['Category', $detail['category']],
+            ['Run ID', $detail['run_id'] ?? '-'],
+            ['Attempts', (string) $detail['attempts']],
+            ['Created', $detail['created_at'] ?? '-'],
+            ['Updated', $detail['updated_at'] ?? '-'],
+            ['Last attempted', $detail['last_attempted_at'] ?? '-'],
+            ['Reserved', $detail['reserved_at'] ?? '-'],
+        ]);
+
+        $this->line('');
+        $this->components->info('Last error');
+        $this->line($lastError ?? '-');
+
+        $this->line('');
+        $this->components->info('Payload');
+        $this->line($this->prettyJson($payload));
+
+        return self::SUCCESS;
+    }
+
+    protected function runRequeue(ConfigRepository $config, Connection $connection, SwarmAuditDispatcher $audit, int $id): int
+    {
+        $row = $this->findRow($config, $connection, $id);
+
+        if ($row === null) {
+            return $this->failWith("Audit outbox row [{$id}] not found.");
+        }
+
+        if ((string) $row->status !== 'dead_letter') {
+            return $this->failWith("Audit outbox row [{$id}] has status [{$row->status}]; only dead_letter rows can be requeued. Pending rows are owned by the relay.");
+        }
+
+        $reason = $this->optionalOptionString('reason');
+
+        if (! $this->confirmAction("Requeue audit outbox row [{$id}] (category={$row->category}, attempts={$row->attempts})?")) {
+            return $this->aborted();
+        }
+
+        $priorAttempts = (int) $row->attempts;
+
+        if (! $this->emitReconcileAudit($audit, 'requeue', $row, $priorAttempts, $reason)) {
+            return self::FAILURE;
+        }
+
+        $connection->table($this->tableName($config))
+            ->where('id', $id)
+            ->update([
+                'status' => 'pending',
+                'attempts' => 0,
+                'reserved_at' => null,
+                'updated_at' => Carbon::now('UTC'),
+            ]);
+
+        if ($this->option('json') === true) {
+            $this->writeJson([
+                'ok' => true,
+                'action' => 'requeue',
+                'id' => $id,
+                'prior_attempts' => $priorAttempts,
+                'reason' => $reason,
+            ]);
+
+            return self::SUCCESS;
+        }
+
+        $this->components->info("Audit outbox row [{$id}] requeued. Status=pending, attempts=0. last_error preserved for forensics.");
+
+        return self::SUCCESS;
+    }
+
+    protected function runDismiss(ConfigRepository $config, Connection $connection, SwarmAuditDispatcher $audit, int $id): int
+    {
+        $reason = $this->optionalOptionString('reason');
+
+        if ($reason === null || trim($reason) === '') {
+            return $this->failWith('--dismiss requires --reason="<text>". Audit evidence cannot be discarded without a chain-of-custody reason.');
+        }
+
+        $row = $this->findRow($config, $connection, $id);
+
+        if ($row === null) {
+            return $this->failWith("Audit outbox row [{$id}] not found.");
+        }
+
+        if ((string) $row->status !== 'dead_letter') {
+            return $this->failWith("Audit outbox row [{$id}] has status [{$row->status}]; only dead_letter rows can be dismissed. Pending rows are owned by the relay.");
+        }
+
+        if (! $this->confirmAction("Permanently delete audit outbox row [{$id}] (category={$row->category}, run_id=".($row->run_id ?? '-').')?')) {
+            return $this->aborted();
+        }
+
+        $priorAttempts = (int) $row->attempts;
+
+        if (! $this->emitReconcileAudit($audit, 'dismiss', $row, $priorAttempts, $reason)) {
+            return self::FAILURE;
+        }
+
+        $connection->table($this->tableName($config))->where('id', $id)->delete();
+
+        if ($this->option('json') === true) {
+            $this->writeJson([
+                'ok' => true,
+                'action' => 'dismiss',
+                'id' => $id,
+                'prior_attempts' => $priorAttempts,
+                'reason' => $reason,
+            ]);
+
+            return self::SUCCESS;
+        }
+
+        $this->components->info("Audit outbox row [{$id}] dismissed. A command.audit_reconcile evidence record preserves the deletion.");
+
+        return self::SUCCESS;
+    }
+
+    protected function emitReconcileAudit(SwarmAuditDispatcher $audit, string $action, object $row, int $priorAttempts, ?string $reason): bool
+    {
+        $actorMetadata = ['actor' => Actor::system('artisan')->toArray()];
+        $now = Carbon::now('UTC');
+
+        $payload = [
+            'action' => $action,
+            'target_id' => (int) $row->id,
+            'target_category' => (string) $row->category,
+            'target_run_id' => $row->run_id !== null ? (string) $row->run_id : null,
+            'prior_attempts' => $priorAttempts,
+            'reason' => $reason,
+            'target_created_at' => $this->formatTimestamp($row->created_at),
+            'target_age_seconds' => $this->ageSeconds($row->created_at, $now),
+            ...$audit->metadata($actorMetadata),
+        ];
+
+        try {
+            $audit->emit('command.audit_reconcile', $payload);
+
+            return true;
+        } catch (Throwable $exception) {
+            $this->failWith(
+                "Failed to emit command.audit_reconcile evidence: {$exception->getMessage()}. "
+                .'The outbox row was NOT modified.',
+            );
+
+            return false;
+        }
+    }
+
+    protected function confirmAction(string $prompt): bool
+    {
+        if ($this->option('force') === true) {
+            return true;
+        }
+
+        if ($this->option('json') === true) {
+            return false;
+        }
+
+        if (! $this->input->isInteractive()) {
+            return false;
+        }
+
+        return $this->confirm($prompt, false);
+    }
+
+    protected function findRow(ConfigRepository $config, Connection $connection, int $id): ?object
+    {
+        $row = $connection->table($this->tableName($config))->where('id', $id)->first();
+
+        return is_object($row) ? $row : null;
+    }
+
+    /**
+     * @return array<string, mixed>|string|null
+     */
+    protected function decodePayload(SwarmPersistenceCipher $cipher, object $row): array|string|null
+    {
+        $raw = is_string($row->payload) ? $cipher->open($row->payload) : null;
+
+        if ($raw === null) {
+            return null;
+        }
+
+        try {
+            $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return $raw;
+        }
+
+        return is_array($decoded) ? $decoded : $raw;
+    }
+
+    protected function decodeLastError(SwarmPersistenceCipher $cipher, object $row): ?string
+    {
+        if (! is_string($row->last_error) || $row->last_error === '') {
+            return null;
+        }
+
+        return $cipher->open($row->last_error);
+    }
+
+    protected function resolveId(string $raw, string $mode): ?int
+    {
+        if (! is_numeric($raw) || (int) $raw < 1) {
+            $this->failWith("--{$mode} must be a positive integer id.");
+
+            return null;
+        }
+
+        return (int) $raw;
+    }
+
+    protected function tableName(ConfigRepository $config): string
+    {
+        return (string) $config->get('swarm.tables.audit_outbox', 'swarm_audit_outbox');
+    }
+
+    protected function formatTimestamp(mixed $value): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        try {
+            return Carbon::parse((string) $value, 'UTC')->toIso8601String();
+        } catch (Throwable) {
+            return is_scalar($value) ? (string) $value : null;
+        }
+    }
+
+    protected function ageHuman(mixed $createdAt, Carbon $now): string
+    {
+        $seconds = $this->ageSeconds($createdAt, $now);
+
+        if ($seconds === null) {
+            return '-';
+        }
+
+        if ($seconds < 60) {
+            return "{$seconds}s";
+        }
+
+        if ($seconds < 3600) {
+            return floor($seconds / 60).'m';
+        }
+
+        if ($seconds < 86400) {
+            return floor($seconds / 3600).'h';
+        }
+
+        return floor($seconds / 86400).'d';
+    }
+
+    protected function ageSeconds(mixed $createdAt, Carbon $now): ?int
+    {
+        if ($createdAt === null || $createdAt === '') {
+            return null;
+        }
+
+        try {
+            $parsed = Carbon::parse((string) $createdAt, 'UTC');
+        } catch (Throwable) {
+            return null;
+        }
+
+        return max(0, (int) abs($now->diffInSeconds($parsed, false)));
+    }
+
+    protected function prettyJson(mixed $value): string
+    {
+        $encoded = json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        return $encoded !== false ? $encoded : '{}';
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    protected function writeJson(array $payload): void
+    {
+        $this->line($this->prettyJson($payload));
+    }
+
+    protected function failWith(string $message): int
+    {
+        if ($this->option('json') === true) {
+            $this->writeJson(['ok' => false, 'error' => $message]);
+        } else {
+            $this->components->error($message);
+        }
+
+        return self::FAILURE;
+    }
+
+    protected function aborted(): int
+    {
+        if ($this->option('json') === true) {
+            $this->writeJson(['ok' => false, 'error' => 'aborted by operator']);
+        } else {
+            $this->components->warn('Aborted.');
+        }
+
+        return self::FAILURE;
+    }
+}

--- a/src/Commands/SwarmAuditReconcileCommand.php
+++ b/src/Commands/SwarmAuditReconcileCommand.php
@@ -21,6 +21,8 @@ class SwarmAuditReconcileCommand extends Command
 {
     use ResolvesStringConsoleInput;
 
+    protected ?string $reconcileAuditError = null;
+
     protected $signature = 'swarm:audit:reconcile
                             {--show= : Print full metadata and unsealed payload for the given outbox id.}
                             {--requeue= : Reset a dead_letter row to pending so the relay re-attempts emission.}
@@ -97,7 +99,7 @@ class SwarmAuditReconcileCommand extends Command
         }
 
         return match ($mode) {
-            'show' => $this->runShow($config, $connection, $cipher, $id),
+            'show' => $this->runShow($config, $connection, $cipher, $audit, $id),
             'requeue' => $this->runRequeue($config, $connection, $audit, $id),
             'dismiss' => $this->runDismiss($config, $connection, $audit, $id),
             default => self::FAILURE,
@@ -178,7 +180,7 @@ class SwarmAuditReconcileCommand extends Command
         return self::SUCCESS;
     }
 
-    protected function runShow(ConfigRepository $config, Connection $connection, SwarmPersistenceCipher $cipher, int $id): int
+    protected function runShow(ConfigRepository $config, Connection $connection, SwarmPersistenceCipher $cipher, SwarmAuditDispatcher $audit, int $id): int
     {
         $row = $this->findRow($config, $connection, $id);
 
@@ -203,10 +205,16 @@ class SwarmAuditReconcileCommand extends Command
             'payload' => $payload,
         ];
 
-        if ($this->option('json') === true) {
-            $this->writeJson(['ok' => true, 'row' => $detail]);
+        $auditEmitted = $this->emitReconcileAudit($audit, 'show', $row, (int) $row->attempts, null);
 
-            return self::SUCCESS;
+        if ($this->option('json') === true) {
+            $this->writeJson([
+                'ok' => $auditEmitted,
+                'row' => $detail,
+                'audit_emitted' => $auditEmitted,
+            ]);
+
+            return $auditEmitted ? self::SUCCESS : self::FAILURE;
         }
 
         $this->table(['Field', 'Value'], [
@@ -228,6 +236,12 @@ class SwarmAuditReconcileCommand extends Command
         $this->line('');
         $this->components->info('Payload');
         $this->line($this->prettyJson($payload));
+
+        if (! $auditEmitted) {
+            $this->components->warn('Read audit chain is broken: command.audit_reconcile emit failed. The row above was already in memory; rerun once the audit sink is healthy.');
+
+            return self::FAILURE;
+        }
 
         return self::SUCCESS;
     }
@@ -253,7 +267,10 @@ class SwarmAuditReconcileCommand extends Command
         $priorAttempts = (int) $row->attempts;
 
         if (! $this->emitReconcileAudit($audit, 'requeue', $row, $priorAttempts, $reason)) {
-            return self::FAILURE;
+            return $this->failWith(
+                "Failed to emit command.audit_reconcile evidence: {$this->reconcileAuditError}. "
+                .'The outbox row was NOT modified.',
+            );
         }
 
         $connection->table($this->tableName($config))
@@ -307,7 +324,10 @@ class SwarmAuditReconcileCommand extends Command
         $priorAttempts = (int) $row->attempts;
 
         if (! $this->emitReconcileAudit($audit, 'dismiss', $row, $priorAttempts, $reason)) {
-            return self::FAILURE;
+            return $this->failWith(
+                "Failed to emit command.audit_reconcile evidence: {$this->reconcileAuditError}. "
+                .'The outbox row was NOT modified.',
+            );
         }
 
         $connection->table($this->tableName($config))->where('id', $id)->delete();
@@ -331,6 +351,8 @@ class SwarmAuditReconcileCommand extends Command
 
     protected function emitReconcileAudit(SwarmAuditDispatcher $audit, string $action, object $row, int $priorAttempts, ?string $reason): bool
     {
+        $this->reconcileAuditError = null;
+
         $actorMetadata = ['actor' => Actor::system('artisan')->toArray()];
         $now = Carbon::now('UTC');
 
@@ -340,21 +362,26 @@ class SwarmAuditReconcileCommand extends Command
             'target_category' => (string) $row->category,
             'target_run_id' => $row->run_id !== null ? (string) $row->run_id : null,
             'prior_attempts' => $priorAttempts,
-            'reason' => $reason,
             'target_created_at' => $this->formatTimestamp($row->created_at),
             'target_age_seconds' => $this->ageSeconds($row->created_at, $now),
-            ...$audit->metadata($actorMetadata),
         ];
+
+        if ($action !== 'show') {
+            $payload['reason'] = $reason;
+        }
+
+        if ($action === 'dismiss') {
+            $payload['target_payload_digest'] = hash('sha256', is_string($row->payload) ? $row->payload : '');
+        }
+
+        $payload = [...$payload, ...$audit->metadata($actorMetadata)];
 
         try {
             $audit->emit('command.audit_reconcile', $payload);
 
             return true;
         } catch (Throwable $exception) {
-            $this->failWith(
-                "Failed to emit command.audit_reconcile evidence: {$exception->getMessage()}. "
-                .'The outbox row was NOT modified.',
-            );
+            $this->reconcileAuditError = $exception->getMessage();
 
             return false;
         }

--- a/src/Commands/SwarmAuditReconcileCommand.php
+++ b/src/Commands/SwarmAuditReconcileCommand.php
@@ -248,6 +248,10 @@ class SwarmAuditReconcileCommand extends Command
 
     protected function runRequeue(ConfigRepository $config, Connection $connection, SwarmAuditDispatcher $audit, int $id): int
     {
+        if (($forceFailure = $this->requireForceForJsonMutation()) !== null) {
+            return $forceFailure;
+        }
+
         $row = $this->findRow($config, $connection, $id);
 
         if ($row === null) {
@@ -301,6 +305,10 @@ class SwarmAuditReconcileCommand extends Command
 
     protected function runDismiss(ConfigRepository $config, Connection $connection, SwarmAuditDispatcher $audit, int $id): int
     {
+        if (($forceFailure = $this->requireForceForJsonMutation()) !== null) {
+            return $forceFailure;
+        }
+
         $reason = $this->optionalOptionString('reason');
 
         if ($reason === null || trim($reason) === '') {
@@ -393,15 +401,23 @@ class SwarmAuditReconcileCommand extends Command
             return true;
         }
 
-        if ($this->option('json') === true) {
-            return false;
-        }
-
-        if (! $this->input->isInteractive()) {
+        if (! $this->input->isInteractive() || $this->option('json') === true) {
             return false;
         }
 
         return $this->confirm($prompt, false);
+    }
+
+    protected function requireForceForJsonMutation(): ?int
+    {
+        if ($this->option('json') !== true || $this->option('force') === true) {
+            return null;
+        }
+
+        $message = 'Non-interactive automation requires --force to confirm requeue/dismiss.';
+        $this->writeJson(['ok' => false, 'error' => 'force_required', 'message' => $message]);
+
+        return self::FAILURE;
     }
 
     protected function findRow(ConfigRepository $config, Connection $connection, int $id): ?object

--- a/src/Commands/SwarmAuditStatusCommand.php
+++ b/src/Commands/SwarmAuditStatusCommand.php
@@ -1,0 +1,292 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Commands;
+
+use BuiltByBerry\LaravelSwarm\Contracts\AuditOutbox;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Carbon;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'swarm:audit:status')]
+class SwarmAuditStatusCommand extends Command
+{
+    protected $signature = 'swarm:audit:status
+                            {--json : Output machine-readable summary results}';
+
+    protected $description = 'Summarize the audit outbox — counts, age distribution, dead-letter categories, and retention';
+
+    public function handle(AuditOutbox $outbox, ConfigRepository $config, Connection $connection): int
+    {
+        if (! $outbox->isAvailable()) {
+            return $this->renderUnavailable();
+        }
+
+        $outboxTable = (string) $config->get('swarm.tables.audit_outbox', 'swarm_audit_outbox');
+        $reservationTimeoutSeconds = (int) $config->get('swarm.durable.relay.reservation_timeout_seconds', 60);
+        $retentionDays = $config->get('swarm.audit.outbox.dead_letter_retention_days');
+        $retentionDays = is_int($retentionDays) && $retentionDays > 0 ? $retentionDays : null;
+
+        $now = Carbon::now('UTC');
+        $staleThreshold = $now->copy()->subSeconds($reservationTimeoutSeconds * 2);
+
+        $counts = $this->collectCounts($connection, $outboxTable, $staleThreshold);
+        $ageDistribution = [
+            'pending' => $this->ageBuckets($connection, $outboxTable, 'pending', $now),
+            'dead_letter' => $this->ageBuckets($connection, $outboxTable, 'dead_letter', $now),
+        ];
+        $topDeadLetterCategories = $this->topDeadLetterCategories($connection, $outboxTable);
+        $oldest = [
+            'pending' => $this->oldestRow($connection, $outboxTable, 'pending', $now),
+            'dead_letter' => $this->oldestRow($connection, $outboxTable, 'dead_letter', $now),
+        ];
+        $retention = [
+            'dead_letter_retention_days' => $retentionDays,
+            'next_prune_count' => $this->nextPruneCount($connection, $outboxTable, $retentionDays, $now),
+        ];
+
+        $summary = [
+            'ok' => true,
+            'store' => 'database',
+            'available' => true,
+            'counts' => $counts,
+            'age_distribution' => $ageDistribution,
+            'top_dead_letter_categories' => $topDeadLetterCategories,
+            'oldest' => $oldest,
+            'retention' => $retention,
+        ];
+
+        if ($this->option('json') === true) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return self::SUCCESS;
+        }
+
+        $this->renderHuman($summary, $reservationTimeoutSeconds);
+
+        return self::SUCCESS;
+    }
+
+    protected function renderUnavailable(): int
+    {
+        if ($this->option('json') === true) {
+            $this->line((string) json_encode([
+                'ok' => true,
+                'store' => 'cache',
+                'available' => false,
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return self::SUCCESS;
+        }
+
+        $this->components->info('Audit outbox is not available on the current persistence driver — switch swarm.persistence.driver to "database" to enable it.');
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array{pending: int, reserved: int, stale_reserved: int, dead_letter: int}
+     */
+    protected function collectCounts(Connection $connection, string $outboxTable, Carbon $staleThreshold): array
+    {
+        $pending = $this->outboxQuery($connection, $outboxTable)
+            ->where('status', 'pending')
+            ->whereNull('reserved_at')
+            ->count();
+
+        $reserved = $this->outboxQuery($connection, $outboxTable)
+            ->where('status', 'pending')
+            ->whereNotNull('reserved_at')
+            ->count();
+
+        $staleReserved = $this->outboxQuery($connection, $outboxTable)
+            ->where('status', 'pending')
+            ->whereNotNull('reserved_at')
+            ->where('reserved_at', '<', $staleThreshold)
+            ->count();
+
+        $deadLetter = $this->outboxQuery($connection, $outboxTable)
+            ->where('status', 'dead_letter')
+            ->count();
+
+        return [
+            'pending' => $pending,
+            'reserved' => $reserved,
+            'stale_reserved' => $staleReserved,
+            'dead_letter' => $deadLetter,
+        ];
+    }
+
+    /**
+     * @return array{lt_1h: int, h1_24: int, d1_7: int, gt_7d: int}
+     */
+    protected function ageBuckets(Connection $connection, string $outboxTable, string $status, Carbon $now): array
+    {
+        $oneHour = $now->copy()->subHour();
+        $oneDay = $now->copy()->subDay();
+        $sevenDays = $now->copy()->subDays(7);
+
+        $base = fn (): Builder => $this->outboxQuery($connection, $outboxTable)->where('status', $status);
+
+        return [
+            'lt_1h' => (clone $base())->where('created_at', '>=', $oneHour)->count(),
+            'h1_24' => (clone $base())->where('created_at', '<', $oneHour)->where('created_at', '>=', $oneDay)->count(),
+            'd1_7' => (clone $base())->where('created_at', '<', $oneDay)->where('created_at', '>=', $sevenDays)->count(),
+            'gt_7d' => (clone $base())->where('created_at', '<', $sevenDays)->count(),
+        ];
+    }
+
+    /**
+     * @return array<int, array{category: string, count: int}>
+     */
+    protected function topDeadLetterCategories(Connection $connection, string $outboxTable): array
+    {
+        return $this->outboxQuery($connection, $outboxTable)
+            ->where('status', 'dead_letter')
+            ->groupBy('category')
+            ->selectRaw('category, COUNT(*) as aggregate')
+            ->orderByDesc('aggregate')
+            ->orderBy('category')
+            ->limit(5)
+            ->get()
+            ->map(fn (object $row): array => [
+                'category' => (string) $row->category,
+                'count' => (int) $row->aggregate,
+            ])
+            ->all();
+    }
+
+    /**
+     * @return array{id: int, age: string}|null
+     */
+    protected function oldestRow(Connection $connection, string $outboxTable, string $status, Carbon $now): ?array
+    {
+        $row = $this->outboxQuery($connection, $outboxTable)
+            ->where('status', $status)
+            ->orderBy('created_at')
+            ->orderBy('id')
+            ->first(['id', 'created_at']);
+
+        if ($row === null) {
+            return null;
+        }
+
+        $createdAt = Carbon::parse($row->created_at, 'UTC');
+
+        return [
+            'id' => (int) $row->id,
+            'age' => $createdAt->diffForHumans($now, [
+                'parts' => 2,
+                'short' => true,
+                'syntax' => Carbon::DIFF_ABSOLUTE,
+            ]),
+        ];
+    }
+
+    protected function nextPruneCount(Connection $connection, string $outboxTable, ?int $retentionDays, Carbon $now): int
+    {
+        if ($retentionDays === null) {
+            return 0;
+        }
+
+        return $this->outboxQuery($connection, $outboxTable)
+            ->where('status', 'dead_letter')
+            ->where('last_attempted_at', '<', $now->copy()->subDays($retentionDays))
+            ->count();
+    }
+
+    /**
+     * @param  array{ok: bool, store: string, available: bool, counts: array<string, int>, age_distribution: array<string, array<string, int>>, top_dead_letter_categories: array<int, array{category: string, count: int}>, oldest: array<string, array{id: int, age: string}|null>, retention: array{dead_letter_retention_days: int|null, next_prune_count: int}}  $summary
+     */
+    protected function renderHuman(array $summary, int $reservationTimeoutSeconds): void
+    {
+        $counts = $summary['counts'];
+        $staleWindow = $reservationTimeoutSeconds * 2;
+
+        $this->components->info('Audit outbox summary');
+
+        $this->table(
+            ['Status', 'Count'],
+            [
+                ['pending (unclaimed)', (string) $counts['pending']],
+                ['reserved', (string) $counts['reserved']],
+                ["  stale (> {$staleWindow}s)", (string) $counts['stale_reserved']],
+                ['dead_letter', (string) $counts['dead_letter']],
+            ],
+        );
+
+        $this->line('');
+        $this->components->info('Age distribution');
+        $this->table(
+            ['Status', '< 1h', '1-24h', '1-7d', '> 7d'],
+            [
+                [
+                    'pending',
+                    (string) $summary['age_distribution']['pending']['lt_1h'],
+                    (string) $summary['age_distribution']['pending']['h1_24'],
+                    (string) $summary['age_distribution']['pending']['d1_7'],
+                    (string) $summary['age_distribution']['pending']['gt_7d'],
+                ],
+                [
+                    'dead_letter',
+                    (string) $summary['age_distribution']['dead_letter']['lt_1h'],
+                    (string) $summary['age_distribution']['dead_letter']['h1_24'],
+                    (string) $summary['age_distribution']['dead_letter']['d1_7'],
+                    (string) $summary['age_distribution']['dead_letter']['gt_7d'],
+                ],
+            ],
+        );
+
+        $this->line('');
+        $this->components->info('Top dead-letter categories');
+
+        if ($summary['top_dead_letter_categories'] === []) {
+            $this->components->bulletList(['no dead-letter rows']);
+        } else {
+            $this->table(
+                ['Category', 'Count'],
+                array_map(
+                    fn (array $row): array => [$row['category'], (string) $row['count']],
+                    $summary['top_dead_letter_categories'],
+                ),
+            );
+        }
+
+        $this->line('');
+        $this->components->info('Oldest rows');
+        $this->table(
+            ['Status', 'ID', 'Age'],
+            [
+                [
+                    'pending',
+                    $summary['oldest']['pending']['id'] ?? 'n/a',
+                    $summary['oldest']['pending']['age'] ?? 'n/a',
+                ],
+                [
+                    'dead_letter',
+                    $summary['oldest']['dead_letter']['id'] ?? 'n/a',
+                    $summary['oldest']['dead_letter']['age'] ?? 'n/a',
+                ],
+            ],
+        );
+
+        $this->line('');
+        $this->components->info('Retention');
+        $retentionDays = $summary['retention']['dead_letter_retention_days'];
+        $this->components->bulletList([
+            $retentionDays === null
+                ? 'dead_letter_retention_days: not configured (rows retained indefinitely)'
+                : "dead_letter_retention_days: {$retentionDays}",
+            "next-prune count: {$summary['retention']['next_prune_count']}",
+        ]);
+    }
+
+    protected function outboxQuery(Connection $connection, string $outboxTable): Builder
+    {
+        return $connection->table($outboxTable);
+    }
+}

--- a/src/Pulse/Livewire/AuditOutbox.php
+++ b/src/Pulse/Livewire/AuditOutbox.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Pulse\Livewire;
+
+use BuiltByBerry\LaravelSwarm\Contracts\AuditOutbox as AuditOutboxContract;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\View;
+use Laravel\Pulse\Livewire\Card;
+use Livewire\Attributes\Lazy;
+
+/**
+ * @internal
+ */
+#[Lazy]
+class AuditOutbox extends Card
+{
+    public function render(): Renderable
+    {
+        $outbox = app(AuditOutboxContract::class);
+
+        if (! $outbox->isAvailable()) {
+            return View::make('swarm::pulse.livewire.audit-outbox', [
+                'available' => false,
+                'snapshot' => null,
+            ]);
+        }
+
+        $snapshot = $this->resolveSnapshot();
+
+        return View::make('swarm::pulse.livewire.audit-outbox', [
+            'available' => true,
+            'snapshot' => $snapshot,
+        ]);
+    }
+
+    /**
+     * @return object{
+     *     pending: int,
+     *     stalePending: int,
+     *     deadLetter: int,
+     *     oldestPendingAge: ?string,
+     *     oldestDeadLetterAge: ?string,
+     *     retentionDays: ?int,
+     *     staleWindowSeconds: int,
+     * }
+     */
+    protected function resolveSnapshot(): object
+    {
+        $config = app(ConfigRepository::class);
+        $connection = DB::connection();
+
+        $outboxTable = (string) $config->get('swarm.tables.audit_outbox', 'swarm_audit_outbox');
+        $reservationTimeoutSeconds = (int) $config->get('swarm.durable.relay.reservation_timeout_seconds', 60);
+        $retentionDays = $config->get('swarm.audit.outbox.dead_letter_retention_days');
+        $retentionDays = is_int($retentionDays) && $retentionDays > 0 ? $retentionDays : null;
+
+        $now = Carbon::now('UTC');
+        $staleWindowSeconds = $reservationTimeoutSeconds * 2;
+        $staleThreshold = $now->copy()->subSeconds($staleWindowSeconds);
+
+        $pending = $this->outboxQuery($connection, $outboxTable)
+            ->where('status', 'pending')
+            ->count();
+
+        $stalePending = $this->outboxQuery($connection, $outboxTable)
+            ->where('status', 'pending')
+            ->whereNotNull('reserved_at')
+            ->where('reserved_at', '<', $staleThreshold)
+            ->count();
+
+        $deadLetter = $this->outboxQuery($connection, $outboxTable)
+            ->where('status', 'dead_letter')
+            ->count();
+
+        return (object) [
+            'pending' => $pending,
+            'stalePending' => $stalePending,
+            'deadLetter' => $deadLetter,
+            'oldestPendingAge' => $this->oldestAge($connection, $outboxTable, 'pending', $now),
+            'oldestDeadLetterAge' => $this->oldestAge($connection, $outboxTable, 'dead_letter', $now),
+            'retentionDays' => $retentionDays,
+            'staleWindowSeconds' => $staleWindowSeconds,
+        ];
+    }
+
+    protected function oldestAge(ConnectionInterface $connection, string $outboxTable, string $status, Carbon $now): ?string
+    {
+        $row = $this->outboxQuery($connection, $outboxTable)
+            ->where('status', $status)
+            ->orderBy('created_at')
+            ->orderBy('id')
+            ->first(['created_at']);
+
+        if ($row === null) {
+            return null;
+        }
+
+        return Carbon::parse($row->created_at, 'UTC')->diffForHumans($now, [
+            'parts' => 2,
+            'short' => true,
+            'syntax' => Carbon::DIFF_ABSOLUTE,
+        ]);
+    }
+
+    protected function outboxQuery(ConnectionInterface $connection, string $outboxTable): Builder
+    {
+        return $connection->table($outboxTable);
+    }
+}

--- a/src/SwarmServiceProvider.php
+++ b/src/SwarmServiceProvider.php
@@ -12,6 +12,7 @@ use BuiltByBerry\LaravelSwarm\Audit\NoOpSwarmAuditSink;
 use BuiltByBerry\LaravelSwarm\Audit\RunAuditEmitter;
 use BuiltByBerry\LaravelSwarm\Audit\SwarmAuditDispatcher;
 use BuiltByBerry\LaravelSwarm\Commands\MakeSwarmCommand;
+use BuiltByBerry\LaravelSwarm\Commands\SwarmAuditStatusCommand;
 use BuiltByBerry\LaravelSwarm\Commands\SwarmCancelCommand;
 use BuiltByBerry\LaravelSwarm\Commands\SwarmHealthCommand;
 use BuiltByBerry\LaravelSwarm\Commands\SwarmHistoryCommand;
@@ -280,6 +281,7 @@ class SwarmServiceProvider extends ServiceProvider
                 SwarmCancelCommand::class,
                 SwarmRecoverCommand::class,
                 SwarmRelayCommand::class,
+                SwarmAuditStatusCommand::class,
                 SwarmSignalCommand::class,
                 SwarmInspectCommand::class,
                 SwarmProgressCommand::class,

--- a/src/SwarmServiceProvider.php
+++ b/src/SwarmServiceProvider.php
@@ -51,6 +51,7 @@ use BuiltByBerry\LaravelSwarm\Persistence\DatabaseDurableRunStore;
 use BuiltByBerry\LaravelSwarm\Persistence\DatabaseRunHistoryStore;
 use BuiltByBerry\LaravelSwarm\Persistence\DatabaseStreamEventStore;
 use BuiltByBerry\LaravelSwarm\Persistence\SwarmPersistenceCipher;
+use BuiltByBerry\LaravelSwarm\Pulse\Livewire\AuditOutbox as AuditOutboxCard;
 use BuiltByBerry\LaravelSwarm\Pulse\Livewire\SwarmRuns;
 use BuiltByBerry\LaravelSwarm\Pulse\Livewire\SwarmSteps;
 use BuiltByBerry\LaravelSwarm\Runners\DispatchValidator;
@@ -255,6 +256,7 @@ class SwarmServiceProvider extends ServiceProvider
             $this->callAfterResolving('livewire', function (LivewireManager $livewire): void {
                 $livewire->component('swarm.runs', SwarmRuns::class);
                 $livewire->component('swarm.steps', SwarmSteps::class);
+                $livewire->component('swarm.audit-outbox', AuditOutboxCard::class);
             });
         }
 

--- a/src/SwarmServiceProvider.php
+++ b/src/SwarmServiceProvider.php
@@ -12,6 +12,7 @@ use BuiltByBerry\LaravelSwarm\Audit\NoOpSwarmAuditSink;
 use BuiltByBerry\LaravelSwarm\Audit\RunAuditEmitter;
 use BuiltByBerry\LaravelSwarm\Audit\SwarmAuditDispatcher;
 use BuiltByBerry\LaravelSwarm\Commands\MakeSwarmCommand;
+use BuiltByBerry\LaravelSwarm\Commands\SwarmAuditReconcileCommand;
 use BuiltByBerry\LaravelSwarm\Commands\SwarmAuditStatusCommand;
 use BuiltByBerry\LaravelSwarm\Commands\SwarmCancelCommand;
 use BuiltByBerry\LaravelSwarm\Commands\SwarmHealthCommand;
@@ -282,6 +283,7 @@ class SwarmServiceProvider extends ServiceProvider
                 SwarmRecoverCommand::class,
                 SwarmRelayCommand::class,
                 SwarmAuditStatusCommand::class,
+                SwarmAuditReconcileCommand::class,
                 SwarmSignalCommand::class,
                 SwarmInspectCommand::class,
                 SwarmProgressCommand::class,

--- a/tests/Feature/AuditOutboxIntegrationTest.php
+++ b/tests/Feature/AuditOutboxIntegrationTest.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Audit\SwarmAuditDispatcher;
+use BuiltByBerry\LaravelSwarm\Contracts\ArtifactRepository;
+use BuiltByBerry\LaravelSwarm\Contracts\AuditOutbox;
+use BuiltByBerry\LaravelSwarm\Contracts\ContextStore;
+use BuiltByBerry\LaravelSwarm\Contracts\DurableOutbox;
+use BuiltByBerry\LaravelSwarm\Contracts\DurableRunStore;
+use BuiltByBerry\LaravelSwarm\Contracts\RunHistoryStore;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
+use BuiltByBerry\LaravelSwarm\Runners\DurableSwarmManager;
+use BuiltByBerry\LaravelSwarm\Runners\SwarmRunner;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\CountingThrowingSink;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\RecordingSwarmAuditSink;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\FakeSequentialSwarm;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Issue #39 — integration coverage for the v0.5 audit outbox flow.
+ *
+ * Three scenarios sanity-checked manually before v0.5.0 tag and now automated:
+ *
+ *   1. DB-backed app, failing sink → outbox row → replay → dead_letter
+ *      (covers the full happy and unhappy paths the operator sees in prod).
+ *   2. Cache-backed app, failing sink → log-and-swallow
+ *      (proves the NoOp fallback never touches the DB).
+ *   3. Cross-lane `swarm:relay` drains both durable and audit lanes in one pass
+ *      and reports both counters in the same `command.relay` audit emit.
+ */
+function configureDatabasePersistence(): void
+{
+    config()->set('swarm.persistence.driver', 'database');
+
+    foreach ([
+        AuditOutbox::class,
+        SwarmAuditDispatcher::class,
+        ContextStore::class,
+        ArtifactRepository::class,
+        RunHistoryStore::class,
+        DurableRunStore::class,
+        SwarmRunner::class,
+        DurableSwarmManager::class,
+    ] as $abstract) {
+        app()->forgetInstance($abstract);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — DB-backed app: failing sink → outbox → replay → dead_letter
+// ---------------------------------------------------------------------------
+
+it('persists a pending outbox row when the bound sink throws under failure_policy=queue', function (): void {
+    configureDatabasePersistence();
+
+    $sink = new CountingThrowingSink;
+    app()->instance(SwarmAuditSink::class, $sink);
+    app()->forgetInstance(SwarmAuditDispatcher::class);
+
+    app(SwarmAuditDispatcher::class)->emit('run.failed', [
+        'run_id' => 'r-queued',
+        'category' => 'run.failed',
+    ]);
+
+    expect($sink->attempts)->toBe(1);
+
+    $row = DB::table('swarm_audit_outbox')->first();
+    expect($row)->not->toBeNull();
+    expect($row->status)->toBe('pending');
+    expect($row->run_id)->toBe('r-queued');
+    // enqueue() stores the freshly-routed row with attempts=0; the first drain
+    // is what increments attempts. The sink failure that put the row here does
+    // not count against max_attempts.
+    expect($row->attempts)->toBe(0);
+});
+
+it('drives a queued outbox row from pending through replay to deletion when a passing sink takes over', function (): void {
+    configureDatabasePersistence();
+
+    // Initial failing emit routes the payload to the outbox.
+    $failingSink = new CountingThrowingSink;
+    app()->instance(SwarmAuditSink::class, $failingSink);
+    app()->forgetInstance(SwarmAuditDispatcher::class);
+
+    app(SwarmAuditDispatcher::class)->emit('run.failed', [
+        'run_id' => 'r-replay',
+        'category' => 'run.failed',
+    ]);
+
+    expect(DB::table('swarm_audit_outbox')->where('status', 'pending')->count())->toBe(1);
+
+    // First drain still sees the failing sink: attempts bumps, row remains pending.
+    $outbox = app(AuditOutbox::class);
+
+    $firstResult = $outbox->drain();
+    expect($firstResult->failed)->toBe(1);
+    expect($firstResult->replayed)->toBe(0);
+
+    $row = DB::table('swarm_audit_outbox')->where('run_id', 'r-replay')->first();
+    expect($row->status)->toBe('pending');
+    expect($row->attempts)->toBe(1);
+
+    // Swap to a passing sink; next drain replays and deletes the row.
+    $passingSink = new RecordingSwarmAuditSink;
+    app()->instance(SwarmAuditSink::class, $passingSink);
+    app()->forgetInstance(AuditOutbox::class);
+
+    $secondResult = app(AuditOutbox::class)->drain();
+    expect($secondResult->replayed)->toBe(1);
+    expect($secondResult->failed)->toBe(0);
+    expect(DB::table('swarm_audit_outbox')->where('run_id', 'r-replay')->count())->toBe(0);
+
+    $records = $passingSink->recordsForCategory('run.failed');
+    expect($records)->toHaveCount(1);
+    expect($records[0]['run_id'])->toBe('r-replay');
+});
+
+it('transitions a queued outbox row to dead_letter and logs the transition once max_attempts is exceeded', function (): void {
+    configureDatabasePersistence();
+    config()->set('swarm.audit.outbox.max_attempts', 2);
+
+    Log::spy();
+
+    $failingSink = new CountingThrowingSink;
+    app()->instance(SwarmAuditSink::class, $failingSink);
+    app()->forgetInstance(SwarmAuditDispatcher::class);
+
+    app(SwarmAuditDispatcher::class)->emit('run.failed', [
+        'run_id' => 'r-dead',
+        'category' => 'run.failed',
+    ]);
+
+    // Drain max_attempts + 1 times: first drain → attempts=1, second drain
+    // hits the cap and transitions the row to dead_letter.
+    $outbox = app(AuditOutbox::class);
+
+    $first = $outbox->drain();
+    expect($first->failed)->toBe(1);
+    expect($first->deadLettered)->toBe(0);
+
+    $second = $outbox->drain();
+    expect($second->failed)->toBe(0);
+    expect($second->deadLettered)->toBe(1);
+
+    $row = DB::table('swarm_audit_outbox')->where('run_id', 'r-dead')->first();
+    expect($row->status)->toBe('dead_letter');
+    expect($row->attempts)->toBe(2);
+
+    Log::shouldHaveReceived('error')
+        ->withArgs(function (string $message, array $context): bool {
+            return str_contains($message, 'dead_letter')
+                && ($context['run_id'] ?? null) === 'r-dead'
+                && ($context['category'] ?? null) === 'run.failed'
+                && ($context['attempts'] ?? null) === 2;
+        })
+        ->once();
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — Cache-backed app: failing sink → log-and-swallow, no DB write
+// ---------------------------------------------------------------------------
+
+it('logs a warning and never writes to the outbox table when the persistence driver is cache', function (): void {
+    // Persistence driver stays at the package default (cache) — NoOpAuditOutbox
+    // is bound, isAvailable() is false, and routeToOutbox() must fall through
+    // to log-and-swallow without attempting any DB write.
+    config()->set('swarm.persistence.driver', 'cache');
+    app()->forgetInstance(AuditOutbox::class);
+    app()->forgetInstance(SwarmAuditDispatcher::class);
+
+    Log::spy();
+
+    $failingSink = new CountingThrowingSink;
+    app()->instance(SwarmAuditSink::class, $failingSink);
+    app()->forgetInstance(SwarmAuditDispatcher::class);
+
+    app(SwarmAuditDispatcher::class)->emit('run.failed', [
+        'run_id' => 'r-cache',
+        'category' => 'run.failed',
+    ]);
+
+    expect($failingSink->attempts)->toBe(1);
+    expect(DB::table('swarm_audit_outbox')->count())->toBe(0);
+
+    Log::shouldHaveReceived('warning')
+        ->withArgs(function (string $message, array $context): bool {
+            return str_contains($message, 'outbox is unavailable')
+                && ($context['category'] ?? null) === 'run.failed'
+                && ($context['decision'] ?? null) === 'queue';
+        })
+        ->once();
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — `swarm:relay` (no --type) drains both lanes in one pass
+// ---------------------------------------------------------------------------
+
+it('drains durable and audit lanes in a single swarm:relay invocation and reports both counters', function (): void {
+    configureDatabasePersistence();
+    config()->set('queue.connections.durable-test', ['driver' => 'null']);
+    config()->set('swarm.durable.queue.connection', 'durable-test');
+    config()->set('swarm.durable.queue.name', 'swarm-durable');
+
+    // Recording sink so we can inspect the command.relay envelope.
+    $sink = new RecordingSwarmAuditSink;
+    app()->instance(SwarmAuditSink::class, $sink);
+    app()->forgetInstance(AuditOutbox::class);
+    app()->forgetInstance(SwarmAuditDispatcher::class);
+
+    // Seed the durable lane: a stuck step dispatch tied to a real durable run.
+    $response = FakeSequentialSwarm::make()->dispatchDurable('cross-lane-task');
+    app(DurableOutbox::class)->enqueueStep($response->runId, 1, null, null);
+    expect(DB::table('swarm_durable_outbox')->where('run_id', $response->runId)->count())->toBe(1);
+
+    // Seed the audit lane: a pending row ready to replay through the recording sink.
+    app(AuditOutbox::class)->enqueue('run.failed', [
+        'run_id' => 'r-cross-lane',
+        'category' => 'run.failed',
+    ]);
+    expect(DB::table('swarm_audit_outbox')->where('status', 'pending')->count())->toBe(1);
+
+    $sink->reset();
+
+    $exitCode = Artisan::call('swarm:relay');
+
+    expect($exitCode)->toBe(0);
+    expect(DB::table('swarm_durable_outbox')->where('run_id', $response->runId)->count())->toBe(0);
+    expect(DB::table('swarm_audit_outbox')->where('run_id', 'r-cross-lane')->count())->toBe(0);
+
+    // The replayed audit row goes through the recording sink alongside the
+    // command.relay emit — pluck the command.relay record specifically.
+    $relayRecords = $sink->recordsForCategory('command.relay');
+    expect($relayRecords)->toHaveCount(1);
+
+    $relay = $relayRecords[0];
+    expect($relay['dispatched_count'])->toBeGreaterThan(0);
+    expect($relay['audit_replayed_count'])->toBeGreaterThan(0);
+    expect($relay['audit_dead_lettered_count'])->toBe(0);
+    expect($relay['status'])->toBe('dispatched');
+
+    // The replayed audit payload also made it through the sink in the same drain.
+    expect($sink->hasCategory('run.failed'))->toBeTrue();
+});

--- a/tests/Feature/PulseAuditOutboxCardTest.php
+++ b/tests/Feature/PulseAuditOutboxCardTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Contracts\AuditOutbox;
+use BuiltByBerry\LaravelSwarm\Pulse\Livewire\AuditOutbox as AuditOutboxCard;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
+
+beforeEach(function (): void {
+    config()->set('swarm.persistence.driver', 'database');
+    app()->forgetInstance(AuditOutbox::class);
+});
+
+function seedCardOutboxRow(array $attributes = []): int
+{
+    $now = Carbon::now('UTC');
+
+    return (int) DB::table('swarm_audit_outbox')->insertGetId(array_merge([
+        'category' => 'run.failed',
+        'run_id' => 'r-card-test',
+        'payload' => json_encode(['run_id' => 'r-card-test', 'category' => 'run.failed']),
+        'attempts' => 0,
+        'status' => 'pending',
+        'last_error' => null,
+        'last_attempted_at' => null,
+        'reserved_at' => null,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ], $attributes));
+}
+
+test('audit outbox card renders zero counts with no alarm against an empty outbox', function (): void {
+    Livewire::withoutLazyLoading();
+
+    Livewire::test('swarm.audit-outbox')
+        ->assertSee('Swarm Audit Outbox')
+        ->assertSee('Dead-letter')
+        ->assertSee('Pending')
+        ->assertSee('Stale pending')
+        ->assertDontSee('attention')
+        ->assertDontSee('relay may not be running')
+        ->assertSee('indefinite');
+});
+
+test('audit outbox card surfaces pending, dead-letter, and stale counts and raises alarm for dead-letter rows', function (): void {
+    config()->set('swarm.durable.relay.reservation_timeout_seconds', 60);
+
+    $now = Carbon::now('UTC');
+    $staleReservedAt = $now->copy()->subSeconds(60 * 2 + 10);
+
+    seedCardOutboxRow(['status' => 'pending']);
+    seedCardOutboxRow(['status' => 'pending']);
+    seedCardOutboxRow(['status' => 'pending', 'reserved_at' => $staleReservedAt]);
+    seedCardOutboxRow(['status' => 'dead_letter']);
+    seedCardOutboxRow(['status' => 'dead_letter']);
+
+    Livewire::withoutLazyLoading();
+
+    Livewire::test('swarm.audit-outbox')
+        ->assertSee('Swarm Audit Outbox')
+        ->assertSeeInOrder(['Dead-letter', '2'])
+        ->assertSeeInOrder(['Pending', '3'])
+        ->assertSeeInOrder(['Stale pending', '1'])
+        ->assertSee('attention')
+        ->assertSee('relay may not be running');
+});
+
+test('audit outbox card honours configured dead-letter retention setting', function (): void {
+    config()->set('swarm.audit.outbox.dead_letter_retention_days', 14);
+
+    Livewire::withoutLazyLoading();
+
+    Livewire::test('swarm.audit-outbox')
+        ->assertSee('14 days');
+});
+
+test('audit outbox card renders unavailable state on cache driver without querying the database', function (): void {
+    config()->set('swarm.persistence.driver', 'cache');
+    app()->forgetInstance(AuditOutbox::class);
+
+    DB::connection()->enableQueryLog();
+    DB::connection()->flushQueryLog();
+
+    Livewire::withoutLazyLoading();
+
+    Livewire::test('swarm.audit-outbox')
+        ->assertSee('Audit outbox unavailable on cache persistence driver.');
+
+    $queries = DB::connection()->getQueryLog();
+    $outboxQueries = array_filter(
+        $queries,
+        fn (array $query): bool => str_contains((string) $query['query'], 'swarm_audit_outbox'),
+    );
+
+    expect($outboxQueries)->toBe([]);
+});
+
+test('audit outbox card resolveSnapshot reports correct oldest ages and counts', function (): void {
+    $now = Carbon::now('UTC');
+
+    DB::table('swarm_audit_outbox')->insert([
+        [
+            'category' => 'run.failed',
+            'run_id' => 'r1',
+            'payload' => json_encode(['run_id' => 'r1']),
+            'attempts' => 0,
+            'status' => 'pending',
+            'last_error' => null,
+            'last_attempted_at' => null,
+            'reserved_at' => null,
+            'created_at' => $now->copy()->subHours(3),
+            'updated_at' => $now->copy()->subHours(3),
+        ],
+        [
+            'category' => 'run.failed',
+            'run_id' => 'r2',
+            'payload' => json_encode(['run_id' => 'r2']),
+            'attempts' => 3,
+            'status' => 'dead_letter',
+            'last_error' => 'boom',
+            'last_attempted_at' => $now->copy()->subDays(2),
+            'reserved_at' => null,
+            'created_at' => $now->copy()->subDays(2),
+            'updated_at' => $now->copy()->subDays(2),
+        ],
+    ]);
+
+    $card = new class extends AuditOutboxCard
+    {
+        public function snapshot(): object
+        {
+            return $this->resolveSnapshot();
+        }
+    };
+
+    $snapshot = $card->snapshot();
+
+    expect($snapshot->pending)->toBe(1);
+    expect($snapshot->deadLetter)->toBe(1);
+    expect($snapshot->stalePending)->toBe(0);
+    expect($snapshot->oldestPendingAge)->not->toBeNull();
+    expect($snapshot->oldestDeadLetterAge)->not->toBeNull();
+});

--- a/tests/Feature/SwarmAuditReconcileCommandTest.php
+++ b/tests/Feature/SwarmAuditReconcileCommandTest.php
@@ -1,0 +1,419 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Audit\SwarmAuditDispatcher;
+use BuiltByBerry\LaravelSwarm\Contracts\AuditOutbox;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
+use BuiltByBerry\LaravelSwarm\Persistence\SwarmPersistenceCipher;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\RecordingSwarmAuditSink;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+
+beforeEach(function (): void {
+    config()->set('swarm.persistence.driver', 'database');
+    app()->forgetInstance(AuditOutbox::class);
+});
+
+function seedReconcileRow(string $status, array $overrides = []): int
+{
+    $payload = $overrides['payload'] ?? ['run_id' => 'r-test', 'category' => 'run.failed', 'secret' => 'top-secret'];
+    $cipher = app(SwarmPersistenceCipher::class);
+    $encoded = json_encode($payload, JSON_THROW_ON_ERROR);
+
+    return (int) DB::table('swarm_audit_outbox')->insertGetId([
+        'category' => $overrides['category'] ?? 'run.failed',
+        'run_id' => $overrides['run_id'] ?? ($payload['run_id'] ?? null),
+        'payload' => $cipher->seal($encoded),
+        'attempts' => $overrides['attempts'] ?? 3,
+        'status' => $status,
+        'last_error' => isset($overrides['last_error']) ? $cipher->seal($overrides['last_error']) : null,
+        'last_attempted_at' => $overrides['last_attempted_at'] ?? Carbon::now('UTC'),
+        'reserved_at' => null,
+        'created_at' => $overrides['created_at'] ?? Carbon::now('UTC')->subMinutes(5),
+        'updated_at' => Carbon::now('UTC'),
+    ]);
+}
+
+function reconcileRecordingSink(): RecordingSwarmAuditSink
+{
+    $sink = new RecordingSwarmAuditSink;
+    app()->instance(SwarmAuditSink::class, $sink);
+    app()->forgetInstance(SwarmAuditDispatcher::class);
+
+    return $sink;
+}
+
+// -----------------------------------------------------------------------------
+// Cache-driver guard
+// -----------------------------------------------------------------------------
+
+test('swarm:audit:reconcile exits non-zero with a clear error when the cache driver is in use', function (): void {
+    config()->set('swarm.persistence.driver', 'cache');
+    app()->forgetInstance(AuditOutbox::class);
+
+    $exit = Artisan::call('swarm:audit:reconcile');
+
+    expect($exit)->toBe(1);
+    expect(Artisan::output())->toContain('database-backed audit outbox');
+});
+
+// -----------------------------------------------------------------------------
+// List
+// -----------------------------------------------------------------------------
+
+test('list mode prints info when the outbox is empty', function (): void {
+    $exit = Artisan::call('swarm:audit:reconcile');
+
+    expect($exit)->toBe(0);
+    expect(Artisan::output())->toContain('No audit outbox rows match.');
+});
+
+test('list mode tabulates pending and dead_letter rows', function (): void {
+    seedReconcileRow('pending');
+    seedReconcileRow('dead_letter');
+
+    $exit = Artisan::call('swarm:audit:reconcile');
+
+    expect($exit)->toBe(0);
+    $output = Artisan::output();
+    expect($output)->toContain('pending');
+    expect($output)->toContain('dead_letter');
+    expect($output)->toContain('run.failed');
+});
+
+test('list mode --status filter only returns matching rows', function (): void {
+    seedReconcileRow('pending', ['run_id' => 'r-pending']);
+    seedReconcileRow('dead_letter', ['run_id' => 'r-dead']);
+
+    Artisan::call('swarm:audit:reconcile', ['--status' => 'dead_letter', '--json' => true]);
+    $decoded = json_decode(Artisan::output(), true);
+
+    expect($decoded['ok'])->toBeTrue();
+    expect($decoded['rows'])->toHaveCount(1);
+    expect($decoded['rows'][0]['status'])->toBe('dead_letter');
+});
+
+test('list mode rejects an unknown --status value', function (): void {
+    $exit = Artisan::call('swarm:audit:reconcile', ['--status' => 'made-up']);
+
+    expect($exit)->toBe(1);
+    expect(Artisan::output())->toContain('--status');
+});
+
+test('list mode --limit caps rows and reports truncation', function (): void {
+    seedReconcileRow('dead_letter');
+    seedReconcileRow('dead_letter');
+    seedReconcileRow('dead_letter');
+
+    Artisan::call('swarm:audit:reconcile', ['--limit' => 2, '--json' => true]);
+    $decoded = json_decode(Artisan::output(), true);
+
+    expect($decoded['rows'])->toHaveCount(2);
+    expect($decoded['truncated'])->toBeTrue();
+    expect($decoded['limit'])->toBe(2);
+});
+
+test('list --json output shape includes the documented fields', function (): void {
+    $id = seedReconcileRow('dead_letter', ['run_id' => 'r-1', 'attempts' => 4]);
+
+    Artisan::call('swarm:audit:reconcile', ['--json' => true]);
+    $decoded = json_decode(Artisan::output(), true);
+
+    expect($decoded['rows'][0])
+        ->toHaveKey('id')
+        ->toHaveKey('status')
+        ->toHaveKey('category')
+        ->toHaveKey('run_id')
+        ->toHaveKey('attempts')
+        ->toHaveKey('last_attempted_at')
+        ->toHaveKey('age');
+    expect($decoded['rows'][0]['id'])->toBe($id);
+    expect($decoded['rows'][0]['attempts'])->toBe(4);
+});
+
+// -----------------------------------------------------------------------------
+// Show
+// -----------------------------------------------------------------------------
+
+test('--show prints metadata and unsealed payload + last_error for a dead_letter row', function (): void {
+    config()->set('swarm.persistence.encrypt_at_rest', true);
+    $id = seedReconcileRow('dead_letter', [
+        'payload' => ['run_id' => 'r-x', 'category' => 'run.failed', 'secret' => 'visible-after-unseal'],
+        'last_error' => 'downstream rejected with 500',
+    ]);
+
+    Artisan::call('swarm:audit:reconcile', ['--show' => (string) $id]);
+    $output = Artisan::output();
+
+    expect($output)->toContain('visible-after-unseal');
+    expect($output)->toContain('downstream rejected with 500');
+    expect($output)->toContain('dead_letter');
+});
+
+test('--show works for pending rows', function (): void {
+    $id = seedReconcileRow('pending');
+
+    $exit = Artisan::call('swarm:audit:reconcile', ['--show' => (string) $id]);
+
+    expect($exit)->toBe(0);
+    expect(Artisan::output())->toContain('pending');
+});
+
+test('--show --json unseals payload into the response', function (): void {
+    config()->set('swarm.persistence.encrypt_at_rest', true);
+    $id = seedReconcileRow('dead_letter', [
+        'payload' => ['run_id' => 'r-x', 'category' => 'run.failed', 'secret' => 'unsealed-payload-x'],
+    ]);
+
+    Artisan::call('swarm:audit:reconcile', ['--show' => (string) $id, '--json' => true]);
+    $decoded = json_decode(Artisan::output(), true);
+
+    expect($decoded['ok'])->toBeTrue();
+    expect($decoded['row']['payload']['secret'])->toBe('unsealed-payload-x');
+});
+
+test('--show with an unknown id returns a clear error', function (): void {
+    $exit = Artisan::call('swarm:audit:reconcile', ['--show' => '99999']);
+
+    expect($exit)->toBe(1);
+    expect(Artisan::output())->toContain('not found');
+});
+
+// -----------------------------------------------------------------------------
+// Requeue
+// -----------------------------------------------------------------------------
+
+test('--requeue resets a dead_letter row to pending with attempts=0 and preserves last_error', function (): void {
+    $sink = reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter', ['attempts' => 5, 'last_error' => 'sink down for 24h']);
+
+    $exit = Artisan::call('swarm:audit:reconcile', ['--requeue' => (string) $id, '--force' => true]);
+
+    expect($exit)->toBe(0);
+
+    $row = DB::table('swarm_audit_outbox')->where('id', $id)->first();
+    expect($row->status)->toBe('pending');
+    expect($row->attempts)->toBe(0);
+    expect($row->reserved_at)->toBeNull();
+    expect($row->last_error)->not->toBeNull();
+
+    $records = $sink->recordsForCategory('command.audit_reconcile');
+    expect($records)->toHaveCount(1);
+    expect($records[0]['action'])->toBe('requeue');
+    expect($records[0]['target_id'])->toBe($id);
+    expect($records[0]['target_category'])->toBe('run.failed');
+    expect($records[0]['prior_attempts'])->toBe(5);
+});
+
+test('--requeue with --reason records the reason on the command.audit_reconcile evidence', function (): void {
+    $sink = reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter');
+
+    Artisan::call('swarm:audit:reconcile', [
+        '--requeue' => (string) $id,
+        '--reason' => 'sink restored after maintenance window',
+        '--force' => true,
+    ]);
+
+    $records = $sink->recordsForCategory('command.audit_reconcile');
+    expect($records[0]['reason'])->toBe('sink restored after maintenance window');
+});
+
+test('--requeue rejects pending rows with a clear error', function (): void {
+    reconcileRecordingSink();
+    $id = seedReconcileRow('pending');
+
+    $exit = Artisan::call('swarm:audit:reconcile', ['--requeue' => (string) $id, '--force' => true]);
+
+    expect($exit)->toBe(1);
+    expect(Artisan::output())->toContain('only dead_letter rows can be requeued');
+
+    $row = DB::table('swarm_audit_outbox')->where('id', $id)->first();
+    expect($row->status)->toBe('pending');
+});
+
+test('--requeue rejects unknown ids', function (): void {
+    reconcileRecordingSink();
+
+    $exit = Artisan::call('swarm:audit:reconcile', ['--requeue' => '99999', '--force' => true]);
+
+    expect($exit)->toBe(1);
+    expect(Artisan::output())->toContain('not found');
+});
+
+test('--requeue without --force aborts when no operator confirms (non-interactive)', function (): void {
+    $sink = reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter');
+
+    $exit = Artisan::call('swarm:audit:reconcile', ['--requeue' => (string) $id]);
+
+    expect($exit)->toBe(1);
+
+    $row = DB::table('swarm_audit_outbox')->where('id', $id)->first();
+    expect($row->status)->toBe('dead_letter');
+    expect($sink->recordsForCategory('command.audit_reconcile'))->toHaveCount(0);
+});
+
+test('--requeue proceeds when confirmation is given interactively', function (): void {
+    $sink = reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter');
+
+    $this->artisan('swarm:audit:reconcile', ['--requeue' => (string) $id])
+        ->expectsConfirmation('Requeue audit outbox row ['.$id.'] (category=run.failed, attempts=3)?', 'yes')
+        ->assertSuccessful();
+
+    expect(DB::table('swarm_audit_outbox')->where('id', $id)->value('status'))->toBe('pending');
+    expect($sink->recordsForCategory('command.audit_reconcile'))->toHaveCount(1);
+});
+
+// -----------------------------------------------------------------------------
+// Dismiss
+// -----------------------------------------------------------------------------
+
+test('--dismiss deletes a dead_letter row and emits the audit record with reason snapshot', function (): void {
+    $sink = reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter', ['attempts' => 7, 'run_id' => 'r-dismiss']);
+
+    $exit = Artisan::call('swarm:audit:reconcile', [
+        '--dismiss' => (string) $id,
+        '--reason' => 'duplicate of run.failed for r-7',
+        '--force' => true,
+    ]);
+
+    expect($exit)->toBe(0);
+    expect(DB::table('swarm_audit_outbox')->where('id', $id)->exists())->toBeFalse();
+
+    $records = $sink->recordsForCategory('command.audit_reconcile');
+    expect($records)->toHaveCount(1);
+    expect($records[0]['action'])->toBe('dismiss');
+    expect($records[0]['target_id'])->toBe($id);
+    expect($records[0]['target_run_id'])->toBe('r-dismiss');
+    expect($records[0]['target_category'])->toBe('run.failed');
+    expect($records[0]['prior_attempts'])->toBe(7);
+    expect($records[0]['reason'])->toBe('duplicate of run.failed for r-7');
+});
+
+test('--dismiss requires --reason and refuses without it', function (): void {
+    $sink = reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter');
+
+    $exit = Artisan::call('swarm:audit:reconcile', ['--dismiss' => (string) $id, '--force' => true]);
+
+    expect($exit)->toBe(1);
+    expect(Artisan::output())->toContain('--reason');
+
+    expect(DB::table('swarm_audit_outbox')->where('id', $id)->exists())->toBeTrue();
+    expect($sink->recordsForCategory('command.audit_reconcile'))->toHaveCount(0);
+});
+
+test('--dismiss rejects pending rows', function (): void {
+    reconcileRecordingSink();
+    $id = seedReconcileRow('pending');
+
+    $exit = Artisan::call('swarm:audit:reconcile', [
+        '--dismiss' => (string) $id,
+        '--reason' => 'wrong row',
+        '--force' => true,
+    ]);
+
+    expect($exit)->toBe(1);
+    expect(Artisan::output())->toContain('only dead_letter rows can be dismissed');
+    expect(DB::table('swarm_audit_outbox')->where('id', $id)->exists())->toBeTrue();
+});
+
+test('--dismiss without --force aborts when no operator confirms (non-interactive)', function (): void {
+    $sink = reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter');
+
+    $exit = Artisan::call('swarm:audit:reconcile', [
+        '--dismiss' => (string) $id,
+        '--reason' => 'duplicate',
+    ]);
+
+    expect($exit)->toBe(1);
+    expect(DB::table('swarm_audit_outbox')->where('id', $id)->exists())->toBeTrue();
+    expect($sink->recordsForCategory('command.audit_reconcile'))->toHaveCount(0);
+});
+
+test('--dismiss proceeds when confirmation is given interactively', function (): void {
+    $sink = reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter');
+
+    $this->artisan('swarm:audit:reconcile', [
+        '--dismiss' => (string) $id,
+        '--reason' => 'duplicate',
+    ])
+        ->expectsConfirmation('Permanently delete audit outbox row ['.$id.'] (category=run.failed, run_id=r-test)?', 'yes')
+        ->assertSuccessful();
+
+    expect(DB::table('swarm_audit_outbox')->where('id', $id)->exists())->toBeFalse();
+    expect($sink->recordsForCategory('command.audit_reconcile'))->toHaveCount(1);
+});
+
+function bindFailingDispatcher(): void
+{
+    $stub = new class extends SwarmAuditDispatcher
+    {
+        public function __construct() {}
+
+        public function emit(string $category, array $payload): void
+        {
+            throw new RuntimeException('emit blew up');
+        }
+
+        public function metadata(array $metadata): array
+        {
+            return ['metadata_keys' => [], 'metadata' => []];
+        }
+    };
+    app()->instance(SwarmAuditDispatcher::class, $stub);
+}
+
+test('dismiss does NOT delete the row when the audit emit fails', function (): void {
+    $id = seedReconcileRow('dead_letter');
+    bindFailingDispatcher();
+
+    $exit = Artisan::call('swarm:audit:reconcile', [
+        '--dismiss' => (string) $id,
+        '--reason' => 'attempted dismiss',
+        '--force' => true,
+    ]);
+
+    expect($exit)->toBe(1);
+    expect(Artisan::output())->toContain('command.audit_reconcile');
+    expect(DB::table('swarm_audit_outbox')->where('id', $id)->exists())->toBeTrue();
+});
+
+test('requeue does NOT mutate the row when the audit emit fails', function (): void {
+    $id = seedReconcileRow('dead_letter', ['attempts' => 4]);
+    bindFailingDispatcher();
+
+    $exit = Artisan::call('swarm:audit:reconcile', [
+        '--requeue' => (string) $id,
+        '--force' => true,
+    ]);
+
+    expect($exit)->toBe(1);
+    $row = DB::table('swarm_audit_outbox')->where('id', $id)->first();
+    expect($row->status)->toBe('dead_letter');
+    expect($row->attempts)->toBe(4);
+});
+
+// -----------------------------------------------------------------------------
+// Mutual exclusivity
+// -----------------------------------------------------------------------------
+
+test('combining --show with --requeue is rejected', function (): void {
+    $id = seedReconcileRow('dead_letter');
+
+    $exit = Artisan::call('swarm:audit:reconcile', [
+        '--show' => (string) $id,
+        '--requeue' => (string) $id,
+        '--force' => true,
+    ]);
+
+    expect($exit)->toBe(1);
+    expect(Artisan::output())->toContain('Use only one of');
+});

--- a/tests/Feature/SwarmAuditReconcileCommandTest.php
+++ b/tests/Feature/SwarmAuditReconcileCommandTest.php
@@ -181,6 +181,55 @@ test('--show with an unknown id returns a clear error', function (): void {
     expect(Artisan::output())->toContain('not found');
 });
 
+test('--show emits a command.audit_reconcile evidence record with action=show and no payload contents', function (): void {
+    $sink = reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter', [
+        'attempts' => 4,
+        'run_id' => 'r-show',
+        'payload' => ['run_id' => 'r-show', 'category' => 'run.failed', 'secret' => 'should-not-leak'],
+    ]);
+
+    $exit = Artisan::call('swarm:audit:reconcile', ['--show' => (string) $id]);
+
+    expect($exit)->toBe(0);
+
+    $records = $sink->recordsForCategory('command.audit_reconcile');
+    expect($records)->toHaveCount(1);
+    expect($records[0]['action'])->toBe('show');
+    expect($records[0]['target_id'])->toBe($id);
+    expect($records[0]['target_category'])->toBe('run.failed');
+    expect($records[0]['target_run_id'])->toBe('r-show');
+    expect($records[0]['prior_attempts'])->toBe(4);
+    expect($records[0])->toHaveKey('target_created_at');
+    expect($records[0])->toHaveKey('target_age_seconds');
+    expect(array_keys($records[0]))->not->toContain('payload');
+    expect(array_keys($records[0]))->not->toContain('reason');
+    expect(array_keys($records[0]))->not->toContain('target_payload_digest');
+});
+
+test('--show --json includes audit_emitted=true on the successful read path', function (): void {
+    reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter');
+
+    Artisan::call('swarm:audit:reconcile', ['--show' => (string) $id, '--json' => true]);
+    $decoded = json_decode(Artisan::output(), true);
+
+    expect($decoded['ok'])->toBeTrue();
+    expect($decoded['audit_emitted'])->toBeTrue();
+});
+
+test('--show exits non-zero with a clear warning when the audit emit fails, but still prints the row', function (): void {
+    $id = seedReconcileRow('dead_letter', ['payload' => ['secret' => 'visible-x']]);
+    bindFailingDispatcher();
+
+    $exit = Artisan::call('swarm:audit:reconcile', ['--show' => (string) $id]);
+
+    expect($exit)->toBe(1);
+    $output = Artisan::output();
+    expect($output)->toContain('visible-x');
+    expect($output)->toContain('Read audit chain is broken');
+});
+
 // -----------------------------------------------------------------------------
 // Requeue
 // -----------------------------------------------------------------------------
@@ -293,6 +342,29 @@ test('--dismiss deletes a dead_letter row and emits the audit record with reason
     expect($records[0]['target_category'])->toBe('run.failed');
     expect($records[0]['prior_attempts'])->toBe(7);
     expect($records[0]['reason'])->toBe('duplicate of run.failed for r-7');
+});
+
+test('--dismiss emits target_payload_digest as sha256 of the stored (sealed) payload bytes', function (): void {
+    config()->set('swarm.persistence.encrypt_at_rest', true);
+    $sink = reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter', [
+        'payload' => ['run_id' => 'r-digest', 'category' => 'run.failed', 'secret' => 'forensic-digest-x'],
+    ]);
+
+    $storedPayload = (string) DB::table('swarm_audit_outbox')->where('id', $id)->value('payload');
+    $expectedDigest = hash('sha256', $storedPayload);
+
+    Artisan::call('swarm:audit:reconcile', [
+        '--dismiss' => (string) $id,
+        '--reason' => 'forensic digest test',
+        '--force' => true,
+    ]);
+
+    $records = $sink->recordsForCategory('command.audit_reconcile');
+    expect($records)->toHaveCount(1);
+    expect($records[0])->toHaveKey('target_payload_digest');
+    expect($records[0]['target_payload_digest'])->toMatch('/^[0-9a-f]{64}$/');
+    expect($records[0]['target_payload_digest'])->toBe($expectedDigest);
 });
 
 test('--dismiss requires --reason and refuses without it', function (): void {

--- a/tests/Feature/SwarmAuditReconcileCommandTest.php
+++ b/tests/Feature/SwarmAuditReconcileCommandTest.php
@@ -6,6 +6,7 @@ use BuiltByBerry\LaravelSwarm\Audit\SwarmAuditDispatcher;
 use BuiltByBerry\LaravelSwarm\Contracts\AuditOutbox;
 use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
 use BuiltByBerry\LaravelSwarm\Persistence\SwarmPersistenceCipher;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\CountingThrowingSink;
 use BuiltByBerry\LaravelSwarm\Tests\Fixtures\RecordingSwarmAuditSink;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
@@ -305,6 +306,48 @@ test('--requeue without --force aborts when no operator confirms (non-interactiv
     expect($sink->recordsForCategory('command.audit_reconcile'))->toHaveCount(0);
 });
 
+test('--requeue --json without --force exits with a force_required error envelope', function (): void {
+    $sink = reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter');
+
+    $exit = Artisan::call('swarm:audit:reconcile', [
+        '--requeue' => (string) $id,
+        '--json' => true,
+    ]);
+
+    expect($exit)->toBe(1);
+
+    $decoded = json_decode(Artisan::output(), true);
+    expect($decoded['ok'])->toBeFalse();
+    expect($decoded['error'])->toBe('force_required');
+    expect($decoded['message'])->toContain('Non-interactive automation requires --force');
+
+    $row = DB::table('swarm_audit_outbox')->where('id', $id)->first();
+    expect($row->status)->toBe('dead_letter');
+    expect($sink->recordsForCategory('command.audit_reconcile'))->toHaveCount(0);
+});
+
+test('--dismiss --json without --force exits with a force_required error envelope', function (): void {
+    $sink = reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter');
+
+    $exit = Artisan::call('swarm:audit:reconcile', [
+        '--dismiss' => (string) $id,
+        '--reason' => 'scripted',
+        '--json' => true,
+    ]);
+
+    expect($exit)->toBe(1);
+
+    $decoded = json_decode(Artisan::output(), true);
+    expect($decoded['ok'])->toBeFalse();
+    expect($decoded['error'])->toBe('force_required');
+    expect($decoded['message'])->toContain('Non-interactive automation requires --force');
+
+    expect(DB::table('swarm_audit_outbox')->where('id', $id)->exists())->toBeTrue();
+    expect($sink->recordsForCategory('command.audit_reconcile'))->toHaveCount(0);
+});
+
 test('--requeue proceeds when confirmation is given interactively', function (): void {
     $sink = reconcileRecordingSink();
     $id = seedReconcileRow('dead_letter');
@@ -488,4 +531,48 @@ test('combining --show with --requeue is rejected', function (): void {
 
     expect($exit)->toBe(1);
     expect(Artisan::output())->toContain('Use only one of');
+});
+
+// -----------------------------------------------------------------------------
+// F6: evidence survives a failing sink under the default queue policy
+// -----------------------------------------------------------------------------
+
+test('--dismiss survives a failing sink under the default queue failure policy and preserves evidence in the outbox', function (): void {
+    config()->set('swarm.audit.failure_policy', 'queue');
+
+    $failingSink = new CountingThrowingSink;
+    app()->instance(SwarmAuditSink::class, $failingSink);
+    app()->forgetInstance(SwarmAuditDispatcher::class);
+
+    $id = seedReconcileRow('dead_letter', [
+        'run_id' => 'r-forensic',
+        'attempts' => 5,
+    ]);
+
+    $exit = Artisan::call('swarm:audit:reconcile', [
+        '--dismiss' => (string) $id,
+        '--reason' => 'forensic test',
+        '--force' => true,
+    ]);
+
+    expect($exit)->toBe(0);
+    expect(DB::table('swarm_audit_outbox')->where('id', $id)->exists())->toBeFalse();
+
+    $reconcileRow = DB::table('swarm_audit_outbox')
+        ->where('category', 'command.audit_reconcile')
+        ->first();
+
+    expect($reconcileRow)->not->toBeNull();
+    expect($reconcileRow->status)->toBe('pending');
+
+    $unsealed = app(SwarmPersistenceCipher::class)->open((string) $reconcileRow->payload);
+    expect($unsealed)->not->toBeNull();
+    $decoded = json_decode((string) $unsealed, true);
+
+    expect($decoded['action'])->toBe('dismiss');
+    expect($decoded['target_id'])->toBe($id);
+    expect($decoded['target_run_id'])->toBe('r-forensic');
+    expect($decoded['prior_attempts'])->toBe(5);
+    expect($decoded['reason'])->toBe('forensic test');
+    expect($decoded)->toHaveKey('target_payload_digest');
 });

--- a/tests/Feature/SwarmAuditStatusCommandTest.php
+++ b/tests/Feature/SwarmAuditStatusCommandTest.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Contracts\AuditOutbox;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+
+beforeEach(function (): void {
+    config()->set('swarm.persistence.driver', 'database');
+    app()->forgetInstance(AuditOutbox::class);
+});
+
+function seedAuditStatusRow(array $attributes): int
+{
+    $now = Carbon::now('UTC');
+
+    return (int) DB::table('swarm_audit_outbox')->insertGetId(array_merge([
+        'category' => 'run.failed',
+        'run_id' => 'r-test',
+        'payload' => json_encode(['run_id' => 'r-test', 'category' => 'run.failed']),
+        'attempts' => 0,
+        'status' => 'pending',
+        'last_error' => null,
+        'last_attempted_at' => null,
+        'reserved_at' => null,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ], $attributes));
+}
+
+test('swarm:audit:status reports zeroed summary against an empty outbox', function (): void {
+    $exitCode = Artisan::call('swarm:audit:status', ['--json' => true]);
+
+    expect($exitCode)->toBe(0);
+
+    $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($payload['ok'])->toBeTrue();
+    expect($payload['store'])->toBe('database');
+    expect($payload['available'])->toBeTrue();
+    expect($payload['counts'])->toBe([
+        'pending' => 0,
+        'reserved' => 0,
+        'stale_reserved' => 0,
+        'dead_letter' => 0,
+    ]);
+    expect($payload['age_distribution']['pending'])->toBe([
+        'lt_1h' => 0,
+        'h1_24' => 0,
+        'd1_7' => 0,
+        'gt_7d' => 0,
+    ]);
+    expect($payload['top_dead_letter_categories'])->toBe([]);
+    expect($payload['oldest']['pending'])->toBeNull();
+    expect($payload['oldest']['dead_letter'])->toBeNull();
+    expect($payload['retention']['dead_letter_retention_days'])->toBeNull();
+    expect($payload['retention']['next_prune_count'])->toBe(0);
+});
+
+test('swarm:audit:status counts pending, reserved, stale_reserved, and dead_letter', function (): void {
+    config()->set('swarm.durable.relay.reservation_timeout_seconds', 60);
+    $now = Carbon::now('UTC');
+
+    seedAuditStatusRow(['status' => 'pending', 'reserved_at' => null]);
+    seedAuditStatusRow(['status' => 'pending', 'reserved_at' => null]);
+    seedAuditStatusRow(['status' => 'pending', 'reserved_at' => $now->copy()->subSeconds(30)]);
+    seedAuditStatusRow(['status' => 'pending', 'reserved_at' => $now->copy()->subSeconds(300)]);
+    seedAuditStatusRow(['status' => 'dead_letter']);
+    seedAuditStatusRow(['status' => 'dead_letter']);
+    seedAuditStatusRow(['status' => 'dead_letter']);
+
+    Artisan::call('swarm:audit:status', ['--json' => true]);
+    $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($payload['counts'])->toBe([
+        'pending' => 2,
+        'reserved' => 2,
+        'stale_reserved' => 1,
+        'dead_letter' => 3,
+    ]);
+});
+
+test('swarm:audit:status buckets pending and dead_letter rows by created_at age', function (): void {
+    $now = Carbon::now('UTC');
+
+    seedAuditStatusRow(['status' => 'pending', 'created_at' => $now->copy()->subMinutes(10)]);
+    seedAuditStatusRow(['status' => 'pending', 'created_at' => $now->copy()->subHours(4)]);
+    seedAuditStatusRow(['status' => 'pending', 'created_at' => $now->copy()->subDays(3)]);
+    seedAuditStatusRow(['status' => 'pending', 'created_at' => $now->copy()->subDays(20)]);
+
+    seedAuditStatusRow(['status' => 'dead_letter', 'created_at' => $now->copy()->subMinutes(5)]);
+    seedAuditStatusRow(['status' => 'dead_letter', 'created_at' => $now->copy()->subDays(2)]);
+    seedAuditStatusRow(['status' => 'dead_letter', 'created_at' => $now->copy()->subDays(40)]);
+    seedAuditStatusRow(['status' => 'dead_letter', 'created_at' => $now->copy()->subDays(40)]);
+
+    Artisan::call('swarm:audit:status', ['--json' => true]);
+    $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($payload['age_distribution']['pending'])->toBe([
+        'lt_1h' => 1,
+        'h1_24' => 1,
+        'd1_7' => 1,
+        'gt_7d' => 1,
+    ]);
+    expect($payload['age_distribution']['dead_letter'])->toBe([
+        'lt_1h' => 1,
+        'h1_24' => 0,
+        'd1_7' => 1,
+        'gt_7d' => 2,
+    ]);
+});
+
+test('swarm:audit:status reports top dead_letter categories sorted by count desc then category', function (): void {
+    foreach (range(1, 4) as $_) {
+        seedAuditStatusRow(['status' => 'dead_letter', 'category' => 'run.failed']);
+    }
+    foreach (range(1, 2) as $_) {
+        seedAuditStatusRow(['status' => 'dead_letter', 'category' => 'tool.invoked']);
+    }
+    seedAuditStatusRow(['status' => 'dead_letter', 'category' => 'guardrail.blocked']);
+    seedAuditStatusRow(['status' => 'dead_letter', 'category' => 'command.relay']);
+    seedAuditStatusRow(['status' => 'dead_letter', 'category' => 'agent.invoked']);
+    seedAuditStatusRow(['status' => 'dead_letter', 'category' => 'something.else']);
+
+    seedAuditStatusRow(['status' => 'pending', 'category' => 'should.not.appear']);
+
+    Artisan::call('swarm:audit:status', ['--json' => true]);
+    $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+    $categories = array_map(fn (array $row): string => $row['category'], $payload['top_dead_letter_categories']);
+    $counts = array_map(fn (array $row): int => $row['count'], $payload['top_dead_letter_categories']);
+
+    expect($categories[0])->toBe('run.failed');
+    expect($counts[0])->toBe(4);
+    expect($categories[1])->toBe('tool.invoked');
+    expect($counts[1])->toBe(2);
+    expect(count($payload['top_dead_letter_categories']))->toBe(5);
+
+    $tail = array_slice($categories, 2);
+    expect($tail)->toBe(['agent.invoked', 'command.relay', 'guardrail.blocked']);
+});
+
+test('swarm:audit:status reports oldest pending and dead_letter row id + age', function (): void {
+    $now = Carbon::now('UTC');
+
+    $newerPending = seedAuditStatusRow(['status' => 'pending', 'created_at' => $now->copy()->subMinutes(5)]);
+    $olderPending = seedAuditStatusRow(['status' => 'pending', 'created_at' => $now->copy()->subDays(3)]);
+
+    $newerDead = seedAuditStatusRow(['status' => 'dead_letter', 'created_at' => $now->copy()->subHours(2)]);
+    $olderDead = seedAuditStatusRow(['status' => 'dead_letter', 'created_at' => $now->copy()->subDays(10)]);
+
+    Artisan::call('swarm:audit:status', ['--json' => true]);
+    $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($payload['oldest']['pending']['id'])->toBe($olderPending);
+    expect($payload['oldest']['pending']['age'])->toBeString();
+    expect($payload['oldest']['dead_letter']['id'])->toBe($olderDead);
+    expect($payload['oldest']['dead_letter']['age'])->toBeString();
+
+    expect($payload['oldest']['pending']['id'])->not->toBe($newerPending);
+    expect($payload['oldest']['dead_letter']['id'])->not->toBe($newerDead);
+});
+
+test('swarm:audit:status reports retention next_prune_count under the configured window', function (): void {
+    config()->set('swarm.audit.outbox.dead_letter_retention_days', 7);
+
+    $now = Carbon::now('UTC');
+
+    seedAuditStatusRow(['status' => 'dead_letter', 'last_attempted_at' => $now->copy()->subDays(10)]);
+    seedAuditStatusRow(['status' => 'dead_letter', 'last_attempted_at' => $now->copy()->subDays(30)]);
+    seedAuditStatusRow(['status' => 'dead_letter', 'last_attempted_at' => $now->copy()->subDays(2)]);
+    seedAuditStatusRow(['status' => 'dead_letter', 'last_attempted_at' => null]);
+
+    Artisan::call('swarm:audit:status', ['--json' => true]);
+    $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($payload['retention']['dead_letter_retention_days'])->toBe(7);
+    expect($payload['retention']['next_prune_count'])->toBe(2);
+});
+
+test('swarm:audit:status reports zero next_prune_count when retention is unconfigured', function (): void {
+    config()->set('swarm.audit.outbox.dead_letter_retention_days', null);
+
+    seedAuditStatusRow(['status' => 'dead_letter', 'last_attempted_at' => Carbon::now('UTC')->subYear()]);
+
+    Artisan::call('swarm:audit:status', ['--json' => true]);
+    $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($payload['retention']['dead_letter_retention_days'])->toBeNull();
+    expect($payload['retention']['next_prune_count'])->toBe(0);
+});
+
+test('swarm:audit:status --json shape stays stable', function (): void {
+    seedAuditStatusRow(['status' => 'pending']);
+    seedAuditStatusRow(['status' => 'dead_letter']);
+
+    Artisan::call('swarm:audit:status', ['--json' => true]);
+    $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+    expect(array_keys($payload))->toBe([
+        'ok',
+        'store',
+        'available',
+        'counts',
+        'age_distribution',
+        'top_dead_letter_categories',
+        'oldest',
+        'retention',
+    ]);
+    expect(array_keys($payload['counts']))->toBe(['pending', 'reserved', 'stale_reserved', 'dead_letter']);
+    expect(array_keys($payload['age_distribution']))->toBe(['pending', 'dead_letter']);
+    expect(array_keys($payload['age_distribution']['pending']))->toBe(['lt_1h', 'h1_24', 'd1_7', 'gt_7d']);
+    expect(array_keys($payload['oldest']))->toBe(['pending', 'dead_letter']);
+    expect(array_keys($payload['retention']))->toBe(['dead_letter_retention_days', 'next_prune_count']);
+});
+
+test('swarm:audit:status degrades on cache persistence without touching the database', function (): void {
+    config()->set('swarm.persistence.driver', 'cache');
+    app()->forgetInstance(AuditOutbox::class);
+
+    DB::enableQueryLog();
+    DB::flushQueryLog();
+
+    $exitCode = Artisan::call('swarm:audit:status', ['--json' => true]);
+
+    expect($exitCode)->toBe(0);
+
+    $payload = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+    expect($payload)->toBe([
+        'ok' => true,
+        'store' => 'cache',
+        'available' => false,
+    ]);
+
+    $queries = collect(DB::getQueryLog())
+        ->reject(fn (array $entry): bool => str_contains(strtolower($entry['query']), 'sqlite_master'))
+        ->filter(fn (array $entry): bool => str_contains(strtolower($entry['query']), 'swarm_audit_outbox'));
+
+    expect($queries)->toBeEmpty();
+
+    DB::disableQueryLog();
+});
+
+test('swarm:audit:status non-JSON output renders Laravel-native sections without errors', function (): void {
+    seedAuditStatusRow(['status' => 'pending']);
+    seedAuditStatusRow(['status' => 'dead_letter', 'category' => 'run.failed']);
+
+    $exitCode = Artisan::call('swarm:audit:status');
+
+    expect($exitCode)->toBe(0);
+
+    $output = Artisan::output();
+    expect($output)->toContain('Audit outbox summary');
+    expect($output)->toContain('Age distribution');
+    expect($output)->toContain('Top dead-letter categories');
+    expect($output)->toContain('Oldest rows');
+    expect($output)->toContain('Retention');
+});

--- a/tests/Fixtures/CountingThrowingSink.php
+++ b/tests/Fixtures/CountingThrowingSink.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures;
+
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
+use RuntimeException;
+
+/**
+ * Test-only audit sink that fails its first N emits, then succeeds.
+ *
+ * Used to exercise sink-failure paths (handler decisions, outbox routing,
+ * retry semantics) without inventing one-off anonymous classes per test.
+ */
+final class CountingThrowingSink implements SwarmAuditSink
+{
+    public int $attempts = 0;
+
+    public function __construct(private readonly int $failFirstN = PHP_INT_MAX) {}
+
+    public function emit(string $category, array $payload): void
+    {
+        $this->attempts++;
+
+        if ($this->attempts <= $this->failFirstN) {
+            throw new RuntimeException("sink failure #{$this->attempts}");
+        }
+    }
+}

--- a/tests/Unit/Audit/SinkFailureHandlerTest.php
+++ b/tests/Unit/Audit/SinkFailureHandlerTest.php
@@ -11,25 +11,10 @@ use BuiltByBerry\LaravelSwarm\Contracts\SinkFailureHandler;
 use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
 use BuiltByBerry\LaravelSwarm\Exceptions\AuditSinkHaltedException;
 use BuiltByBerry\LaravelSwarm\Exceptions\SwarmException;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\CountingThrowingSink;
 use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Support\Facades\Log;
 use Psr\Log\NullLogger;
-
-class CountingThrowingSink implements SwarmAuditSink
-{
-    public int $attempts = 0;
-
-    public function __construct(private readonly int $failFirstN = PHP_INT_MAX) {}
-
-    public function emit(string $category, array $payload): void
-    {
-        $this->attempts++;
-
-        if ($this->attempts <= $this->failFirstN) {
-            throw new RuntimeException("sink failure #{$this->attempts}");
-        }
-    }
-}
 
 class StubFailureHandler implements SinkFailureHandler
 {


### PR DESCRIPTION
## Summary

Umbrella PR for the **v0.6.0** milestone. Theme: operator UX, developer experience, and test coverage on top of the v0.5 audit outbox foundation. No new public-surface contracts; no migration changes; no breaking changes.

Tracks [milestone 0.6.0](https://github.com/builtbyberry/laravel-swarm/milestone/6).

## Component PRs (merge into this branch first)

- [x] #53 — `test(audit): integration coverage for v0.5 outbox flow` (Closes #39)
- [x] #54 — `feat(audit): swarm:audit:status summary command` (Closes #37)
- [ ] #55 — `feat(audit): swarm:audit:reconcile forensic CLI` (Closes #36)

Pending (Batch B — will branch off this release branch):

- [ ] #38 — Pulse audit dashboard parity audit
- [ ] #45 — Operator runbook: audit outbox dead-letter triage
- [ ] #46 — Expanded regulated-workload examples for v0.5 audit chain

## Release wrap (final commits on this branch before merge to main)

- [ ] CHANGELOG.md v0.6.0 entry (currently a stub)
- [ ] UPGRADING.md note (no breaking changes; new operator surfaces)
- [ ] Version bump
- [ ] `/multi-expert-change-review` pass

## Test plan

- [ ] All component PRs CI green before merging into release branch
- [ ] Full `composer test` green on the integrated branch after each merge
- [ ] `composer lint` + `composer analyse` clean on the integrated branch
- [ ] Manual smoke: `php artisan swarm:audit:status` + `swarm:audit:reconcile` against a seeded outbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)