### PR TITLE
feat(pulse): AuditOutbox card for v0.5 outbox state (#38)

### DIFF
--- a/docs/pulse.md
+++ b/docs/pulse.md
@@ -59,9 +59,10 @@ Then add the swarm cards to `resources/views/vendor/pulse/dashboard.blade.php`:
 ```blade
 <livewire:swarm.runs cols="6" />
 <livewire:swarm.steps cols="6" />
+<livewire:swarm.audit-outbox cols="6" />
 ```
 
-`<livewire:swarm.runs />` shows per-swarm totals, failures, failure rate, average run duration, and topology mix. `<livewire:swarm.steps />` shows the slowest average swarm steps by agent.
+`<livewire:swarm.runs />` shows per-swarm totals, failures, failure rate, average run duration, and topology mix. `<livewire:swarm.steps />` shows the slowest average swarm steps by agent. `<livewire:swarm.audit-outbox />` surfaces the live operational state of the audit outbox.
 
 ## What Pulse Aggregates
 
@@ -102,9 +103,25 @@ The card shows up to 25 entries sorted by average duration descending — the sl
 
 The `SwarmStepDurations` recorder fires on `SwarmStepCompleted`.
 
+### swarm.audit-outbox card
+
+The `swarm.audit-outbox` card surfaces the live operational state of the v0.5 audit outbox — the same signal an operator would see by running `php artisan swarm:audit:status`. Unlike `swarm.runs` and `swarm.steps`, this card does not depend on a Pulse recorder; the outbox is low-volume operational state, so the card queries the `swarm_audit_outbox` table directly (via the `AuditOutbox` contract / configured table name).
+
+The card surfaces:
+
+- **Dead-letter count** — number of rows in `dead_letter` status. The card renders this prominently in red whenever the count is greater than zero.
+- **Pending count** — total rows in `pending` status, claimed or not.
+- **Stale-pending count** — pending rows with a `reserved_at` older than `2 × swarm.durable.relay.reservation_timeout_seconds`, matching the same heuristic that `swarm:audit:status` and `swarm:health` use to flag a relay that may not be running.
+- **Oldest pending age** and **oldest dead-letter age** — short, human-readable ages for the longest-waiting row in each status.
+- **Dead-letter retention** — the configured `swarm.audit.outbox.dead_letter_retention_days`, or `indefinite` when no retention is configured.
+
+When `swarm.persistence.driver` is not `database`, the `AuditOutbox` contract resolves to `NoOpAuditOutbox::isAvailable() === false` and the card renders a neutral "Audit outbox unavailable on cache persistence driver." state without touching the database.
+
+When the card raises an alarm signal, follow the in-card hint: run `php artisan swarm:audit:status` for the full breakdown (age distribution, top dead-letter categories, oldest IDs), and `php artisan swarm:audit:reconcile` to triage. See [Maintenance](maintenance.md) and [Audit Evidence Contract](audit-evidence-contract.md) for the full operator workflow.
+
 ### Period selectors
 
-Both cards inherit Pulse's standard period controls (1h, 24h, 7d). The period applies to all aggregates on the card simultaneously. Pulse stores bucketed time-series data, so switching periods reloads pre-aggregated buckets rather than scanning raw events.
+The `swarm.runs` and `swarm.steps` cards inherit Pulse's standard period controls (1h, 24h, 7d). The period applies to all aggregates on the card simultaneously. Pulse stores bucketed time-series data, so switching periods reloads pre-aggregated buckets rather than scanning raw events. The `swarm.audit-outbox` card reflects live operational state — period selectors do not apply because the underlying counts are point-in-time queries against the outbox table.
 
 ## Relationship to Telemetry
 

--- a/resources/views/pulse/livewire/audit-outbox.blade.php
+++ b/resources/views/pulse/livewire/audit-outbox.blade.php
@@ -1,0 +1,96 @@
+<x-pulse::card :cols="$cols" :rows="$rows" :class="$class">
+    <x-pulse::card-header
+        name="Swarm Audit Outbox"
+        details="live operational state"
+    >
+        <x-slot:icon>
+            <x-pulse::icons.clipboard />
+        </x-slot:icon>
+    </x-pulse::card-header>
+
+    <x-pulse::scroll :expand="$expand" wire:poll.10s="">
+        @if (! $available)
+            <div class="p-4 text-sm text-gray-500 dark:text-gray-400">
+                Audit outbox unavailable on cache persistence driver.
+                <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                    Switch <code>swarm.persistence.driver</code> to <code>database</code> and run the package migrations to enable it.
+                </p>
+            </div>
+        @else
+            <div class="grid grid-cols-3 gap-3 p-4">
+                <div class="rounded-md p-3 {{ $snapshot->deadLetter > 0 ? 'bg-red-50 dark:bg-red-900/30 ring-1 ring-red-500/40' : 'bg-gray-50 dark:bg-gray-800' }}">
+                    <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Dead-letter</p>
+                    <p class="mt-1 text-2xl font-bold {{ $snapshot->deadLetter > 0 ? 'text-red-700 dark:text-red-300' : 'text-gray-700 dark:text-gray-200' }}">
+                        {{ number_format($snapshot->deadLetter) }}
+                    </p>
+                    @if ($snapshot->deadLetter > 0)
+                        <span class="inline-flex items-center gap-1 mt-1 rounded-full bg-red-100 dark:bg-red-900/60 px-2 py-0.5 text-xs font-medium text-red-700 dark:text-red-200">
+                            attention
+                        </span>
+                    @endif
+                </div>
+
+                <div class="rounded-md p-3 bg-gray-50 dark:bg-gray-800">
+                    <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Pending</p>
+                    <p class="mt-1 text-2xl font-bold text-gray-700 dark:text-gray-200">
+                        {{ number_format($snapshot->pending) }}
+                    </p>
+                </div>
+
+                <div class="rounded-md p-3 {{ $snapshot->stalePending > 0 ? 'bg-amber-50 dark:bg-amber-900/30 ring-1 ring-amber-500/40' : 'bg-gray-50 dark:bg-gray-800' }}">
+                    <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                        Stale pending
+                        <span class="text-[10px] normal-case text-gray-400 dark:text-gray-500">
+                            (&gt; {{ $snapshot->staleWindowSeconds }}s)
+                        </span>
+                    </p>
+                    <p class="mt-1 text-2xl font-bold {{ $snapshot->stalePending > 0 ? 'text-amber-700 dark:text-amber-300' : 'text-gray-700 dark:text-gray-200' }}">
+                        {{ number_format($snapshot->stalePending) }}
+                    </p>
+                    @if ($snapshot->stalePending > 0)
+                        <p class="mt-1 text-xs text-amber-700 dark:text-amber-300">
+                            relay may not be running
+                        </p>
+                    @endif
+                </div>
+            </div>
+
+            <x-pulse::table>
+                <colgroup>
+                    <col width="100%" />
+                    <col width="0%" />
+                </colgroup>
+                <x-pulse::thead>
+                    <tr>
+                        <x-pulse::th>Metric</x-pulse::th>
+                        <x-pulse::th class="text-right">Value</x-pulse::th>
+                    </tr>
+                </x-pulse::thead>
+                <tbody>
+                    <tr>
+                        <x-pulse::td class="text-gray-700 dark:text-gray-300">Oldest pending age</x-pulse::td>
+                        <x-pulse::td numeric class="text-gray-700 dark:text-gray-300">
+                            {{ $snapshot->oldestPendingAge ?? 'n/a' }}
+                        </x-pulse::td>
+                    </tr>
+                    <tr>
+                        <x-pulse::td class="text-gray-700 dark:text-gray-300">Oldest dead-letter age</x-pulse::td>
+                        <x-pulse::td numeric class="text-gray-700 dark:text-gray-300">
+                            {{ $snapshot->oldestDeadLetterAge ?? 'n/a' }}
+                        </x-pulse::td>
+                    </tr>
+                    <tr>
+                        <x-pulse::td class="text-gray-700 dark:text-gray-300">Dead-letter retention</x-pulse::td>
+                        <x-pulse::td numeric class="text-gray-700 dark:text-gray-300">
+                            {{ $snapshot->retentionDays === null ? 'indefinite' : $snapshot->retentionDays.' days' }}
+                        </x-pulse::td>
+                    </tr>
+                </tbody>
+            </x-pulse::table>
+
+            <div class="p-4 text-xs text-gray-500 dark:text-gray-400 border-t border-gray-100 dark:border-gray-800">
+                Run <code>php artisan swarm:audit:status</code> for detail, <code>swarm:audit:reconcile</code> to triage.
+            </div>
+        @endif
+    </x-pulse::scroll>
+</x-pulse::card>

--- a/src/Pulse/Livewire/AuditOutbox.php
+++ b/src/Pulse/Livewire/AuditOutbox.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Pulse\Livewire;
+
+use BuiltByBerry\LaravelSwarm\Contracts\AuditOutbox as AuditOutboxContract;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\View;
+use Laravel\Pulse\Livewire\Card;
+use Livewire\Attributes\Lazy;
+
+/**
+ * @internal
+ */
+#[Lazy]
+class AuditOutbox extends Card
+{
+    public function render(): Renderable
+    {
+        $outbox = app(AuditOutboxContract::class);
+
+        if (! $outbox->isAvailable()) {
+            return View::make('swarm::pulse.livewire.audit-outbox', [
+                'available' => false,
+                'snapshot' => null,
+            ]);
+        }
+
+        $snapshot = $this->resolveSnapshot();
+
+        return View::make('swarm::pulse.livewire.audit-outbox', [
+            'available' => true,
+            'snapshot' => $snapshot,
+        ]);
+    }
+
+    /**
+     * @return object{
+     *     pending: int,
+     *     stalePending: int,
+     *     deadLetter: int,
+     *     oldestPendingAge: ?string,
+     *     oldestDeadLetterAge: ?string,
+     *     retentionDays: ?int,
+     *     staleWindowSeconds: int,
+     * }
+     */
+    protected function resolveSnapshot(): object
+    {
+        $config = app(ConfigRepository::class);
+        $connection = DB::connection();
+
+        $outboxTable = (string) $config->get('swarm.tables.audit_outbox', 'swarm_audit_outbox');
+        $reservationTimeoutSeconds = (int) $config->get('swarm.durable.relay.reservation_timeout_seconds', 60);
+        $retentionDays = $config->get('swarm.audit.outbox.dead_letter_retention_days');
+        $retentionDays = is_int($retentionDays) && $retentionDays > 0 ? $retentionDays : null;
+
+        $now = Carbon::now('UTC');
+        $staleWindowSeconds = $reservationTimeoutSeconds * 2;
+        $staleThreshold = $now->copy()->subSeconds($staleWindowSeconds);
+
+        $pending = $this->outboxQuery($connection, $outboxTable)
+            ->where('status', 'pending')
+            ->count();
+
+        $stalePending = $this->outboxQuery($connection, $outboxTable)
+            ->where('status', 'pending')
+            ->whereNotNull('reserved_at')
+            ->where('reserved_at', '<', $staleThreshold)
+            ->count();
+
+        $deadLetter = $this->outboxQuery($connection, $outboxTable)
+            ->where('status', 'dead_letter')
+            ->count();
+
+        return (object) [
+            'pending' => $pending,
+            'stalePending' => $stalePending,
+            'deadLetter' => $deadLetter,
+            'oldestPendingAge' => $this->oldestAge($connection, $outboxTable, 'pending', $now),
+            'oldestDeadLetterAge' => $this->oldestAge($connection, $outboxTable, 'dead_letter', $now),
+            'retentionDays' => $retentionDays,
+            'staleWindowSeconds' => $staleWindowSeconds,
+        ];
+    }
+
+    protected function oldestAge(ConnectionInterface $connection, string $outboxTable, string $status, Carbon $now): ?string
+    {
+        $row = $this->outboxQuery($connection, $outboxTable)
+            ->where('status', $status)
+            ->orderBy('created_at')
+            ->orderBy('id')
+            ->first(['created_at']);
+
+        if ($row === null) {
+            return null;
+        }
+
+        return Carbon::parse($row->created_at, 'UTC')->diffForHumans($now, [
+            'parts' => 2,
+            'short' => true,
+            'syntax' => Carbon::DIFF_ABSOLUTE,
+        ]);
+    }
+
+    protected function outboxQuery(ConnectionInterface $connection, string $outboxTable): Builder
+    {
+        return $connection->table($outboxTable);
+    }
+}

--- a/src/SwarmServiceProvider.php
+++ b/src/SwarmServiceProvider.php
@@ -51,6 +51,7 @@ use BuiltByBerry\LaravelSwarm\Persistence\DatabaseDurableRunStore;
 use BuiltByBerry\LaravelSwarm\Persistence\DatabaseRunHistoryStore;
 use BuiltByBerry\LaravelSwarm\Persistence\DatabaseStreamEventStore;
 use BuiltByBerry\LaravelSwarm\Persistence\SwarmPersistenceCipher;
+use BuiltByBerry\LaravelSwarm\Pulse\Livewire\AuditOutbox as AuditOutboxCard;
 use BuiltByBerry\LaravelSwarm\Pulse\Livewire\SwarmRuns;
 use BuiltByBerry\LaravelSwarm\Pulse\Livewire\SwarmSteps;
 use BuiltByBerry\LaravelSwarm\Runners\DispatchValidator;
@@ -255,6 +256,7 @@ class SwarmServiceProvider extends ServiceProvider
             $this->callAfterResolving('livewire', function (LivewireManager $livewire): void {
                 $livewire->component('swarm.runs', SwarmRuns::class);
                 $livewire->component('swarm.steps', SwarmSteps::class);
+                $livewire->component('swarm.audit-outbox', AuditOutboxCard::class);
             });
         }
 

--- a/tests/Feature/PulseAuditOutboxCardTest.php
+++ b/tests/Feature/PulseAuditOutboxCardTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Contracts\AuditOutbox;
+use BuiltByBerry\LaravelSwarm\Pulse\Livewire\AuditOutbox as AuditOutboxCard;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
+
+beforeEach(function (): void {
+    config()->set('swarm.persistence.driver', 'database');
+    app()->forgetInstance(AuditOutbox::class);
+});
+
+function seedCardOutboxRow(array $attributes = []): int
+{
+    $now = Carbon::now('UTC');
+
+    return (int) DB::table('swarm_audit_outbox')->insertGetId(array_merge([
+        'category' => 'run.failed',
+        'run_id' => 'r-card-test',
+        'payload' => json_encode(['run_id' => 'r-card-test', 'category' => 'run.failed']),
+        'attempts' => 0,
+        'status' => 'pending',
+        'last_error' => null,
+        'last_attempted_at' => null,
+        'reserved_at' => null,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ], $attributes));
+}
+
+test('audit outbox card renders zero counts with no alarm against an empty outbox', function (): void {
+    Livewire::withoutLazyLoading();
+
+    Livewire::test('swarm.audit-outbox')
+        ->assertSee('Swarm Audit Outbox')
+        ->assertSee('Dead-letter')
+        ->assertSee('Pending')
+        ->assertSee('Stale pending')
+        ->assertDontSee('attention')
+        ->assertDontSee('relay may not be running')
+        ->assertSee('indefinite');
+});
+
+test('audit outbox card surfaces pending, dead-letter, and stale counts and raises alarm for dead-letter rows', function (): void {
+    config()->set('swarm.durable.relay.reservation_timeout_seconds', 60);
+
+    $now = Carbon::now('UTC');
+    $staleReservedAt = $now->copy()->subSeconds(60 * 2 + 10);
+
+    seedCardOutboxRow(['status' => 'pending']);
+    seedCardOutboxRow(['status' => 'pending']);
+    seedCardOutboxRow(['status' => 'pending', 'reserved_at' => $staleReservedAt]);
+    seedCardOutboxRow(['status' => 'dead_letter']);
+    seedCardOutboxRow(['status' => 'dead_letter']);
+
+    Livewire::withoutLazyLoading();
+
+    Livewire::test('swarm.audit-outbox')
+        ->assertSee('Swarm Audit Outbox')
+        ->assertSeeInOrder(['Dead-letter', '2'])
+        ->assertSeeInOrder(['Pending', '3'])
+        ->assertSeeInOrder(['Stale pending', '1'])
+        ->assertSee('attention')
+        ->assertSee('relay may not be running');
+});
+
+test('audit outbox card honours configured dead-letter retention setting', function (): void {
+    config()->set('swarm.audit.outbox.dead_letter_retention_days', 14);
+
+    Livewire::withoutLazyLoading();
+
+    Livewire::test('swarm.audit-outbox')
+        ->assertSee('14 days');
+});
+
+test('audit outbox card renders unavailable state on cache driver without querying the database', function (): void {
+    config()->set('swarm.persistence.driver', 'cache');
+    app()->forgetInstance(AuditOutbox::class);
+
+    DB::connection()->enableQueryLog();
+    DB::connection()->flushQueryLog();
+
+    Livewire::withoutLazyLoading();
+
+    Livewire::test('swarm.audit-outbox')
+        ->assertSee('Audit outbox unavailable on cache persistence driver.');
+
+    $queries = DB::connection()->getQueryLog();
+    $outboxQueries = array_filter(
+        $queries,
+        fn (array $query): bool => str_contains((string) $query['query'], 'swarm_audit_outbox'),
+    );
+
+    expect($outboxQueries)->toBe([]);
+});
+
+test('audit outbox card resolveSnapshot reports correct oldest ages and counts', function (): void {
+    $now = Carbon::now('UTC');
+
+    DB::table('swarm_audit_outbox')->insert([
+        [
+            'category' => 'run.failed',
+            'run_id' => 'r1',
+            'payload' => json_encode(['run_id' => 'r1']),
+            'attempts' => 0,
+            'status' => 'pending',
+            'last_error' => null,
+            'last_attempted_at' => null,
+            'reserved_at' => null,
+            'created_at' => $now->copy()->subHours(3),
+            'updated_at' => $now->copy()->subHours(3),
+        ],
+        [
+            'category' => 'run.failed',
+            'run_id' => 'r2',
+            'payload' => json_encode(['run_id' => 'r2']),
+            'attempts' => 3,
+            'status' => 'dead_letter',
+            'last_error' => 'boom',
+            'last_attempted_at' => $now->copy()->subDays(2),
+            'reserved_at' => null,
+            'created_at' => $now->copy()->subDays(2),
+            'updated_at' => $now->copy()->subDays(2),
+        ],
+    ]);
+
+    $card = new class extends AuditOutboxCard
+    {
+        public function snapshot(): object
+        {
+            return $this->resolveSnapshot();
+        }
+    };
+
+    $snapshot = $card->snapshot();
+
+    expect($snapshot->pending)->toBe(1);
+    expect($snapshot->deadLetter)->toBe(1);
+    expect($snapshot->stalePending)->toBe(0);
+    expect($snapshot->oldestPendingAge)->not->toBeNull();
+    expect($snapshot->oldestDeadLetterAge)->not->toBeNull();
+});


### PR DESCRIPTION
Closes #38.

## Survey

The package's existing Pulse Livewire cards live in `src/Pulse/Livewire/`:

- **`SwarmRuns`** — queries Pulse aggregates (`swarm_run_total`, `swarm_run_failed`, topology counters, duration totals/samples) via `aggregateTypes(...)`. Surfaces per-swarm totals, failures, failure rate, average duration, topology mix.
- **`SwarmSteps`** — queries the `swarm_step_duration` Pulse aggregate via `aggregate('swarm_step_duration', ['avg', 'count'], ...)`. Surfaces per-(swarm, agent) average step duration and sample count.

Confirmed: neither card touches the audit outbox. There is no operational health surface for the v0.5 audit outbox in Pulse today.

## Decision

Add a new `swarm.audit-outbox` card. The existing cards are untouched (public surface stability). The new card does **not** add a Pulse recorder — the outbox is low-volume operational state, not aggregate telemetry, so it should be queried live the same way `swarm:audit:status` and `swarm:health` already do.

## Summary

- New `BuiltByBerry\\LaravelSwarm\\Pulse\\Livewire\\AuditOutbox` Livewire card, registered as `swarm.audit-outbox`. Extends `Laravel\\Pulse\\Livewire\\Card` and uses the same `#[Lazy]` shape as the existing cards.
- Surfaces, in priority order: dead-letter count (with red alarm chip when > 0), pending count, stale-pending count using the existing `2 × swarm.durable.relay.reservation_timeout_seconds` heuristic, oldest pending / dead-letter ages, configured `dead_letter_retention_days`, and a footer pointing to `swarm:audit:status` / `swarm:audit:reconcile`.
- Cache-driver guard: when `AuditOutbox::isAvailable()` returns false (NoOpAuditOutbox path), renders a neutral degraded state. No DB query is issued.
- New Blade view `resources/views/pulse/livewire/audit-outbox.blade.php` matches the existing card aesthetic.
- `docs/pulse.md` updated with a new `swarm.audit-outbox card` section, install snippet, alarm semantics, and links to maintenance / audit-evidence docs.

## Test plan

- [x] `composer test` — full suite, 807 passed
- [x] `composer lint` — Pint passed
- [x] `composer analyse` — PHPStan no errors
- [x] New `tests/Feature/PulseAuditOutboxCardTest.php` covers:
  - Empty outbox renders zero counts with no alarm
  - Mixed pending / stale-pending / dead-letter rows produce correct counts and raise the dead-letter and stale-pending alarms
  - Configured `dead_letter_retention_days` shows up on the card
  - Cache-driver path renders the unavailable message and issues no queries against `swarm_audit_outbox` (asserted via `enableQueryLog()`)
  - `resolveSnapshot()` reports correct counts and ages with seeded rows