### PR TITLE
chore(release): v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,20 @@
 # Changelog
 
-## v0.6.0 - unreleased
+## v0.6.0 - 2026-05-20
 
 Operator UX, developer experience, and test coverage on top of the v0.5 audit outbox foundation. No new public-surface contracts. No migration changes. No breaking changes.
 
 ### Added
 
-_To be filled in during release wrap-up._
+- **`swarm:audit:status` summary command (#37).** New read-only Artisan command that surfaces the audit outbox at a glance for operators triaging from the CLI; reports counts (pending / reserved / stale_reserved / dead_letter), an age-distribution histogram, the top-5 dead-letter categories, the oldest pending and dead-letter rows, and the configured retention window alongside the next-prune count. `--json` mirrors the `SwarmHealthCommand` shape so the same monitoring scrapers consume both. Degrades cleanly on cache persistence by skipping with an informational note instead of querying a table that does not exist.
+- **`swarm:audit:reconcile` forensic CLI (#36).** New operator-driven Artisan command for dead-letter triage; defaults to `list` mode and gains `--show=<id>` (display a single row with its sealed payload unsealed for human review), `--requeue=<id>` (re-enqueue a dead-letter record for one more relay pass), and `--dismiss=<id> --reason="..."` (permanently dismiss a record with a mandatory operator-supplied reason). Supports `--json`, `--force` (required for mutations under `--json`), `--limit`, and `--status` flags. Pending rows can be listed or shown but the relay owns their lifecycle — mutations are dead-letter-only.
+- **`command.audit_reconcile` audit category.** Emitted on every `swarm:audit:reconcile` requeue, dismiss, and show action so triage is itself chain-of-custody evidence; payload carries `action`, `target_id`, `target_category`, `target_run_id`, `prior_attempts`, `reason` (required on dismiss, optional on requeue, omitted on show), `target_created_at`, `target_age_seconds`, and `target_payload_digest` (sha256 hex over the stored payload bytes, present on dismiss only so a dismissal can be cross-checked against a forensic backup without unsealing). Enumerated in `docs/audit-evidence-contract.md` as a frozen category. Custom `SwarmAuditSink` implementations that allowlist categories or schema-validate payloads must add `command.audit_reconcile` to their allowlist — without it, operator triage actions are silently dropped, exactly the records that exist to survive scrutiny.
+- **`swarm.audit-outbox` Pulse Livewire card (#38).** New operator-facing dashboard card showing dead-letter count (red alarm if > 0), pending count, stale-pending count (amber alarm if > 0), oldest pending and dead-letter ages, and the configured retention setting; mirrors the `SwarmRuns` / `SwarmSteps` card layout already shipped by the package. Renders a neutral state with zero DB queries on cache persistence so dashboards do not error out under the unsupported driver. Documented in `docs/pulse.md` alongside the existing cards.
+- **Operator runbook at `docs/operator-runbook-audit-outbox.md` (#45).** Scenario-driven 3am-triage walkthrough across five sections: dead-letter triage decision tree, stale-pending decision tree, sink-permanently-broken procedure, retention decision tree per regulatory regime (21 CFR Part 11, SOC 2, HIPAA — deliberately defers regime-specific retention guidance to compliance officers rather than asserting it), and forensic reconstruction (forward marker for `swarm:trace` in v0.7). Cross-linked from the README Production Checklist, `docs/maintenance.md`, and the `docs/README.md` index so operators discovering the package from any entry point find the runbook.
+- **v0.5 audit-chain walkthroughs in `examples/durable-compliance-review/` and `examples/privacy-capture/` (#46).** `durable-compliance-review` gains a full simulated-outage scenario with baseline config, a `RecoveringSinkDemo` fixture that fails then heals, `swarm:audit:status` and `swarm:health --audit` output samples, recovery via `swarm:relay --type=audit`, and dead-letter triage via `swarm:audit:reconcile --show/--requeue/--dismiss`. `privacy-capture` gains a smaller "v0.5 Audit Chain For Redacted Evidence" section covering what `failure_policy=queue` means for redacted payloads and the privacy implications of `--show` on sealed outbox rows.
+- **Integration test coverage for the v0.5 audit outbox flow (#39).** New `tests/Feature/AuditOutboxIntegrationTest.php` covering three end-to-end scenarios: DB-backed failing-sink → outbox → replay → dead_letter; cache-backed log-and-swallow fallback; and cross-lane `swarm:relay` draining both durable and audit lanes in a single pass. Extracted the existing `CountingThrowingSink` fixture from `tests/Unit/Audit/SinkFailureHandlerTest.php` into `tests/Fixtures/CountingThrowingSink.php` for reuse across the suite.
 
-### Changed
-
-_To be filled in during release wrap-up._
+## v0.5.0 - 2026-05-19
 
 ## v0.5.0 - 2026-05-19
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -268,6 +268,88 @@ This package’s `composer.json` uses `"minimum-stability": "dev"` with
 still prefers tagged releases. Your application may need compatible Composer
 stability settings while Laravel AI remains pre-stable.
 
+## Upgrading to v0.6.0
+
+v0.6.0 is purely additive on top of v0.5.0 — no migrations, no env-var
+changes, no breaking surface. Existing v0.5 deployments can adopt v0.6
+surfaces incrementally.
+
+### High Impact Changes
+
+#### Custom `SwarmAuditSink` allowlists must add `command.audit_reconcile`
+
+v0.6.0 introduces a new audit category, `command.audit_reconcile`,
+emitted by the new `swarm:audit:reconcile` Artisan command on every
+operator triage action against the audit outbox (requeue, dismiss, and
+show). The category is enumerated in
+`docs/audit-evidence-contract.md` and behaves like every other
+`command.*` category — it carries `schema_version: "2"` and the
+standard `metadata.actor` envelope slot.
+
+**Required if you implement a custom `SwarmAuditSink` that allowlists
+categories or schema-validates payloads:** add `command.audit_reconcile`
+to your allowlist. Without this, operator triage actions are silently
+dropped — exactly the records that exist to survive scrutiny. A sink
+that rejects unknown categories will also reject these records, so
+either accept the new category or extend the strict-validation switch
+to cover it.
+
+The frozen payload fields, in order:
+
+- `action` (string, one of `requeue`, `dismiss`, `show`)
+- `target_id` (int) — the `swarm_audit_outbox` row id
+- `target_category` (string) — the category of the original failed emit
+- `target_run_id` (string&#124;null) — the run id from the original payload, if present
+- `prior_attempts` (int) — the outbox row's attempt count at the time of the action
+- `reason` (string) — required on `dismiss`, optional on `requeue`, omitted on `show`
+- `target_created_at` (ISO 8601 string) — when the outbox row was first written
+- `target_age_seconds` (int) — age at the time of the action
+- `target_payload_digest` (sha256 hex string) — **present on `dismiss` only**; a sha256 over the stored payload bytes so an auditor can verify the deletion against a forensic backup without unsealing
+
+Sinks that ignore unknown categories (or fall through to a generic
+`emit($category, $payload)` path) need no changes.
+
+### Medium Impact Changes
+
+#### Operator adoption — optional v0.6 surfaces
+
+The new dashboard card and the two new Artisan commands are
+opt-in operator surfaces. Adopt them where they fit; nothing about
+v0.5 stops working if you defer.
+
+- **Pulse card.** Register the new card by adding
+  `\BuiltByBerry\LaravelSwarm\Pulse\Livewire\AuditOutbox::class` to
+  your `pulse.cards` config, or place the `<livewire:swarm.audit-outbox />`
+  Blade tag directly in a custom dashboard view. The card renders a
+  neutral state with zero DB queries on cache persistence; no further
+  configuration is required.
+- **`swarm:audit:status`.** Read-only outbox summary; safe to run from
+  the CLI or wire into a monitoring scraper via `--json`.
+- **`swarm:audit:reconcile`.** Operator-on-demand forensic CLI. Treat
+  it like `swarm:recover` — invoke from the CLI when triaging, do not
+  schedule it. **Do not** add either of the new commands to the
+  scheduler. `swarm:relay` (already scheduled in v0.5) continues to
+  drain the audit lane on its existing cadence.
+
+### Low Impact Changes
+
+#### Compliance posture: dismissals are now digest-bound and reads are counted
+
+v0.6 strengthens the chain of custody on operator dismissals via the
+new `target_payload_digest` field — a sha256 over the stored payload
+bytes that lets an auditor verify a `--dismiss` action against a
+forensic backup of the outbox without unsealing. Payload **reads** are
+also now counted: `swarm:audit:reconcile --show` emits a
+`command.audit_reconcile` record with `action=show` (no payload
+contents in the audit record), so operator inspection of a dead-letter
+row is itself a tracked event.
+
+Operators with shell access to `swarm:audit:reconcile --show` should
+be treated the same as operators with direct database read access —
+the audit emit accounts for individual reads but does not authorize
+them. Gate shell access accordingly. The `docs/operator-runbook-audit-outbox.md`
+"Audit trail of reads" subsection covers the operational expectations.
+
 ## Upgrading to v0.5.0
 
 v0.5.0 settles the audit evidence envelope and lands the durability layer


### PR DESCRIPTION
**DO NOT MERGE YET** — multi-expert review + release-readiness pass to follow.

PR B for the v0.6.0 release wrap-up. Docs-only — the package is git-tag-versioned, so no version constant lives in code.

Lands under the v0.6.0 umbrella (#56).

## Summary

- Fills in the v0.6.0 `CHANGELOG.md` section. Dates the release at 2026-05-20 and inventories every operator-facing surface that landed: `swarm:audit:status` (#37), `swarm:audit:reconcile` + the `command.audit_reconcile` audit category (#36), the `swarm.audit-outbox` Pulse card (#38), the operator runbook (#45), the v0.5 audit-chain walkthroughs in regulated examples (#46), and the integration test coverage for the audit outbox flow (#39). Style matches the v0.5.0 entry. No Changed section — v0.6 is purely additive.
- Adds an "Upgrading to v0.6.0" block to `UPGRADING.md` above the v0.5.0 block. Mirrors the v0.5.0 structure (High / Medium / Low Impact). Header summary is the one-liner: purely additive, no migrations, no env-var changes, no breaking surface.
  - **High impact:** custom `SwarmAuditSink` allowlists must add `command.audit_reconcile` or operator triage actions are silently dropped. Full payload field list inline.
  - **Medium impact:** optional Pulse card registration + the operator-on-demand `swarm:audit:status` / `swarm:audit:reconcile` commands. Explicit "do not schedule" note; `swarm:relay` continues to drain the audit lane.
  - **Low impact:** compliance posture for the new `target_payload_digest` on dismissals and the `action=show` emit that counts payload reads.

## Test plan

- [x] `composer lint` passes (Pint).
- [x] `composer test` — 814 passed (baseline after PR A, no test churn from docs-only diff).
- [ ] Multi-expert review pass.
- [ ] Release-readiness pass.

## Out of scope (deliberately)

- No version bump anywhere in code (package is git-tag-versioned).
- No tag push.
- No source code changes.
- No changes to runbook / example content (those landed in PRs #63, #64).