### PR TITLE
chore(audit): v0.6.0 review followups (F1-F7)

### DIFF
--- a/docs/audit-evidence-contract.md
+++ b/docs/audit-evidence-contract.md
@@ -204,6 +204,7 @@ advance execution.
 | `command.recover` | `swarm:recover` was invoked. Includes `recovered_count` and `recovered_run_ids`. |
 | `command.relay`   | `swarm:relay` completed or failed. Always includes `dispatched_count`, `skipped_count`, `failed_count`, `claimed_count` (rows reserved in phase 1), `reclaimed_count` (of those, rows with a stale prior reservation), `types`, `limit`, `drain_until_empty`, `max_attempts` (null when not set), and `attempts` (number of drain iterations executed). As of v0.5.0, also always includes `audit_replayed_count` (audit records successfully re-emitted through the bound sink during this drain) and `audit_dead_lettered_count` (audit records that exhausted `swarm.audit.outbox.max_attempts` during this drain and moved to dead-letter status). Status values: `dispatched` (at least one entry dispatched or audit record replayed, no transient failures at exit); `skipped` (only permanently invalid entries processed, none dispatched); `none_found` (both outboxes were empty); `transient_failure` (one or more entries could not be dispatched due to a transient queue error — `failed_count` is > 0, entries remain in the outbox for reclaim); `error` (an unhandled exception escaped the drain loop — includes `exception_class`). Note: `exception_class` is present only on `status: "error"` events. Individual `run_id`s of permanently deleted rows (counted in `skipped_count`) are not in the audit payload — they are in the application error tracker via `report()`, where the exception message includes the outbox entry ID. Cross-reference by entry ID for post-incident reconstruction. |
 | `command.prune`   | `swarm:prune` completed. Includes `dry_run`, `prevent_prune`, `status`, and `counts` (row counts per table). |
+| `command.audit_reconcile` | Emitted on every `--requeue`, `--dismiss`, or `--show` of an audit outbox row by `swarm:audit:reconcile` (v0.6.0+). Chain-of-custody for operator triage actions. `--show` emits with `action=show` and no `payload` contents — reads are at least counted. `--dismiss` includes `target_payload_digest` (sha256 of the stored payload bytes) so the deleted row can be tied back to a forensic backup of the table without unsealing it. |
 
 All command categories carry actor identity under `metadata.actor` as an
 `Actor` value object array — typically `{id: "artisan", type: "system"}`.
@@ -446,6 +447,7 @@ Additional frozen fields by category:
 | `command.recover` |
 | `command.relay`   |
 | `command.prune`   |
+| `command.audit_reconcile` |
 
 Every `command.*` event carries:
 
@@ -464,6 +466,7 @@ Additional frozen fields by category:
 | `command.recover` | `target_run_id` (string&#124;null), `target_swarm_class` (string&#124;null). On success: `recovered_count` (int), `recovered_run_ids` (array&lt;string&gt;). On failure: `exception_class` (string). |
 | `command.relay`   | `types` (array&lt;string&gt;), `limit` (int), `drain_until_empty` (bool), `max_attempts` (int&#124;null), `attempts` (int), `dispatched_count` (int), `skipped_count` (int), `failed_count` (int), `claimed_count` (int), `reclaimed_count` (int), `audit_replayed_count` (int, v0.5.0+), `audit_dead_lettered_count` (int, v0.5.0+). |
 | `command.prune`   | `dry_run` (bool), `prevent_prune` (bool), `counts` (array&lt;string, int&gt;).                                    |
+| `command.audit_reconcile` | `action` (string, one of `requeue`, `dismiss`, `show`), `target_id` (int), `target_category` (string), `target_run_id` (string&#124;null), `prior_attempts` (int), `target_created_at` (ISO 8601 string), `target_age_seconds` (int). `reason` (string) is required on `dismiss`, optional on `requeue`, and omitted on `show`. `target_payload_digest` (sha256 hex string) is present on `dismiss` only — computed over the stored (sealed or plaintext fallback) payload bytes so an auditor can verify the deletion against a forensic backup without unsealing. v0.6.0+. |
 
 #### Webhook Idempotency
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -342,9 +342,15 @@ recovery. Every sub-mode accepts `--json` for automation.
 
 Every requeue or dismiss emits a `command.audit_reconcile` audit record
 carrying `action`, `target_id`, `target_category`, `target_run_id`,
-`prior_attempts`, and `reason` **before** mutating the row. If the
-audit emit fails the row is left untouched, so reconciliation cannot
-silently erase evidence.
+`prior_attempts`, and `reason` **before** mutating the row. `--show`
+emits the same category with `action=show` and no payload contents so
+reads are counted in the audit chain. Dismiss emits also include a
+`target_payload_digest` (sha256 hex of the stored payload bytes) so the
+deleted row can be tied back to a forensic backup of the table without
+unsealing. If the audit emit fails outright (for example under
+`failure_policy=halt`), the row is left untouched. Under the default
+`queue` policy, the reconcile record is itself enqueued for retry —
+evidence is preserved in the outbox even when the sink is unavailable.
 
 ## High-volume dashboards
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -338,7 +338,10 @@ php artisan swarm:audit:reconcile --dismiss=42 --reason="duplicate of r-7"
 Pending rows can be listed and shown but cannot be requeued or
 dismissed; the relay owns their lifecycle. Both `--requeue` and
 `--dismiss` prompt for confirmation; use `--force` for scripted
-recovery. Every sub-mode accepts `--json` for automation.
+recovery. Every sub-mode accepts `--json` for automation. When
+scripting a loop with `--json`, also pass `--force` to confirm
+requeue/dismiss; without it the command exits with a `force_required`
+error envelope rather than silently aborting.
 
 Every requeue or dismiss emits a `command.audit_reconcile` audit record
 carrying `action`, `target_id`, `target_category`, `target_run_id`,

--- a/docs/operator-runbook-audit-outbox.md
+++ b/docs/operator-runbook-audit-outbox.md
@@ -116,8 +116,10 @@ Action:
 
    For more than a handful of rows, script the loop using
    `swarm:audit:reconcile --status=dead_letter --json --limit=200` and
-   feed the IDs into `--requeue=<id>` calls. Use `--force` to skip the
-   interactive confirm.
+   feed the IDs into `--requeue=<id>` calls. Pass `--force` on each
+   call to confirm requeue/dismiss; without it `--json` mutations exit
+   with a `force_required` error envelope rather than silently
+   aborting.
 
 #### Branch C — Evidence is legitimately undeliverable and not worth retrying
 

--- a/docs/operator-runbook-audit-outbox.md
+++ b/docs/operator-runbook-audit-outbox.md
@@ -52,6 +52,26 @@ php artisan swarm:audit:reconcile --show=<id>
 This unseals the payload and prints `last_error`. Read both. The error
 string is the sink's verbatim rejection.
 
+#### Audit trail of reads
+
+Every `--show` invocation emits a `command.audit_reconcile` evidence
+record with `action=show` so reads are counted in the audit chain. The
+emit carries `target_id`, `target_category`, `target_run_id`,
+`prior_attempts`, `target_created_at`, and `target_age_seconds` — but no
+payload contents and no `reason` (reads do not require justification,
+only accounting).
+
+Shell access to `swarm:audit:reconcile --show` is operator-trusted.
+Treat the command's reach the same way you treat database read access.
+The audit emit accounts for individual reads but does not authorize
+them — host-access controls are still where you gate who can run this
+in the first place.
+
+If the audit sink itself is unavailable when you run `--show`, the
+command still prints the row (read-only, already in memory) but exits
+non-zero with a clear warning so the broken audit chain is visible.
+Rerun once the sink recovers.
+
 ### Step 3 — Decide
 
 Match `last_error` (and, if needed, the sink's own logs) against the

--- a/docs/operator-runbook-audit-outbox.md
+++ b/docs/operator-runbook-audit-outbox.md
@@ -134,9 +134,12 @@ php artisan swarm:audit:reconcile --dismiss=<id> --reason="dev-env test run; sin
 
 `--reason` is required. The dismissal emits a `command.audit_reconcile`
 audit record (with `action`, `target_id`, `target_category`,
-`target_run_id`, `prior_attempts`, and `reason`) **before** deleting the
-row. If that audit emit fails, the row is left untouched — dismissal cannot
-silently erase evidence.
+`target_run_id`, `prior_attempts`, `reason`, and `target_payload_digest`)
+**before** deleting the row. If the audit emit fails outright (for example
+under `failure_policy=halt`), the row is left untouched. Under the default
+`queue` policy, the reconcile record is itself enqueued for retry —
+evidence is preserved in the outbox even when the sink is unavailable, so
+dismissal never silently erases evidence.
 
 For regulated workloads, document the dismissal in your operations log
 alongside the audit chain-of-custody record. "Consult your compliance

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,4 +19,3 @@ parameters:
                 - src/Persistence/DatabaseRunHistoryStore.php
                 - src/Persistence/DatabaseContextStore.php
                 - src/Pulse/Livewire/SwarmSteps.php
-                - src/Commands/SwarmAuditReconcileCommand.php

--- a/src/Commands/SwarmAuditReconcileCommand.php
+++ b/src/Commands/SwarmAuditReconcileCommand.php
@@ -131,7 +131,7 @@ class SwarmAuditReconcileCommand extends Command
         $rows = $rows->take($limit);
 
         $now = Carbon::now('UTC');
-        $records = $rows->map(fn (object $row): array => [
+        $records = $rows->map(fn (\stdClass $row): array => [
             'id' => (int) $row->id,
             'status' => (string) $row->status,
             'category' => (string) $row->category,
@@ -357,7 +357,7 @@ class SwarmAuditReconcileCommand extends Command
         return self::SUCCESS;
     }
 
-    protected function emitReconcileAudit(SwarmAuditDispatcher $audit, string $action, object $row, int $priorAttempts, ?string $reason): bool
+    protected function emitReconcileAudit(SwarmAuditDispatcher $audit, string $action, \stdClass $row, int $priorAttempts, ?string $reason): bool
     {
         $this->reconcileAuditError = null;
 
@@ -420,17 +420,17 @@ class SwarmAuditReconcileCommand extends Command
         return self::FAILURE;
     }
 
-    protected function findRow(ConfigRepository $config, Connection $connection, int $id): ?object
+    protected function findRow(ConfigRepository $config, Connection $connection, int $id): ?\stdClass
     {
         $row = $connection->table($this->tableName($config))->where('id', $id)->first();
 
-        return is_object($row) ? $row : null;
+        return $row instanceof \stdClass ? $row : null;
     }
 
     /**
      * @return array<string, mixed>|string|null
      */
-    protected function decodePayload(SwarmPersistenceCipher $cipher, object $row): array|string|null
+    protected function decodePayload(SwarmPersistenceCipher $cipher, \stdClass $row): array|string|null
     {
         $raw = is_string($row->payload) ? $cipher->open($row->payload) : null;
 
@@ -447,7 +447,7 @@ class SwarmAuditReconcileCommand extends Command
         return is_array($decoded) ? $decoded : $raw;
     }
 
-    protected function decodeLastError(SwarmPersistenceCipher $cipher, object $row): ?string
+    protected function decodeLastError(SwarmPersistenceCipher $cipher, \stdClass $row): ?string
     {
         if (! is_string($row->last_error) || $row->last_error === '') {
             return null;

--- a/src/Commands/SwarmAuditReconcileCommand.php
+++ b/src/Commands/SwarmAuditReconcileCommand.php
@@ -21,6 +21,8 @@ class SwarmAuditReconcileCommand extends Command
 {
     use ResolvesStringConsoleInput;
 
+    protected ?string $reconcileAuditError = null;
+
     protected $signature = 'swarm:audit:reconcile
                             {--show= : Print full metadata and unsealed payload for the given outbox id.}
                             {--requeue= : Reset a dead_letter row to pending so the relay re-attempts emission.}
@@ -97,7 +99,7 @@ class SwarmAuditReconcileCommand extends Command
         }
 
         return match ($mode) {
-            'show' => $this->runShow($config, $connection, $cipher, $id),
+            'show' => $this->runShow($config, $connection, $cipher, $audit, $id),
             'requeue' => $this->runRequeue($config, $connection, $audit, $id),
             'dismiss' => $this->runDismiss($config, $connection, $audit, $id),
             default => self::FAILURE,
@@ -178,7 +180,7 @@ class SwarmAuditReconcileCommand extends Command
         return self::SUCCESS;
     }
 
-    protected function runShow(ConfigRepository $config, Connection $connection, SwarmPersistenceCipher $cipher, int $id): int
+    protected function runShow(ConfigRepository $config, Connection $connection, SwarmPersistenceCipher $cipher, SwarmAuditDispatcher $audit, int $id): int
     {
         $row = $this->findRow($config, $connection, $id);
 
@@ -203,10 +205,16 @@ class SwarmAuditReconcileCommand extends Command
             'payload' => $payload,
         ];
 
-        if ($this->option('json') === true) {
-            $this->writeJson(['ok' => true, 'row' => $detail]);
+        $auditEmitted = $this->emitReconcileAudit($audit, 'show', $row, (int) $row->attempts, null);
 
-            return self::SUCCESS;
+        if ($this->option('json') === true) {
+            $this->writeJson([
+                'ok' => $auditEmitted,
+                'row' => $detail,
+                'audit_emitted' => $auditEmitted,
+            ]);
+
+            return $auditEmitted ? self::SUCCESS : self::FAILURE;
         }
 
         $this->table(['Field', 'Value'], [
@@ -228,6 +236,12 @@ class SwarmAuditReconcileCommand extends Command
         $this->line('');
         $this->components->info('Payload');
         $this->line($this->prettyJson($payload));
+
+        if (! $auditEmitted) {
+            $this->components->warn('Read audit chain is broken: command.audit_reconcile emit failed. The row above was already in memory; rerun once the audit sink is healthy.');
+
+            return self::FAILURE;
+        }
 
         return self::SUCCESS;
     }
@@ -253,7 +267,10 @@ class SwarmAuditReconcileCommand extends Command
         $priorAttempts = (int) $row->attempts;
 
         if (! $this->emitReconcileAudit($audit, 'requeue', $row, $priorAttempts, $reason)) {
-            return self::FAILURE;
+            return $this->failWith(
+                "Failed to emit command.audit_reconcile evidence: {$this->reconcileAuditError}. "
+                .'The outbox row was NOT modified.',
+            );
         }
 
         $connection->table($this->tableName($config))
@@ -307,7 +324,10 @@ class SwarmAuditReconcileCommand extends Command
         $priorAttempts = (int) $row->attempts;
 
         if (! $this->emitReconcileAudit($audit, 'dismiss', $row, $priorAttempts, $reason)) {
-            return self::FAILURE;
+            return $this->failWith(
+                "Failed to emit command.audit_reconcile evidence: {$this->reconcileAuditError}. "
+                .'The outbox row was NOT modified.',
+            );
         }
 
         $connection->table($this->tableName($config))->where('id', $id)->delete();
@@ -331,6 +351,8 @@ class SwarmAuditReconcileCommand extends Command
 
     protected function emitReconcileAudit(SwarmAuditDispatcher $audit, string $action, object $row, int $priorAttempts, ?string $reason): bool
     {
+        $this->reconcileAuditError = null;
+
         $actorMetadata = ['actor' => Actor::system('artisan')->toArray()];
         $now = Carbon::now('UTC');
 
@@ -340,21 +362,26 @@ class SwarmAuditReconcileCommand extends Command
             'target_category' => (string) $row->category,
             'target_run_id' => $row->run_id !== null ? (string) $row->run_id : null,
             'prior_attempts' => $priorAttempts,
-            'reason' => $reason,
             'target_created_at' => $this->formatTimestamp($row->created_at),
             'target_age_seconds' => $this->ageSeconds($row->created_at, $now),
-            ...$audit->metadata($actorMetadata),
         ];
+
+        if ($action !== 'show') {
+            $payload['reason'] = $reason;
+        }
+
+        if ($action === 'dismiss') {
+            $payload['target_payload_digest'] = hash('sha256', is_string($row->payload) ? $row->payload : '');
+        }
+
+        $payload = [...$payload, ...$audit->metadata($actorMetadata)];
 
         try {
             $audit->emit('command.audit_reconcile', $payload);
 
             return true;
         } catch (Throwable $exception) {
-            $this->failWith(
-                "Failed to emit command.audit_reconcile evidence: {$exception->getMessage()}. "
-                .'The outbox row was NOT modified.',
-            );
+            $this->reconcileAuditError = $exception->getMessage();
 
             return false;
         }

--- a/src/Commands/SwarmAuditReconcileCommand.php
+++ b/src/Commands/SwarmAuditReconcileCommand.php
@@ -248,6 +248,10 @@ class SwarmAuditReconcileCommand extends Command
 
     protected function runRequeue(ConfigRepository $config, Connection $connection, SwarmAuditDispatcher $audit, int $id): int
     {
+        if (($forceFailure = $this->requireForceForJsonMutation()) !== null) {
+            return $forceFailure;
+        }
+
         $row = $this->findRow($config, $connection, $id);
 
         if ($row === null) {
@@ -301,6 +305,10 @@ class SwarmAuditReconcileCommand extends Command
 
     protected function runDismiss(ConfigRepository $config, Connection $connection, SwarmAuditDispatcher $audit, int $id): int
     {
+        if (($forceFailure = $this->requireForceForJsonMutation()) !== null) {
+            return $forceFailure;
+        }
+
         $reason = $this->optionalOptionString('reason');
 
         if ($reason === null || trim($reason) === '') {
@@ -393,15 +401,23 @@ class SwarmAuditReconcileCommand extends Command
             return true;
         }
 
-        if ($this->option('json') === true) {
-            return false;
-        }
-
-        if (! $this->input->isInteractive()) {
+        if (! $this->input->isInteractive() || $this->option('json') === true) {
             return false;
         }
 
         return $this->confirm($prompt, false);
+    }
+
+    protected function requireForceForJsonMutation(): ?int
+    {
+        if ($this->option('json') !== true || $this->option('force') === true) {
+            return null;
+        }
+
+        $message = 'Non-interactive automation requires --force to confirm requeue/dismiss.';
+        $this->writeJson(['ok' => false, 'error' => 'force_required', 'message' => $message]);
+
+        return self::FAILURE;
     }
 
     protected function findRow(ConfigRepository $config, Connection $connection, int $id): ?object

--- a/tests/Feature/SwarmAuditReconcileCommandTest.php
+++ b/tests/Feature/SwarmAuditReconcileCommandTest.php
@@ -181,6 +181,55 @@ test('--show with an unknown id returns a clear error', function (): void {
     expect(Artisan::output())->toContain('not found');
 });
 
+test('--show emits a command.audit_reconcile evidence record with action=show and no payload contents', function (): void {
+    $sink = reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter', [
+        'attempts' => 4,
+        'run_id' => 'r-show',
+        'payload' => ['run_id' => 'r-show', 'category' => 'run.failed', 'secret' => 'should-not-leak'],
+    ]);
+
+    $exit = Artisan::call('swarm:audit:reconcile', ['--show' => (string) $id]);
+
+    expect($exit)->toBe(0);
+
+    $records = $sink->recordsForCategory('command.audit_reconcile');
+    expect($records)->toHaveCount(1);
+    expect($records[0]['action'])->toBe('show');
+    expect($records[0]['target_id'])->toBe($id);
+    expect($records[0]['target_category'])->toBe('run.failed');
+    expect($records[0]['target_run_id'])->toBe('r-show');
+    expect($records[0]['prior_attempts'])->toBe(4);
+    expect($records[0])->toHaveKey('target_created_at');
+    expect($records[0])->toHaveKey('target_age_seconds');
+    expect(array_keys($records[0]))->not->toContain('payload');
+    expect(array_keys($records[0]))->not->toContain('reason');
+    expect(array_keys($records[0]))->not->toContain('target_payload_digest');
+});
+
+test('--show --json includes audit_emitted=true on the successful read path', function (): void {
+    reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter');
+
+    Artisan::call('swarm:audit:reconcile', ['--show' => (string) $id, '--json' => true]);
+    $decoded = json_decode(Artisan::output(), true);
+
+    expect($decoded['ok'])->toBeTrue();
+    expect($decoded['audit_emitted'])->toBeTrue();
+});
+
+test('--show exits non-zero with a clear warning when the audit emit fails, but still prints the row', function (): void {
+    $id = seedReconcileRow('dead_letter', ['payload' => ['secret' => 'visible-x']]);
+    bindFailingDispatcher();
+
+    $exit = Artisan::call('swarm:audit:reconcile', ['--show' => (string) $id]);
+
+    expect($exit)->toBe(1);
+    $output = Artisan::output();
+    expect($output)->toContain('visible-x');
+    expect($output)->toContain('Read audit chain is broken');
+});
+
 // -----------------------------------------------------------------------------
 // Requeue
 // -----------------------------------------------------------------------------
@@ -293,6 +342,29 @@ test('--dismiss deletes a dead_letter row and emits the audit record with reason
     expect($records[0]['target_category'])->toBe('run.failed');
     expect($records[0]['prior_attempts'])->toBe(7);
     expect($records[0]['reason'])->toBe('duplicate of run.failed for r-7');
+});
+
+test('--dismiss emits target_payload_digest as sha256 of the stored (sealed) payload bytes', function (): void {
+    config()->set('swarm.persistence.encrypt_at_rest', true);
+    $sink = reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter', [
+        'payload' => ['run_id' => 'r-digest', 'category' => 'run.failed', 'secret' => 'forensic-digest-x'],
+    ]);
+
+    $storedPayload = (string) DB::table('swarm_audit_outbox')->where('id', $id)->value('payload');
+    $expectedDigest = hash('sha256', $storedPayload);
+
+    Artisan::call('swarm:audit:reconcile', [
+        '--dismiss' => (string) $id,
+        '--reason' => 'forensic digest test',
+        '--force' => true,
+    ]);
+
+    $records = $sink->recordsForCategory('command.audit_reconcile');
+    expect($records)->toHaveCount(1);
+    expect($records[0])->toHaveKey('target_payload_digest');
+    expect($records[0]['target_payload_digest'])->toMatch('/^[0-9a-f]{64}$/');
+    expect($records[0]['target_payload_digest'])->toBe($expectedDigest);
 });
 
 test('--dismiss requires --reason and refuses without it', function (): void {

--- a/tests/Feature/SwarmAuditReconcileCommandTest.php
+++ b/tests/Feature/SwarmAuditReconcileCommandTest.php
@@ -6,6 +6,7 @@ use BuiltByBerry\LaravelSwarm\Audit\SwarmAuditDispatcher;
 use BuiltByBerry\LaravelSwarm\Contracts\AuditOutbox;
 use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
 use BuiltByBerry\LaravelSwarm\Persistence\SwarmPersistenceCipher;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\CountingThrowingSink;
 use BuiltByBerry\LaravelSwarm\Tests\Fixtures\RecordingSwarmAuditSink;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
@@ -305,6 +306,48 @@ test('--requeue without --force aborts when no operator confirms (non-interactiv
     expect($sink->recordsForCategory('command.audit_reconcile'))->toHaveCount(0);
 });
 
+test('--requeue --json without --force exits with a force_required error envelope', function (): void {
+    $sink = reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter');
+
+    $exit = Artisan::call('swarm:audit:reconcile', [
+        '--requeue' => (string) $id,
+        '--json' => true,
+    ]);
+
+    expect($exit)->toBe(1);
+
+    $decoded = json_decode(Artisan::output(), true);
+    expect($decoded['ok'])->toBeFalse();
+    expect($decoded['error'])->toBe('force_required');
+    expect($decoded['message'])->toContain('Non-interactive automation requires --force');
+
+    $row = DB::table('swarm_audit_outbox')->where('id', $id)->first();
+    expect($row->status)->toBe('dead_letter');
+    expect($sink->recordsForCategory('command.audit_reconcile'))->toHaveCount(0);
+});
+
+test('--dismiss --json without --force exits with a force_required error envelope', function (): void {
+    $sink = reconcileRecordingSink();
+    $id = seedReconcileRow('dead_letter');
+
+    $exit = Artisan::call('swarm:audit:reconcile', [
+        '--dismiss' => (string) $id,
+        '--reason' => 'scripted',
+        '--json' => true,
+    ]);
+
+    expect($exit)->toBe(1);
+
+    $decoded = json_decode(Artisan::output(), true);
+    expect($decoded['ok'])->toBeFalse();
+    expect($decoded['error'])->toBe('force_required');
+    expect($decoded['message'])->toContain('Non-interactive automation requires --force');
+
+    expect(DB::table('swarm_audit_outbox')->where('id', $id)->exists())->toBeTrue();
+    expect($sink->recordsForCategory('command.audit_reconcile'))->toHaveCount(0);
+});
+
 test('--requeue proceeds when confirmation is given interactively', function (): void {
     $sink = reconcileRecordingSink();
     $id = seedReconcileRow('dead_letter');
@@ -488,4 +531,48 @@ test('combining --show with --requeue is rejected', function (): void {
 
     expect($exit)->toBe(1);
     expect(Artisan::output())->toContain('Use only one of');
+});
+
+// -----------------------------------------------------------------------------
+// F6: evidence survives a failing sink under the default queue policy
+// -----------------------------------------------------------------------------
+
+test('--dismiss survives a failing sink under the default queue failure policy and preserves evidence in the outbox', function (): void {
+    config()->set('swarm.audit.failure_policy', 'queue');
+
+    $failingSink = new CountingThrowingSink;
+    app()->instance(SwarmAuditSink::class, $failingSink);
+    app()->forgetInstance(SwarmAuditDispatcher::class);
+
+    $id = seedReconcileRow('dead_letter', [
+        'run_id' => 'r-forensic',
+        'attempts' => 5,
+    ]);
+
+    $exit = Artisan::call('swarm:audit:reconcile', [
+        '--dismiss' => (string) $id,
+        '--reason' => 'forensic test',
+        '--force' => true,
+    ]);
+
+    expect($exit)->toBe(0);
+    expect(DB::table('swarm_audit_outbox')->where('id', $id)->exists())->toBeFalse();
+
+    $reconcileRow = DB::table('swarm_audit_outbox')
+        ->where('category', 'command.audit_reconcile')
+        ->first();
+
+    expect($reconcileRow)->not->toBeNull();
+    expect($reconcileRow->status)->toBe('pending');
+
+    $unsealed = app(SwarmPersistenceCipher::class)->open((string) $reconcileRow->payload);
+    expect($unsealed)->not->toBeNull();
+    $decoded = json_decode((string) $unsealed, true);
+
+    expect($decoded['action'])->toBe('dismiss');
+    expect($decoded['target_id'])->toBe($id);
+    expect($decoded['target_run_id'])->toBe('r-forensic');
+    expect($decoded['prior_attempts'])->toBe(5);
+    expect($decoded['reason'])->toBe('forensic test');
+    expect($decoded)->toHaveKey('target_payload_digest');
 });


### PR DESCRIPTION
Targets the v0.6.0 multi-expert review followups. Five commits, each scoped to a specific finding ID so the PR can be reviewed commit-by-commit.

## Summary

| Commit | Finding | Fix |
|---|---|---|
| `feat(audit): widen reconcile evidence to cover show and dismiss digest` | F1, F2, F3 | `swarm:audit:reconcile --show` now emits a `command.audit_reconcile` evidence record with `action=show` (no payload, no reason) so reads are counted in the audit chain. `--dismiss` includes a new `target_payload_digest` (sha256 of stored payload bytes) so the deleted row can be tied back to a forensic backup without unsealing. |
| `docs(audit): document reconcile evidence and show audit trail` | F1, F2, F3 | Adds `command.audit_reconcile` to the frozen-category list and the field-required table in `docs/audit-evidence-contract.md`. New "Audit trail of reads" subsection in the operator runbook explains that `--show` counts the read without authorizing it. |
| `docs(audit): correct emit-fail wording for default queue policy` | F4 | Previous "row is left untouched if the audit emit fails" was only true under `failure_policy=halt`. Under the default `queue` policy a sink outage routes the reconcile record itself into the outbox for retry. Fixed in both `docs/operator-runbook-audit-outbox.md` and `docs/maintenance.md`. |
| `feat(audit): explicit force_required error for scripted reconcile mutations` | F5, F6 | `--json --requeue` / `--json --dismiss` without `--force` now exits with a structured `{"ok": false, "error": "force_required", "message": "..."}` envelope instead of silently aborting through the prompt path. F6 regression test seeds a `dead_letter` row, binds `CountingThrowingSink` under the default queue policy, runs `--dismiss`, and asserts the target row is deleted while a new outbox row with `action=dismiss` and `target_payload_digest` is preserved — proving evidence survives a sink outage. |
| `chore(audit): drop reconcile from phpstan excludes by tightening row types` | F7 | Narrows `findRow()`'s return and the row-shape helper parameters from the permissive `object` to `\stdClass`. With the tighter type, PHPStan resolves stdClass column access through Larastan and the `SwarmAuditReconcileCommand.php` entry comes out of `ignoreErrors` entirely — no blanket file-level ignore re-introduced. |

No new public-API surface. No new env vars. No migrations. Existing API is additive: `command.audit_reconcile` gains an `action=show` variant and a `target_payload_digest` field on dismiss; the `--json --requeue/--dismiss` without `--force` path returns a typed error envelope instead of silently aborting.

## Test plan

- [x] `composer test` — full suite, 814 passed (baseline 807 + 7 new tests across F2/F3/F5/F6)
- [x] `composer lint` — Pint passed
- [x] `composer analyse` — PHPStan no errors, with `SwarmAuditReconcileCommand.php` no longer on the `ignoreErrors` list
- [x] New tests in `tests/Feature/SwarmAuditReconcileCommandTest.php`:
  - `--show` emits `action=show` with no `payload` / `reason` / `target_payload_digest` keys
  - `--show --json` includes `audit_emitted: true`
  - `--show` exits non-zero with a clear warning when the audit emit fails, but still prints the row
  - `--dismiss` emits `target_payload_digest` matching `/^[0-9a-f]{64}$/` and `hash('sha256', $row->payload)` against the stored bytes
  - `--requeue --json` without `--force` returns the `force_required` JSON envelope and leaves the row untouched
  - `--dismiss --json` without `--force` returns the `force_required` JSON envelope and leaves the row untouched
  - F6 integration test: dismiss survives a `CountingThrowingSink` under `failure_policy=queue` — target row deleted, reconcile evidence preserved in the outbox with `action=dismiss` + `target_payload_digest`

## Changelog note (for the wrap-up PR to merge)

- `swarm:audit:reconcile --show` now emits a `command.audit_reconcile` evidence record with `action=show` and no payload contents so reads are counted in the audit chain.
- `swarm:audit:reconcile --dismiss` evidence now includes `target_payload_digest`, a sha256 over the stored payload bytes, so dismissals can be cross-checked against a forensic backup.
- `swarm:audit:reconcile --json` with `--requeue` or `--dismiss` and no `--force` now exits with `{ok: false, error: "force_required"}` instead of silently aborting through the prompt path.