### PR TITLE
docs(examples): v0.5 audit-chain walkthroughs in regulated examples (#46)

### DIFF
--- a/examples/durable-compliance-review/README.md
+++ b/examples/durable-compliance-review/README.md
@@ -54,6 +54,403 @@ emit unsigned evidence or complete a run whose audit trail was discarded.
 See `docs/audit-evidence-contract.md` (Sink Failure Handler) for the full
 contract and custom `SinkFailureHandler` patterns.
 
+## v0.5 Audit Chain Walkthrough
+
+`halt` is still the right setting when you absolutely cannot let a run continue
+without proof of evidence emission. But most regulated workloads now want the
+**default** v0.5 policy, `queue`, which keeps the run moving while persisting
+the failed evidence record to `swarm_audit_outbox` for retry. The package then
+ships with `swarm:audit:status`, `swarm:audit:reconcile`, and the existing
+`swarm:relay --type=audit` lane so operators have a complete forensic loop.
+
+This section walks through that loop end-to-end against a simulated downstream
+sink outage. Everything below is **copy-pasteable** into a Tinker session
+against a database-backed install once you have a sink bound and migrations
+run.
+
+### Baseline Configuration
+
+For a regulated compliance review with the v0.5 default chain, your `.env`
+should look like:
+
+```bash
+SWARM_PERSISTENCE_DRIVER=database
+SWARM_CAPTURE_ACTIVE_CONTEXT=true
+
+# v0.5 defaults — listed explicitly so operators see them in one place
+SWARM_AUDIT_FAILURE_POLICY=queue
+SWARM_ENCRYPT_AT_REST=true
+SWARM_AUDIT_ACTOR_REQUIRED=true
+
+# Audit outbox tuning — keep the retention window inside your compliance
+# review SLA (90 days is a common Part 11-style starting point).
+SWARM_AUDIT_OUTBOX_MAX_ATTEMPTS=5
+SWARM_AUDIT_OUTBOX_DEAD_LETTER_RETENTION_DAYS=90
+```
+
+`failure_policy=queue` is the v0.5 default; `encrypt_at_rest=true` is the
+default on database persistence. They are listed here so the configuration
+surface for regulated callers is visible in one place.
+
+You also need a bound `SwarmAuditSink` (the no-op default does not emit
+anywhere) and a bound `SwarmAuditSigner` so emitted records carry a signature
+under your current key.
+
+### Bind The Sink And Signer
+
+```php
+// app/Providers/AppServiceProvider.php
+namespace App\Providers;
+
+use App\Audit\HmacAuditSigner;
+use App\Audit\HttpAuditSink;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSigner;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
+use Illuminate\Support\ServiceProvider;
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->bind(SwarmAuditSink::class, HttpAuditSink::class);
+
+        $this->app->singleton(
+            SwarmAuditSigner::class,
+            fn () => new HmacAuditSigner(config('audit.hmac_secret')),
+        );
+    }
+}
+```
+
+`HttpAuditSink` is your application's real sink — typically a thin wrapper that
+ships the payload to a SIEM, append-only object store, or signed log service.
+The signer pattern lives in
+[`privacy-capture/README.md`](../privacy-capture/README.md#sign-audit-evidence).
+
+### Simulated Sink Outage
+
+To demonstrate the recovery loop you can substitute a **test-only sink** that
+throws on its first N emit attempts, then succeeds. The package's test suite
+uses `tests/Fixtures/CountingThrowingSink.php` for the same purpose. Examples
+cannot import test fixtures, so define an example-side equivalent:
+
+```php
+// app/Audit/RecoveringSinkDemo.php
+namespace App\Audit;
+
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+
+/**
+ * WHY: This sink exists ONLY to demonstrate the v0.5 audit-outbox recovery
+ * loop. It is not a real sink. It deterministically fails its first N emit
+ * attempts and then begins succeeding — which is exactly the shape of a
+ * downstream incident (a few queued retries, then a recovered sink).
+ *
+ * In a real deployment, your bound sink should be backed by an actual
+ * append-only store; bind THIS class only inside a Tinker session, a feature
+ * test, or a dedicated demo environment.
+ */
+final class RecoveringSinkDemo implements SwarmAuditSink
+{
+    public int $attempts = 0;
+
+    public function __construct(private readonly int $failFirstN = 3) {}
+
+    public function emit(string $category, array $payload): void
+    {
+        $this->attempts++;
+
+        if ($this->attempts <= $this->failFirstN) {
+            Log::warning("RecoveringSinkDemo: simulated failure #{$this->attempts} for {$category}");
+            throw new RuntimeException("simulated sink outage #{$this->attempts}");
+        }
+
+        // After the simulated outage, succeed silently. A real sink would
+        // ship the payload here.
+    }
+}
+```
+
+Bind it in a Tinker session for the duration of the walkthrough:
+
+```php
+use App\Audit\RecoveringSinkDemo;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
+
+app()->singleton(SwarmAuditSink::class, fn () => new RecoveringSinkDemo(failFirstN: 3));
+```
+
+Now dispatch the compliance review:
+
+```php
+use App\Ai\Swarms\ComplianceReviewSwarm;
+use Illuminate\Support\Facades\Context;
+
+Context::add('swarm:actor', auth()->user()); // satisfies actor.required=true
+
+ComplianceReviewSwarm::make()->dispatchDurable([
+    'document_id' => 1234,
+    'document_type' => 'vendor contract',
+    'jurisdiction' => 'US',
+    'review_goal' => 'identify renewal and termination risk',
+]);
+```
+
+The run advances normally — `failure_policy=queue` means audit-sink failures
+**do not halt the swarm**. They land in `swarm_audit_outbox` instead.
+
+### Step 1 — Rows Accumulating During The Outage
+
+After a few lifecycle events have tried to emit (`run.started`,
+`step.completed`, etc.) and the sink has refused them, the outbox starts
+filling up. `swarm:audit:status` is your one-shot summary:
+
+```bash
+php artisan swarm:audit:status
+```
+
+```
+  INFO  Audit outbox summary.
+
+  ----------------------- -------
+   Status                  Count
+  ----------------------- -------
+   pending (unclaimed)     3
+   reserved                0
+     stale (> 120s)        0
+   dead_letter             0
+  ----------------------- -------
+
+  INFO  Age distribution.
+
+  ------------- ------ ------- ------ ------
+   Status        < 1h   1-24h   1-7d   > 7d
+  ------------- ------ ------- ------ ------
+   pending       3      0       0      0
+   dead_letter   0      0       0      0
+  ------------- ------ ------- ------ ------
+
+  INFO  Top dead-letter categories.
+
+  • no dead-letter rows
+
+  INFO  Oldest rows.
+
+  ------------- ----- -----
+   Status        ID    Age
+  ------------- ----- -----
+   pending       12    42s
+   dead_letter   n/a   n/a
+  ------------- ----- -----
+
+  INFO  Retention.
+
+  • dead_letter_retention_days: 90
+  • next-prune count: 0
+```
+
+`swarm:health --audit` raises the same signal in a format suited to a
+healthcheck endpoint or alerting integration:
+
+```bash
+php artisan swarm:health --audit
+```
+
+```
+  -------------------------- ---------- ------- --------- ------------------------------------
+   Component                  Driver     Store   Status    Details
+  -------------------------- ---------- ------- --------- ------------------------------------
+   Audit outbox staleness     database   n/a     ok        3 pending row(s), relay appears active
+   Audit outbox dead-letter   database   n/a     ok        0 dead-letter row(s)
+  -------------------------- ---------- ------- --------- ------------------------------------
+```
+
+If `swarm:relay` is not scheduled (or has stopped running for some reason),
+the staleness check escalates to `warning` after 2× the reservation timeout.
+For Part 11 / regulated callers, treat any staleness warning as page-worthy:
+it means evidence is queued but not draining.
+
+### Step 2 — Recovery Via The Relay
+
+The scheduled `swarm:relay` runs every minute by default. To trigger it
+immediately in the walkthrough:
+
+```bash
+php artisan swarm:relay --type=audit --drain-until-empty
+```
+
+```
+  INFO  Replayed 3 audit records.
+```
+
+The relay calls `RecoveringSinkDemo::emit()` for each pending row. With
+`failFirstN=3` already exhausted by the original synchronous attempts, every
+replay call now succeeds and the rows are deleted from `swarm_audit_outbox`.
+A follow-up `swarm:audit:status` shows an empty outbox.
+
+The `command.relay` audit record itself is emitted at the end of the run with
+`audit_replayed_count`, `audit_dead_lettered_count`, and a `status` field so
+you can audit the recovery action.
+
+### Step 3 — Dead-Letter Triage
+
+To demonstrate the dead-letter path, raise the failure window past
+`max_attempts`. With `SWARM_AUDIT_OUTBOX_MAX_ATTEMPTS=5`, a sink that fails
+six times will push at least one row into `dead_letter` status:
+
+```php
+app()->singleton(SwarmAuditSink::class, fn () => new RecoveringSinkDemo(failFirstN: 999));
+```
+
+Dispatch a run, then drain repeatedly (or wait for the scheduled relay to run
+through five attempts on the same row over its reservation-timeout cycles).
+After the row exceeds `max_attempts`:
+
+```bash
+php artisan swarm:audit:status
+```
+
+```
+  INFO  Audit outbox summary.
+
+  ----------------------- -------
+   Status                  Count
+  ----------------------- -------
+   pending (unclaimed)     0
+   reserved                0
+     stale (> 120s)        0
+   dead_letter             1
+  ----------------------- -------
+
+  INFO  Top dead-letter categories.
+
+  ------------- -------
+   Category      Count
+  ------------- -------
+   run.started   1
+  ------------- -------
+
+  INFO  Oldest rows.
+
+  ------------- ----- ------
+   Status        ID    Age
+  ------------- ----- ------
+   pending       n/a   n/a
+   dead_letter   18    4m
+  ------------- ----- ------
+```
+
+`swarm:health --audit` now warns:
+
+```
+  -------------------------- ---------- ------- ---------- -----------------------------------------------------------------
+   Component                  Driver     Store   Status     Details
+  -------------------------- ---------- ------- ---------- -----------------------------------------------------------------
+   Audit outbox staleness     database   n/a     ok         no pending rows
+   Audit outbox dead-letter   database   n/a     warning    1 dead-letter row(s) — undelivered audit evidence requires operator reconciliation
+  -------------------------- ---------- ------- ---------- -----------------------------------------------------------------
+```
+
+Inspect the row. `--show` unseals the payload from `swarm_audit_outbox`,
+which is normally encrypted at rest, and prints it for human review:
+
+```bash
+php artisan swarm:audit:reconcile --show=18
+```
+
+```
+  -------------- -------------------------------------
+   Field          Value
+  -------------- -------------------------------------
+   ID             18
+   Status         dead_letter
+   Category       run.started
+   Run ID         r-019035fa-b1d2-7c8a-...
+   Attempts       5
+   Created        2026-05-19T14:02:11+00:00
+   Updated        2026-05-19T14:06:48+00:00
+   Last attempted 2026-05-19T14:06:48+00:00
+   Reserved       -
+  -------------- -------------------------------------
+
+  INFO  Last error.
+
+  simulated sink outage #5
+
+  INFO  Payload.
+
+  {
+      "schema_version": "2",
+      "category": "run.started",
+      "occurred_at": "2026-05-19T14:02:11+00:00",
+      "run_id": "r-019035fa-b1d2-7c8a-...",
+      "swarm_class": "App\\Ai\\Swarms\\ComplianceReviewSwarm",
+      "topology": "sequential",
+      "execution_mode": "durable",
+      "actor": {
+          "type": "user",
+          "id": "u-42",
+          "name": "Daniel Berry"
+      },
+      "signature": "...",
+      "signature_algorithm": "HMAC-SHA256",
+      "signed_at": "2026-05-19T14:02:11+00:00"
+   }
+```
+
+Operators now have two choices, both backed by a forced `command.audit_reconcile`
+audit record that is emitted **before** the row is mutated. If that audit emit
+fails, the dead-letter row is left untouched, so reconciliation cannot silently
+erase evidence.
+
+**Requeue** — the downstream sink is restored and you want the relay to
+re-attempt emission. `attempts` is zeroed; `last_error` is preserved as
+forensic context:
+
+```bash
+php artisan swarm:audit:reconcile --requeue=18 --reason="downstream sink restored after vendor outage 2026-05-19"
+```
+
+```
+ Requeue audit outbox row [18] (category=run.started, attempts=5)? (yes/no) [no]:
+ > yes
+
+  INFO  Audit outbox row [18] requeued. Status=pending, attempts=0. last_error preserved for forensics.
+```
+
+**Dismiss** — the record is a verified duplicate, was emitted out-of-band, or
+otherwise cannot be delivered. `--reason` is required:
+
+```bash
+php artisan swarm:audit:reconcile --dismiss=18 --reason="duplicate of run.failed emitted manually via vendor support ticket SUP-4419"
+```
+
+```
+ Permanently delete audit outbox row [18] (category=run.started, run_id=r-019035fa-...)? (yes/no) [no]:
+ > yes
+
+  INFO  Audit outbox row [18] dismissed. A command.audit_reconcile evidence record preserves the deletion.
+```
+
+For scripted recovery (for example, a runbook automation), pass `--force` to
+skip the confirmation prompt. Both sub-modes accept `--json` for machine
+parsing.
+
+### Forward Reference: Operator Runbook
+
+This section is a **demonstration**, not a full runbook. The end-to-end
+operator decision tree for audit-outbox triage — incident playbooks, on-call
+escalation, retention-policy alignment, and chain-of-custody templates — lives
+in [`docs/operator-runbook-audit-outbox.md`](../../docs/operator-runbook-audit-outbox.md)
+(GitHub issue #45).
+
+See also:
+
+- [`docs/audit-evidence-contract.md`](../../docs/audit-evidence-contract.md) — frozen audit evidence and outbox contract.
+- [`docs/maintenance.md`](../../docs/maintenance.md) — `Audit outbox` and `Forensic triage` operations sections.
+
 ## What Durable Changes
 
 `queue()` runs one queued job for the whole swarm. `dispatchDurable()` runs one

--- a/examples/privacy-capture/README.md
+++ b/examples/privacy-capture/README.md
@@ -166,3 +166,96 @@ class HmacAuditSigner implements SwarmAuditSigner
 Implementations must not mutate or remove existing keys. See
 `docs/audit-evidence-contract.md` for the full envelope contract, signing
 scope guidance, and chain-signing patterns.
+
+## v0.5 Audit Chain For Redacted Evidence
+
+Privacy-sensitive workflows lean harder on the v0.5 audit chain than
+non-regulated callers do. With redaction enabled, the audit evidence emitted
+for each run is the **only** durable record of what happened — there is no raw
+prompt or output to fall back on. So the behavior of the bound `SwarmAuditSink`
+under failure becomes a privacy and compliance question, not just an operations
+one.
+
+In v0.5, `SWARM_AUDIT_FAILURE_POLICY` **defaults to `queue`**. That means:
+
+- A sink that throws no longer silently drops the redacted evidence record.
+- Instead, the failed record is persisted to the `swarm_audit_outbox` table
+  for retry via `swarm:relay --type=audit`.
+- When `swarm.persistence.encrypt_at_rest=true` (also the default on database
+  persistence), the persisted `payload` and `last_error` columns are sealed
+  with `SwarmPersistenceCipher` — the same encrypter-backed sealing used
+  elsewhere in the package, scoped to `APP_KEY`.
+
+For a privacy-capture deployment the recommended baseline is:
+
+```bash
+SWARM_PERSISTENCE_DRIVER=database
+SWARM_CAPTURE_INPUTS=false
+SWARM_CAPTURE_OUTPUTS=false
+
+# v0.5 defaults — listed explicitly for the audit chain
+SWARM_AUDIT_FAILURE_POLICY=queue
+SWARM_ENCRYPT_AT_REST=true
+SWARM_AUDIT_OUTBOX_DEAD_LETTER_RETENTION_DAYS=90
+```
+
+### Inspecting Redacted Payloads In The Outbox
+
+When a sink failure persists a record, the redacted shape is preserved. Input
+and output values are still `[redacted]`; the categories, run identifiers, and
+metadata stay queryable for triage:
+
+```bash
+php artisan swarm:audit:status
+```
+
+```
+  INFO  Audit outbox summary.
+
+  ----------------------- -------
+   Status                  Count
+  ----------------------- -------
+   pending (unclaimed)     2
+   reserved                0
+     stale (> 120s)        0
+   dead_letter             0
+  ----------------------- -------
+
+  INFO  Top dead-letter categories.
+
+  • no dead-letter rows
+```
+
+The summary tells operators **how much** redacted evidence is queued and
+**where it is in the lifecycle**, without exposing the payloads themselves —
+which is exactly the layer of indirection privacy-sensitive workloads want
+between routine monitoring and forensic inspection.
+
+### A Privacy Note On `swarm:audit:reconcile --show`
+
+`swarm:audit:reconcile --show=<id>` **unseals** the encrypted-at-rest payload
+and prints it to the terminal for human review:
+
+```bash
+php artisan swarm:audit:reconcile --show=42
+```
+
+In a privacy-capture deployment this command performs a **privileged
+re-disclosure**. The payload itself is already redacted at the field level, so
+input and output values remain `[redacted]`, but metadata, actor identity, and
+correlation IDs become visible. Treat access to `swarm:audit:reconcile --show`
+the same way you treat access to your application's audit-log viewer — log
+the operator who ran it, restrict it to the on-call audit reviewer role, and
+gate it behind your standard privileged-command controls.
+
+`swarm:audit:reconcile --requeue` and `--dismiss` are themselves audited: each
+sub-mode emits a `command.audit_reconcile` evidence record **before** the
+outbox row is mutated. If the audit emit fails the row is left untouched, so
+reconciliation can never silently erase redacted evidence.
+
+For the full forensic loop — including the simulated sink-outage walkthrough,
+recovery via the relay, and dead-letter triage — see
+[`durable-compliance-review/README.md`](../durable-compliance-review/README.md#v05-audit-chain-walkthrough).
+The operator decision tree for audit-outbox triage lives in
+[`docs/operator-runbook-audit-outbox.md`](../../docs/operator-runbook-audit-outbox.md)
+(GitHub issue #45).


### PR DESCRIPTION
## Summary

Extends the two existing regulated-workload examples with end-to-end coverage of the v0.5 default audit chain. No new top-level example directory.

- **`examples/durable-compliance-review/README.md`** — adds a `v0.5 Audit Chain Walkthrough` section with baseline config (`failure_policy=queue`, `encrypt_at_rest=true`, bound signer, 90-day retention), a small example-side `RecoveringSinkDemo` fixture (throws first N then succeeds, with a pedagogical `WHY` comment explaining why this rare in-code comment exists), a simulated sink-outage scenario showing rows accumulating in `swarm_audit_outbox`, sample output from `swarm:audit:status` and `swarm:health --audit`, recovery via `swarm:relay --type=audit`, and a dead-letter triage walkthrough covering `swarm:audit:reconcile --show`, `--requeue`, and `--dismiss --reason`. Cross-links the operator runbook (#45) as a forward reference.
- **`examples/privacy-capture/README.md`** — adds a smaller `v0.5 Audit Chain For Redacted Evidence` section explaining that `failure_policy=queue` now means redacted payloads are persisted to `swarm_audit_outbox` (sealed at rest) instead of silently dropped, sample `swarm:audit:status` output, and a privacy-specific note on `swarm:audit:reconcile --show` unsealing payloads for human review.

Both sections cross-link `docs/audit-evidence-contract.md`, `docs/maintenance.md`, and the forthcoming operator runbook in #45.

## Test plan

- [ ] Review rendered Markdown on the PR page for the two READMEs
- [ ] Verify cross-links resolve: `examples/privacy-capture` → `examples/durable-compliance-review#v05-audit-chain-walkthrough`, both → `docs/audit-evidence-contract.md`, `docs/maintenance.md`, `docs/operator-runbook-audit-outbox.md`
- [ ] Spot-check the command output samples against actual `swarm:audit:status` / `swarm:audit:reconcile --show` output if a database-backed Testbench install is handy
- [ ] Confirm the example-side `RecoveringSinkDemo` shape matches the test fixture pattern (`tests/Fixtures/CountingThrowingSink.php`) without importing it

Closes #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)