### PR TITLE
chore(release): v0.6.0 readiness gate followups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@ Operator UX, developer experience, and test coverage on top of the v0.5 audit ou
 
 ## v0.5.0 - 2026-05-19
 
-## v0.5.0 - 2026-05-19
-
 ### Added
 
 - **Audit outbox + queue/dead-letter failure policies (#20).** Sink failures can now be persisted to the new `swarm_audit_outbox` table and retried via `swarm:relay --type=audit`. The relay command drains both the durable lane and the audit lane in a single pass (or each independently with `--type=step` / `--type=audit`). `SinkFailureDecision` gains `Queue` and `DeadLetter` cases. `ConfiguredSinkFailureHandler` recognizes `queue` and `dead_letter` failure-policy values in addition to the v0.4 `swallow` / `log` / `halt`. `swarm.audit.outbox.max_attempts` (default 5) controls how many retry passes a record gets before moving to the dead-letter status. `command.relay` evidence gains `audit_replayed_count` and `audit_dead_lettered_count` fields. Dead-letter transitions emit `Log::error` so monitoring stacks can alert on undelivered audit evidence. The `payload` and `last_error` columns are sealed when `swarm.persistence.encrypt_at_rest` is enabled.

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "0.5.x-dev"
+            "dev-main": "0.6.x-dev"
         },
         "laravel": {
             "providers": [


### PR DESCRIPTION
Addresses the two medium findings surfaced by both `/swarm-release-readiness` and `/multi-expert-change-review` against `release/v0.6.0`. Both are quick, mechanical fixes — no source code changes.

## Commits

| Commit | Finding | Fix |
|---|---|---|
| `docs(changelog): drop duplicate v0.5.0 header (readiness F1)` | F1 | Removed the stray duplicate `## v0.5.0 - 2026-05-19` line that sat between the v0.6.0 entry and the real v0.5.0 body. keep-a-changelog renderers and GitHub Releases auto-imports were misreading the phantom empty section. |
| `chore(composer): bump branch-alias to 0.6.x-dev (readiness F2)` | F2 | Updated `extra.branch-alias.dev-main` from `0.5.x-dev` to `0.6.x-dev` so downstream consumers tracking `dev-main` resolve as v0.6.x-compatible after the tag. |

## Verification

- `composer test` — 814 passing, 3136 assertions (matches release-branch baseline).
- `composer lint` — Pint passed.
- `composer analyse` — not re-run (no source changes since the last green analyse on `release/v0.6.0`).

## Release impact

Both gates returned `approve-with-followups` / `ship-with-followups`. With this PR merged, `release/v0.6.0` is ready for the umbrella PR (#56) review and the v0.6.0 tag.