### PR TITLE
feat(testing): RunContext::fake() helper for ad-hoc test setup (#43)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -21,6 +21,41 @@ ArticlePipeline::fake(['first', 'second']);
 expect((string) ArticlePipeline::make()->prompt('Draft a blog outline about Laravel queues.'))->toBe('first');
 ```
 
+## Building A `RunContext` For Tests
+
+`RunContext::fake()` is a named constructor for ad-hoc test setup. It returns a
+context with a deterministic run id (`fake-run-id`), empty input, no actor, no
+data, no metadata, and no artifacts. Pass an array of overrides for the slots
+you want to populate, and compose with the existing fluent builders
+(`withActor()`, `mergeData()`, `mergeMetadata()`, `withLabels()`,
+`withDetails()`, `addArtifact()`) for everything else:
+
+```php
+use BuiltByBerry\LaravelSwarm\Audit\Actor;
+use BuiltByBerry\LaravelSwarm\Support\RunContext;
+
+$context = RunContext::fake([
+    'input' => 'Draft a blog outline about Laravel queues.',
+    'actor' => 'user:42',
+])
+    ->mergeData(['draft_id' => 7])
+    ->withLabels(['tenant' => 'acme']);
+
+ArticlePipeline::fake();
+ArticlePipeline::make()->run($context);
+
+ArticlePipeline::assertDispatchedWithActor(new Actor(id: '42', type: 'user'));
+ArticlePipeline::assertPrompted(['draft_id' => 7]);
+```
+
+The `actor` override accepts anything `RunContext::withActor()` accepts (an
+`Actor`, an `Authenticatable`, a `"type:id"` or bare-id string, or `null`).
+Pass it through `RunContext::fake()` when actor binding is the only thing you
+need, and reach for `withActor()` directly when chaining with other builders.
+
+`RunContext::fake()` is a test helper. Production code should construct
+contexts with `RunContext::from()`, `::fromTask()`, or `::fromPayload()`.
+
 ## Asserting Basic Interaction
 
 You can assert against synchronous, queued, durable, and streamed execution:

--- a/src/Support/RunContext.php
+++ b/src/Support/RunContext.php
@@ -87,6 +87,45 @@ class RunContext
         return (string) str()->uuid();
     }
 
+    /**
+     * Build a RunContext suitable for ad-hoc test setup.
+     *
+     * Defaults to a deterministic run id ("fake-run-id"), empty input, no
+     * data, no metadata, no artifacts, and no actor. Any of those slots can be
+     * overridden via the $overrides array using the keys: run_id, input, data,
+     * metadata, artifacts, actor. The actor override accepts anything
+     * RunContext::withActor() accepts (Actor, Authenticatable, "type:id" or
+     * bare-id string, or null) and is applied via that existing builder so the
+     * actor is stored under the reserved metadata.actor slot.
+     *
+     * Compose with the existing fluent builders for richer setups:
+     *
+     *   RunContext::fake(['input' => 'draft outline'])
+     *       ->withActor('user:42')
+     *       ->withLabels(['tenant' => 'acme'])
+     *       ->mergeData(['draft_id' => 7]);
+     *
+     * This is a test helper. Do not use it in production code paths.
+     *
+     * @param  array{run_id?: string, input?: string, data?: array<string, mixed>, metadata?: array<string, mixed>, artifacts?: array<int, SwarmArtifact>, actor?: Actor|Authenticatable|string|null}  $overrides
+     */
+    public static function fake(array $overrides = []): self
+    {
+        $context = new self(
+            runId: $overrides['run_id'] ?? 'fake-run-id',
+            input: $overrides['input'] ?? '',
+            data: $overrides['data'] ?? [],
+            metadata: $overrides['metadata'] ?? [],
+            artifacts: $overrides['artifacts'] ?? [],
+        );
+
+        if (array_key_exists('actor', $overrides)) {
+            $context->withActor($overrides['actor']);
+        }
+
+        return $context;
+    }
+
     public function prompt(): string
     {
         return (string) ($this->data['last_output'] ?? $this->input);

--- a/tests/Unit/RunContextTest.php
+++ b/tests/Unit/RunContextTest.php
@@ -323,3 +323,87 @@ test('withActor survives queue payload serialization roundtrip', function () {
     expect($rehydrated->metadata['actor']['id'])->toBe('u-9');
     expect($rehydrated->metadata['actor']['type'])->toBe('user');
 });
+
+test('fake returns a deterministic context with sensible defaults', function () {
+    $context = RunContext::fake();
+
+    expect($context->runId)->toBe('fake-run-id');
+    expect($context->input)->toBe('');
+    expect($context->data)->toBe([]);
+    expect($context->metadata)->toBe([]);
+    expect($context->artifacts)->toBe([]);
+    expect($context->actor())->toBeNull();
+});
+
+test('fake applies run_id, input, data, metadata and artifact overrides', function () {
+    $artifact = new SwarmArtifact('manual', 'draft body');
+
+    $context = RunContext::fake([
+        'run_id' => 'test-run-1',
+        'input' => 'Draft outline',
+        'data' => ['draft_id' => 42],
+        'metadata' => ['campaign' => 'content-calendar'],
+        'artifacts' => [$artifact],
+    ]);
+
+    expect($context->runId)->toBe('test-run-1');
+    expect($context->input)->toBe('Draft outline');
+    expect($context->data)->toBe(['draft_id' => 42]);
+    expect($context->metadata)->toBe(['campaign' => 'content-calendar']);
+    expect($context->artifacts)->toBe([$artifact]);
+});
+
+test('fake actor override accepts an Actor value object', function () {
+    $context = RunContext::fake([
+        'actor' => new Actor(id: 'u-1', type: 'user', name: 'Ada'),
+    ]);
+
+    expect($context->actor()?->id)->toBe('u-1');
+    expect($context->actor()?->type)->toBe('user');
+    expect($context->actor()?->name)->toBe('Ada');
+});
+
+test('fake actor override accepts string shorthand', function () {
+    $context = RunContext::fake(['actor' => 'system:cron']);
+
+    expect($context->metadata['actor']['type'])->toBe('system');
+    expect($context->metadata['actor']['id'])->toBe('cron');
+});
+
+test('fake actor override null does not bind any actor', function () {
+    $context = RunContext::fake(['actor' => null]);
+
+    expect($context->actor())->toBeNull();
+    expect($context->metadata)->not->toHaveKey('actor');
+});
+
+test('fake composes cleanly with the existing fluent builders', function () {
+    $context = RunContext::fake(['input' => 'Draft outline'])
+        ->withActor('user:42')
+        ->withLabels(['tenant' => 'acme'])
+        ->mergeData(['draft_id' => 7])
+        ->mergeMetadata(['campaign' => 'content-calendar']);
+
+    expect($context->runId)->toBe('fake-run-id');
+    expect($context->input)->toBe('Draft outline');
+    expect($context->data)->toBe(['draft_id' => 7]);
+    expect($context->actor()?->id)->toBe('42');
+    expect($context->labels())->toBe(['tenant' => 'acme']);
+    expect($context->metadata['campaign'])->toBe('content-calendar');
+});
+
+test('fake context serializes through the queue payload roundtrip', function () {
+    $context = RunContext::fake([
+        'input' => 'Draft outline',
+        'data' => ['draft_id' => 42],
+        'actor' => 'user:7',
+    ]);
+
+    $rehydrated = RunContext::fromPayload($context->toQueuePayload());
+
+    expect($rehydrated->runId)->toBe('fake-run-id');
+    expect($rehydrated->input)->toBe('Draft outline');
+    expect($rehydrated->data)->toBe(['draft_id' => 42]);
+    expect($rehydrated->metadata['actor']['id'])->toBe('7');
+    expect($rehydrated->metadata['actor']['type'])->toBe('user');
+});


### PR DESCRIPTION
## Summary

- New `RunContext::fake(array $overrides = [])` named constructor returns a context with deterministic defaults (`run_id` = `fake-run-id`, empty input, no actor, no data, no metadata, no artifacts) and applies overrides keyed on `run_id`, `input`, `data`, `metadata`, `artifacts`, and `actor`. The `actor` override flows through the existing `withActor()` builder.
- Composes with the existing fluent builders (`withActor`, `mergeData`, `mergeMetadata`, `withLabels`, `withDetails`, `addArtifact`) rather than introducing fake-only sugar — pure addition, no change to any existing `RunContext` public method.
- `docs/testing.md` gains a "Building A `RunContext` For Tests" section with a worked example that bridges `RunContext::fake()` into `SwarmFake` actor and prompt assertions.

Closes #43

## Test plan

- [x] `composer test` (821 passed, 3165 assertions)
- [x] `composer lint` (pint: passed)
- [x] `composer analyse` (phpstan: no errors)
- [x] 7 new unit tests in `tests/Unit/RunContextTest.php` cover defaults, every override slot, actor override variants (Actor / string / null), composition with existing builders, and queue-payload roundtrip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)