### PR TITLE
feat(testing): SwarmFake intercepts for audit extension contracts (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ DX + test rigor.
 
 ### Added
 
-_To be filled in during release wrap-up._
+- **`SwarmFake` intercepts for the v0.4 audit-extension contracts (#42).** Three new static helpers — `SwarmFake::interceptCapturePolicy()`, `interceptSinkFailureHandler()`, and `interceptSwarmAuditSigner()` — swap the container binding for the corresponding contract to a recording decorator and return a recorder with first-class assertion methods (`assertCaptured`, `assertCapturedDecision`, `assertCapturedWith`, `assertSinkFailureRouted`, `assertSinkFailureRoutedAs`, `assertSigned`, plus `Never*` variants). Each decorator wraps an optional delegate so existing policy / handler / signer logic still drives behavior; the recorder only captures inputs, the routed decision, and the resulting payload. Replaces the v0.4.3 workaround-pattern documentation; `docs/testing.md` "Testing Audit Extension Points" gains a new leading section covering the intercepts and how they preserve `SwarmFake`'s "doesn't touch the dispatcher" design property — recording happens when the real dispatcher resolves the contract from the container during a non-faked run, so `SwarmFake` itself never constructs or invokes the dispatcher.
 
 ### Changed
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -138,8 +138,82 @@ SwarmFake-visible mirror.
 
 The four v0.4 audit extension contracts — `CapturePolicy`,
 `SinkFailureHandler`, `SwarmAuditSigner`, and `ActorResolver` — are
-invoked inside `SwarmRunner` and the audit dispatcher, code paths that
-`SwarmFake` intentionally skips. Three testing patterns cover them:
+invoked inside `SwarmRunner` and the audit dispatcher. `SwarmFake`
+intentionally skips that code path for `prompt()` / `run()` / `queue()` /
+`stream()` / `dispatchDurable()`, so the three patterns below cover what
+the fake cannot observe directly.
+
+### Use `SwarmFake` intercepts for the three audit contracts (v0.7+)
+
+`SwarmFake` ships three intercept helpers for `CapturePolicy`,
+`SinkFailureHandler`, and `SwarmAuditSigner`. Each helper swaps the
+container binding for the corresponding contract to a recording
+decorator and returns a recorder you can assert against. The decorators
+wrap an optional delegate, so existing policy / handler / signer logic
+still drives behavior — the recorder only captures inputs, the routed
+decision, and the resulting payload.
+
+Intercepts work during real (non-faked) swarm runs, since the
+recording happens when the real audit dispatcher resolves the contract
+from the container. `SwarmFake` itself never constructs or invokes the
+dispatcher — installing an intercept only mutates the container
+binding and flushes the `SwarmAuditDispatcher` singleton so the next
+resolution picks up the recorder.
+
+```php
+use BuiltByBerry\LaravelSwarm\Audit\CaptureDecision;
+use BuiltByBerry\LaravelSwarm\Audit\SinkFailureDecision;
+use BuiltByBerry\LaravelSwarm\Testing\SwarmFake;
+
+test('article pipeline captures inputs and signs run.started', function () {
+    $capturePolicy = SwarmFake::interceptCapturePolicy();
+    $signer = SwarmFake::interceptSwarmAuditSigner(new MyEcdsaSigner);
+
+    ArticlePipeline::make()->run('draft a launch post');
+
+    $capturePolicy->assertCapturedDecision('inputs', CaptureDecision::Full);
+    $signer->assertSigned('run.started');
+});
+
+test('article pipeline routes a flaky sink to the outbox', function () {
+    // Bind a sink that fails the first emit.
+    app()->instance(SwarmAuditSink::class, new FlakySink);
+
+    $handler = SwarmFake::interceptSinkFailureHandler();
+
+    ArticlePipeline::make()->run('task');
+
+    $handler->assertSinkFailureRouted();
+    $handler->assertSinkFailureRoutedAs(SinkFailureDecision::Swallow);
+});
+```
+
+Each recorder exposes:
+
+- `assertCaptured(string $category, ?callable $matcher = null)`,
+  `assertCapturedDecision(string $category, CaptureDecision $decision)`,
+  `assertCapturedWith(callable $matcher)`,
+  `assertNeverCaptured(?string $category = null)` on
+  `RecordingCapturePolicy`.
+- `assertSinkFailureRouted(?callable $matcher = null)`,
+  `assertSinkFailureRoutedAs(SinkFailureDecision $decision, ?string $category = null)`,
+  `assertNeverSinkFailure(?string $category = null)` on
+  `RecordingSinkFailureHandler`.
+- `assertSigned(?string $category = null, ?callable $matcher = null)`,
+  `assertNeverSigned(?string $category = null)` on
+  `RecordingSwarmAuditSigner`.
+
+All three recorders also expose `records()` and `recordsFor(string $category)`
+for raw inspection when you need shape assertions richer than what the
+helpers cover.
+
+The intercepts cover the dispatch-time signal: was the contract invoked,
+with what category, and what did it decide. They do not replace the two
+patterns below, which remain the right tool for unit-testing the contract
+in isolation or for asserting on the fully enriched envelope a sink sees.
+`ActorResolver` still has no dispatch-time intercept; cover it with the
+patterns below or with `SwarmFake::assertDispatchedWithActor()` (see
+[Asserting Actor Binding](#asserting-actor-binding)).
 
 ### Unit-test the contract directly
 

--- a/src/Testing/Audit/RecordingCapturePolicy.php
+++ b/src/Testing/Audit/RecordingCapturePolicy.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Testing\Audit;
+
+use BuiltByBerry\LaravelSwarm\Audit\Actor;
+use BuiltByBerry\LaravelSwarm\Audit\CaptureDecision;
+use BuiltByBerry\LaravelSwarm\Contracts\CapturePolicy;
+use BuiltByBerry\LaravelSwarm\Support\RunContext;
+use BuiltByBerry\LaravelSwarm\Testing\SwarmFake;
+use Illuminate\Testing\Assert as PHPUnit;
+
+/**
+ * Test double for {@see CapturePolicy} that records every decision call.
+ *
+ * Wraps an optional delegate policy and forwards each category call to it,
+ * recording the category name, context, actor, and resulting decision so
+ * tests can assert what the audit dispatcher would have seen during a run.
+ * When no delegate is supplied, every category returns
+ * {@see CaptureDecision::Full} so the recorder is usable as a stand-alone
+ * policy that records every dispatcher invocation without further setup.
+ *
+ * SwarmFake installs this via {@see SwarmFake::interceptCapturePolicy()},
+ * which swaps the container binding only. SwarmFake itself never constructs
+ * or invokes the audit dispatcher; recording happens when the real
+ * dispatcher resolves the contract from the container during a non-faked
+ * run.
+ */
+class RecordingCapturePolicy implements CapturePolicy
+{
+    /**
+     * @var array<int, array{category: string, context: ?RunContext, actor: ?Actor, decision: CaptureDecision}>
+     */
+    protected array $records = [];
+
+    public function __construct(
+        protected ?CapturePolicy $delegate = null,
+    ) {}
+
+    public function inputs(?RunContext $context = null, ?Actor $actor = null): CaptureDecision
+    {
+        return $this->record('inputs', $context, $actor);
+    }
+
+    public function outputs(?RunContext $context = null, ?Actor $actor = null): CaptureDecision
+    {
+        return $this->record('outputs', $context, $actor);
+    }
+
+    public function artifacts(?RunContext $context = null, ?Actor $actor = null): CaptureDecision
+    {
+        return $this->record('artifacts', $context, $actor);
+    }
+
+    public function activeContext(?RunContext $context = null, ?Actor $actor = null): CaptureDecision
+    {
+        return $this->record('active_context', $context, $actor);
+    }
+
+    /**
+     * Every recorded decision in the order it was emitted.
+     *
+     * @return array<int, array{category: string, context: ?RunContext, actor: ?Actor, decision: CaptureDecision}>
+     */
+    public function records(): array
+    {
+        return $this->records;
+    }
+
+    /**
+     * Records for a single capture category.
+     *
+     * @return array<int, array{category: string, context: ?RunContext, actor: ?Actor, decision: CaptureDecision}>
+     */
+    public function recordsFor(string $category): array
+    {
+        return array_values(array_filter(
+            $this->records,
+            fn (array $record): bool => $record['category'] === $category,
+        ));
+    }
+
+    /**
+     * Assert the policy was invoked for the given category at least once.
+     *
+     * Pass a callable matcher to inspect the recorded entry (category,
+     * context, actor, decision). Without a matcher the assertion only
+     * verifies the category was touched.
+     */
+    public function assertCaptured(string $category, ?callable $matcher = null): void
+    {
+        $records = $this->recordsFor($category);
+
+        if ($matcher === null) {
+            PHPUnit::assertNotEmpty(
+                $records,
+                "CapturePolicy was not invoked for category [{$category}].",
+            );
+
+            return;
+        }
+
+        PHPUnit::assertTrue(
+            collect($records)->contains(fn (array $record): bool => (bool) $matcher($record)),
+            "CapturePolicy was not invoked for category [{$category}] with a record matching the expected matcher.",
+        );
+    }
+
+    /**
+     * Assert the policy returned the given decision for the given category
+     * at least once.
+     */
+    public function assertCapturedDecision(string $category, CaptureDecision $decision): void
+    {
+        PHPUnit::assertTrue(
+            collect($this->recordsFor($category))->contains(fn (array $record): bool => $record['decision'] === $decision),
+            "CapturePolicy did not return [{$decision->name}] for category [{$category}].",
+        );
+    }
+
+    /**
+     * Assert at least one capture record across any category satisfies the
+     * matcher. Useful for "any category saw this actor" style checks.
+     */
+    public function assertCapturedWith(callable $matcher): void
+    {
+        PHPUnit::assertTrue(
+            collect($this->records)->contains(fn (array $record): bool => (bool) $matcher($record)),
+            'CapturePolicy did not record an invocation matching the expected matcher.',
+        );
+    }
+
+    /**
+     * Assert the policy was never invoked at all.
+     */
+    public function assertNeverCaptured(?string $category = null): void
+    {
+        if ($category === null) {
+            PHPUnit::assertEmpty(
+                $this->records,
+                'CapturePolicy was invoked unexpectedly.',
+            );
+
+            return;
+        }
+
+        PHPUnit::assertEmpty(
+            $this->recordsFor($category),
+            "CapturePolicy was invoked for category [{$category}] unexpectedly.",
+        );
+    }
+
+    protected function record(string $category, ?RunContext $context, ?Actor $actor): CaptureDecision
+    {
+        $decision = $this->delegate !== null
+            ? $this->delegate->{$category === 'active_context' ? 'activeContext' : $category}($context, $actor)
+            : CaptureDecision::Full;
+
+        $this->records[] = [
+            'category' => $category,
+            'context' => $context,
+            'actor' => $actor,
+            'decision' => $decision,
+        ];
+
+        return $decision;
+    }
+}

--- a/src/Testing/Audit/RecordingSinkFailureHandler.php
+++ b/src/Testing/Audit/RecordingSinkFailureHandler.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Testing\Audit;
+
+use BuiltByBerry\LaravelSwarm\Audit\SinkFailureDecision;
+use BuiltByBerry\LaravelSwarm\Contracts\SinkFailureHandler;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
+use BuiltByBerry\LaravelSwarm\Testing\SwarmFake;
+use Illuminate\Testing\Assert as PHPUnit;
+use Throwable;
+
+/**
+ * Test double for {@see SinkFailureHandler} that records every routed
+ * sink (or signing) failure.
+ *
+ * Wraps an optional delegate handler and forwards each handle() call to it,
+ * recording the category, payload, exception, and routing decision the
+ * dispatcher acted on. When no delegate is supplied, every failure routes to
+ * {@see SinkFailureDecision::Swallow} so the recorder works as a stand-alone
+ * handler without further setup.
+ *
+ * SwarmFake installs this via
+ * {@see SwarmFake::interceptSinkFailureHandler()},
+ * which swaps the container binding only. The dispatcher resolves this
+ * recorder during the real run and records the failure path without
+ * SwarmFake itself ever invoking the dispatcher.
+ */
+class RecordingSinkFailureHandler implements SinkFailureHandler
+{
+    /**
+     * @var array<int, array{sink: SwarmAuditSink, category: string, payload: array<string, mixed>, exception: Throwable, decision: SinkFailureDecision}>
+     */
+    protected array $records = [];
+
+    public function __construct(
+        protected ?SinkFailureHandler $delegate = null,
+        protected SinkFailureDecision $defaultDecision = SinkFailureDecision::Swallow,
+    ) {}
+
+    public function handle(
+        SwarmAuditSink $sink,
+        string $category,
+        array $payload,
+        Throwable $exception,
+    ): SinkFailureDecision {
+        $decision = $this->delegate !== null
+            ? $this->delegate->handle($sink, $category, $payload, $exception)
+            : $this->defaultDecision;
+
+        $this->records[] = [
+            'sink' => $sink,
+            'category' => $category,
+            'payload' => $payload,
+            'exception' => $exception,
+            'decision' => $decision,
+        ];
+
+        return $decision;
+    }
+
+    /**
+     * Every recorded failure routing in the order it was handled.
+     *
+     * @return array<int, array{sink: SwarmAuditSink, category: string, payload: array<string, mixed>, exception: Throwable, decision: SinkFailureDecision}>
+     */
+    public function records(): array
+    {
+        return $this->records;
+    }
+
+    /**
+     * Records for a single category.
+     *
+     * @return array<int, array{sink: SwarmAuditSink, category: string, payload: array<string, mixed>, exception: Throwable, decision: SinkFailureDecision}>
+     */
+    public function recordsFor(string $category): array
+    {
+        return array_values(array_filter(
+            $this->records,
+            fn (array $record): bool => $record['category'] === $category,
+        ));
+    }
+
+    /**
+     * Assert at least one sink failure was routed.
+     *
+     * Pass a callable matcher to inspect a recorded entry (sink, category,
+     * payload, exception, decision). Without a matcher the assertion only
+     * verifies the handler was invoked at least once.
+     */
+    public function assertSinkFailureRouted(?callable $matcher = null): void
+    {
+        if ($matcher === null) {
+            PHPUnit::assertNotEmpty(
+                $this->records,
+                'SinkFailureHandler was not invoked.',
+            );
+
+            return;
+        }
+
+        PHPUnit::assertTrue(
+            collect($this->records)->contains(fn (array $record): bool => (bool) $matcher($record)),
+            'SinkFailureHandler did not record a routing matching the expected matcher.',
+        );
+    }
+
+    /**
+     * Assert at least one sink failure was routed with the given decision.
+     */
+    public function assertSinkFailureRoutedAs(SinkFailureDecision $decision, ?string $category = null): void
+    {
+        $records = $category === null
+            ? $this->records
+            : $this->recordsFor($category);
+
+        $label = $category === null
+            ? 'across any category'
+            : "for category [{$category}]";
+
+        PHPUnit::assertTrue(
+            collect($records)->contains(fn (array $record): bool => $record['decision'] === $decision),
+            "SinkFailureHandler did not return [{$decision->name}] {$label}.",
+        );
+    }
+
+    /**
+     * Assert no sink failure was routed at all (optionally for a single
+     * category).
+     */
+    public function assertNeverSinkFailure(?string $category = null): void
+    {
+        if ($category === null) {
+            PHPUnit::assertEmpty(
+                $this->records,
+                'SinkFailureHandler was invoked unexpectedly.',
+            );
+
+            return;
+        }
+
+        PHPUnit::assertEmpty(
+            $this->recordsFor($category),
+            "SinkFailureHandler was invoked for category [{$category}] unexpectedly.",
+        );
+    }
+}

--- a/src/Testing/Audit/RecordingSwarmAuditSigner.php
+++ b/src/Testing/Audit/RecordingSwarmAuditSigner.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Testing\Audit;
+
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSigner;
+use BuiltByBerry\LaravelSwarm\Testing\SwarmFake;
+use Illuminate\Testing\Assert as PHPUnit;
+
+/**
+ * Test double for {@see SwarmAuditSigner} that records every signing call.
+ *
+ * Wraps an optional delegate signer and forwards each sign() call to it,
+ * recording the category, the input payload, and the signed payload the
+ * delegate returned. When no delegate is supplied, the recorder returns the
+ * input payload unchanged so it works as a transparent stand-alone signer
+ * for tests that only care that signing was invoked.
+ *
+ * SwarmFake installs this via
+ * {@see SwarmFake::interceptSwarmAuditSigner()},
+ * which swaps the container binding only. The dispatcher resolves this
+ * recorder during the real run and records the signing path without
+ * SwarmFake itself ever invoking the dispatcher.
+ */
+class RecordingSwarmAuditSigner implements SwarmAuditSigner
+{
+    /**
+     * @var array<int, array{category: string, input: array<string, mixed>, output: array<string, mixed>}>
+     */
+    protected array $records = [];
+
+    public function __construct(
+        protected ?SwarmAuditSigner $delegate = null,
+    ) {}
+
+    public function sign(string $category, array $payload): array
+    {
+        $output = $this->delegate !== null
+            ? $this->delegate->sign($category, $payload)
+            : $payload;
+
+        $this->records[] = [
+            'category' => $category,
+            'input' => $payload,
+            'output' => $output,
+        ];
+
+        return $output;
+    }
+
+    /**
+     * Every recorded signing call in the order it was emitted.
+     *
+     * @return array<int, array{category: string, input: array<string, mixed>, output: array<string, mixed>}>
+     */
+    public function records(): array
+    {
+        return $this->records;
+    }
+
+    /**
+     * Records for a single category.
+     *
+     * @return array<int, array{category: string, input: array<string, mixed>, output: array<string, mixed>}>
+     */
+    public function recordsFor(string $category): array
+    {
+        return array_values(array_filter(
+            $this->records,
+            fn (array $record): bool => $record['category'] === $category,
+        ));
+    }
+
+    /**
+     * Assert the signer was invoked at least once.
+     *
+     * Pass a category to scope the assertion. Pass a callable matcher to
+     * inspect the recorded entry (category, input, output).
+     */
+    public function assertSigned(?string $category = null, ?callable $matcher = null): void
+    {
+        $records = $category === null
+            ? $this->records
+            : $this->recordsFor($category);
+
+        $label = $category === null
+            ? 'for any category'
+            : "for category [{$category}]";
+
+        if ($matcher === null) {
+            PHPUnit::assertNotEmpty(
+                $records,
+                "SwarmAuditSigner was not invoked {$label}.",
+            );
+
+            return;
+        }
+
+        PHPUnit::assertTrue(
+            collect($records)->contains(fn (array $record): bool => (bool) $matcher($record)),
+            "SwarmAuditSigner was not invoked {$label} with a record matching the expected matcher.",
+        );
+    }
+
+    /**
+     * Assert the signer was never invoked (optionally for a single category).
+     */
+    public function assertNeverSigned(?string $category = null): void
+    {
+        if ($category === null) {
+            PHPUnit::assertEmpty(
+                $this->records,
+                'SwarmAuditSigner was invoked unexpectedly.',
+            );
+
+            return;
+        }
+
+        PHPUnit::assertEmpty(
+            $this->recordsFor($category),
+            "SwarmAuditSigner was invoked for category [{$category}] unexpectedly.",
+        );
+    }
+}

--- a/src/Testing/SwarmFake.php
+++ b/src/Testing/SwarmFake.php
@@ -6,8 +6,13 @@ namespace BuiltByBerry\LaravelSwarm\Testing;
 
 use BuiltByBerry\LaravelSwarm\Attributes\Topology as TopologyAttribute;
 use BuiltByBerry\LaravelSwarm\Audit\Actor;
+use BuiltByBerry\LaravelSwarm\Audit\CaptureDecision;
+use BuiltByBerry\LaravelSwarm\Audit\SwarmAuditDispatcher;
 use BuiltByBerry\LaravelSwarm\Contracts\Agent;
+use BuiltByBerry\LaravelSwarm\Contracts\CapturePolicy;
+use BuiltByBerry\LaravelSwarm\Contracts\SinkFailureHandler;
 use BuiltByBerry\LaravelSwarm\Contracts\Swarm;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSigner;
 use BuiltByBerry\LaravelSwarm\Enums\Topology as TopologyEnum;
 use BuiltByBerry\LaravelSwarm\Responses\DurableRunDetail;
 use BuiltByBerry\LaravelSwarm\Responses\DurableSwarmResponse;
@@ -22,7 +27,11 @@ use BuiltByBerry\LaravelSwarm\Streaming\Events\SwarmStreamEvent;
 use BuiltByBerry\LaravelSwarm\Streaming\Events\SwarmStreamStart;
 use BuiltByBerry\LaravelSwarm\Streaming\Events\SwarmTextDelta;
 use BuiltByBerry\LaravelSwarm\Support\RunContext;
+use BuiltByBerry\LaravelSwarm\Testing\Audit\RecordingCapturePolicy;
+use BuiltByBerry\LaravelSwarm\Testing\Audit\RecordingSinkFailureHandler;
+use BuiltByBerry\LaravelSwarm\Testing\Audit\RecordingSwarmAuditSigner;
 use Illuminate\Broadcasting\Channel;
+use Illuminate\Container\Container;
 use Illuminate\Testing\Assert as PHPUnit;
 use Laravel\Ai\FakePendingDispatch;
 
@@ -614,6 +623,77 @@ class SwarmFake implements Swarm
             $actors,
             "The swarm [{$this->swarmClass}] was dispatched with an actor unexpectedly.",
         );
+    }
+
+    /**
+     * Install a {@see RecordingCapturePolicy} as the bound {@see CapturePolicy}
+     * for the duration of the test.
+     *
+     * The returned recorder exposes assertion helpers covering every
+     * dispatcher invocation of the policy (inputs, outputs, artifacts,
+     * activeContext). The optional delegate is forwarded to behind the
+     * recording layer so existing policy logic still drives decisions;
+     * pass null to record-and-return {@see CaptureDecision::Full}
+     * for every category.
+     *
+     * Recording happens when the real audit dispatcher resolves the
+     * contract from the container during a non-faked run. SwarmFake itself
+     * never constructs or invokes the dispatcher — this helper only swaps
+     * the container binding and flushes the dispatcher singleton so the
+     * next resolution picks up the recorder.
+     */
+    public static function interceptCapturePolicy(?CapturePolicy $delegate = null): RecordingCapturePolicy
+    {
+        $recorder = new RecordingCapturePolicy($delegate);
+
+        self::bindAuditIntercept(CapturePolicy::class, $recorder);
+
+        return $recorder;
+    }
+
+    /**
+     * Install a {@see RecordingSinkFailureHandler} as the bound
+     * {@see SinkFailureHandler} for the duration of the test.
+     *
+     * See {@see interceptCapturePolicy()} for the design contract.
+     */
+    public static function interceptSinkFailureHandler(?SinkFailureHandler $delegate = null): RecordingSinkFailureHandler
+    {
+        $recorder = new RecordingSinkFailureHandler($delegate);
+
+        self::bindAuditIntercept(SinkFailureHandler::class, $recorder);
+
+        return $recorder;
+    }
+
+    /**
+     * Install a {@see RecordingSwarmAuditSigner} as the bound
+     * {@see SwarmAuditSigner} for the duration of the test.
+     *
+     * See {@see interceptCapturePolicy()} for the design contract. Unlike
+     * the other two contracts, no default binding exists for the signer —
+     * installing the recorder is what enables signing in the dispatcher
+     * during the run.
+     */
+    public static function interceptSwarmAuditSigner(?SwarmAuditSigner $delegate = null): RecordingSwarmAuditSigner
+    {
+        $recorder = new RecordingSwarmAuditSigner($delegate);
+
+        self::bindAuditIntercept(SwarmAuditSigner::class, $recorder);
+
+        return $recorder;
+    }
+
+    /**
+     * Swap the bound contract to the recording decorator and flush the
+     * dispatcher singleton so it picks up the new contract on next resolve.
+     */
+    protected static function bindAuditIntercept(string $abstract, object $recorder): void
+    {
+        $container = Container::getInstance();
+
+        $container->instance($abstract, $recorder);
+        $container->forgetInstance(SwarmAuditDispatcher::class);
     }
 
     /**

--- a/tests/Unit/Testing/SwarmFakeAuditInterceptsTest.php
+++ b/tests/Unit/Testing/SwarmFakeAuditInterceptsTest.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Audit\Actor;
+use BuiltByBerry\LaravelSwarm\Audit\CaptureDecision;
+use BuiltByBerry\LaravelSwarm\Audit\SinkFailureDecision;
+use BuiltByBerry\LaravelSwarm\Audit\SwarmAuditDispatcher;
+use BuiltByBerry\LaravelSwarm\Contracts\CapturePolicy;
+use BuiltByBerry\LaravelSwarm\Contracts\SinkFailureHandler;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSigner;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
+use BuiltByBerry\LaravelSwarm\Support\RunContext;
+use BuiltByBerry\LaravelSwarm\Testing\Audit\RecordingCapturePolicy;
+use BuiltByBerry\LaravelSwarm\Testing\Audit\RecordingSinkFailureHandler;
+use BuiltByBerry\LaravelSwarm\Testing\Audit\RecordingSwarmAuditSigner;
+use BuiltByBerry\LaravelSwarm\Testing\SwarmFake;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\RecordingSwarmAuditSink;
+use PHPUnit\Framework\AssertionFailedError;
+
+// -- RecordingCapturePolicy ---------------------------------------------------
+
+test('RecordingCapturePolicy returns Full for every category when no delegate is supplied', function (): void {
+    $recorder = new RecordingCapturePolicy;
+
+    expect($recorder->inputs())->toBe(CaptureDecision::Full);
+    expect($recorder->outputs())->toBe(CaptureDecision::Full);
+    expect($recorder->artifacts())->toBe(CaptureDecision::Full);
+    expect($recorder->activeContext())->toBe(CaptureDecision::Full);
+
+    expect($recorder->records())->toHaveCount(4);
+});
+
+test('RecordingCapturePolicy forwards to the delegate when one is supplied', function (): void {
+    $delegate = new class implements CapturePolicy
+    {
+        public function inputs(?RunContext $context = null, ?Actor $actor = null): CaptureDecision
+        {
+            return CaptureDecision::Redact;
+        }
+
+        public function outputs(?RunContext $context = null, ?Actor $actor = null): CaptureDecision
+        {
+            return CaptureDecision::Skip;
+        }
+
+        public function artifacts(?RunContext $context = null, ?Actor $actor = null): CaptureDecision
+        {
+            return CaptureDecision::Redact;
+        }
+
+        public function activeContext(?RunContext $context = null, ?Actor $actor = null): CaptureDecision
+        {
+            return CaptureDecision::Full;
+        }
+    };
+
+    $recorder = new RecordingCapturePolicy($delegate);
+
+    expect($recorder->inputs())->toBe(CaptureDecision::Redact);
+    expect($recorder->outputs())->toBe(CaptureDecision::Skip);
+    expect($recorder->artifacts())->toBe(CaptureDecision::Redact);
+    expect($recorder->activeContext())->toBe(CaptureDecision::Full);
+
+    $recorder->assertCapturedDecision('inputs', CaptureDecision::Redact);
+    $recorder->assertCapturedDecision('outputs', CaptureDecision::Skip);
+});
+
+test('RecordingCapturePolicy records context and actor', function (): void {
+    $recorder = new RecordingCapturePolicy;
+    $context = RunContext::fromTask('hi');
+    $actor = new Actor(id: 'u-1', type: 'user');
+
+    $recorder->inputs($context, $actor);
+
+    $records = $recorder->recordsFor('inputs');
+    expect($records)->toHaveCount(1);
+    expect($records[0]['context'])->toBe($context);
+    expect($records[0]['actor'])->toBe($actor);
+});
+
+test('assertCaptured fails with a clear message when the category was never invoked', function (): void {
+    $recorder = new RecordingCapturePolicy;
+
+    expect(fn () => $recorder->assertCaptured('outputs'))
+        ->toThrow(AssertionFailedError::class, 'CapturePolicy was not invoked for category [outputs].');
+});
+
+test('assertNeverCaptured fails when the category was invoked', function (): void {
+    $recorder = new RecordingCapturePolicy;
+    $recorder->inputs();
+
+    expect(fn () => $recorder->assertNeverCaptured('inputs'))
+        ->toThrow(AssertionFailedError::class, 'CapturePolicy was invoked for category [inputs] unexpectedly.');
+});
+
+test('assertCapturedWith matches across categories', function (): void {
+    $recorder = new RecordingCapturePolicy;
+    $actor = new Actor(id: 'u-7', type: 'user');
+    $recorder->outputs(actor: $actor);
+
+    $recorder->assertCapturedWith(fn (array $record): bool => ($record['actor']?->id ?? null) === 'u-7');
+});
+
+// -- RecordingSinkFailureHandler ---------------------------------------------
+
+test('RecordingSinkFailureHandler returns Swallow by default', function (): void {
+    $recorder = new RecordingSinkFailureHandler;
+    $sink = new RecordingSwarmAuditSink;
+
+    $decision = $recorder->handle($sink, 'run.started', ['run_id' => 'x'], new RuntimeException('sink down'));
+
+    expect($decision)->toBe(SinkFailureDecision::Swallow);
+    expect($recorder->records())->toHaveCount(1);
+});
+
+test('RecordingSinkFailureHandler can return a custom default decision', function (): void {
+    $recorder = new RecordingSinkFailureHandler(defaultDecision: SinkFailureDecision::Halt);
+
+    $decision = $recorder->handle(new RecordingSwarmAuditSink, 'run.started', [], new RuntimeException('x'));
+
+    expect($decision)->toBe(SinkFailureDecision::Halt);
+});
+
+test('RecordingSinkFailureHandler forwards to the delegate when supplied', function (): void {
+    $delegate = new class implements SinkFailureHandler
+    {
+        public function handle(SwarmAuditSink $sink, string $category, array $payload, Throwable $exception): SinkFailureDecision
+        {
+            return SinkFailureDecision::DeadLetter;
+        }
+    };
+
+    $recorder = new RecordingSinkFailureHandler($delegate);
+
+    $decision = $recorder->handle(new RecordingSwarmAuditSink, 'run.failed', [], new RuntimeException('x'));
+
+    expect($decision)->toBe(SinkFailureDecision::DeadLetter);
+    $recorder->assertSinkFailureRoutedAs(SinkFailureDecision::DeadLetter);
+});
+
+test('assertSinkFailureRouted fails when the handler was never invoked', function (): void {
+    $recorder = new RecordingSinkFailureHandler;
+
+    expect(fn () => $recorder->assertSinkFailureRouted())
+        ->toThrow(AssertionFailedError::class, 'SinkFailureHandler was not invoked.');
+});
+
+test('assertNeverSinkFailure fails when the handler was invoked', function (): void {
+    $recorder = new RecordingSinkFailureHandler;
+    $recorder->handle(new RecordingSwarmAuditSink, 'run.started', [], new RuntimeException('x'));
+
+    expect(fn () => $recorder->assertNeverSinkFailure())
+        ->toThrow(AssertionFailedError::class, 'SinkFailureHandler was invoked unexpectedly.');
+});
+
+// -- RecordingSwarmAuditSigner -----------------------------------------------
+
+test('RecordingSwarmAuditSigner returns the payload unchanged when no delegate is supplied', function (): void {
+    $recorder = new RecordingSwarmAuditSigner;
+
+    $signed = $recorder->sign('run.started', ['run_id' => 'r-1']);
+
+    expect($signed)->toBe(['run_id' => 'r-1']);
+    expect($recorder->records())->toHaveCount(1);
+});
+
+test('RecordingSwarmAuditSigner forwards to the delegate when supplied', function (): void {
+    $delegate = new class implements SwarmAuditSigner
+    {
+        public function sign(string $category, array $payload): array
+        {
+            $payload['signature'] = 'sig-of-'.$category;
+
+            return $payload;
+        }
+    };
+
+    $recorder = new RecordingSwarmAuditSigner($delegate);
+
+    $signed = $recorder->sign('run.completed', ['run_id' => 'r-2']);
+
+    expect($signed)->toBe(['run_id' => 'r-2', 'signature' => 'sig-of-run.completed']);
+
+    $recorder->assertSigned('run.completed', fn (array $record): bool => $record['output']['signature'] === 'sig-of-run.completed');
+});
+
+test('assertSigned fails when the signer was never invoked', function (): void {
+    $recorder = new RecordingSwarmAuditSigner;
+
+    expect(fn () => $recorder->assertSigned())
+        ->toThrow(AssertionFailedError::class, 'SwarmAuditSigner was not invoked for any category.');
+});
+
+test('assertNeverSigned fails when the signer was invoked', function (): void {
+    $recorder = new RecordingSwarmAuditSigner;
+    $recorder->sign('run.started', ['x' => 1]);
+
+    expect(fn () => $recorder->assertNeverSigned())
+        ->toThrow(AssertionFailedError::class, 'SwarmAuditSigner was invoked unexpectedly.');
+});
+
+// -- SwarmFake intercept helpers + real dispatcher integration ---------------
+
+test('SwarmFake::interceptCapturePolicy swaps the container binding to a recorder', function (): void {
+    $recorder = SwarmFake::interceptCapturePolicy();
+
+    expect(app(CapturePolicy::class))->toBe($recorder);
+});
+
+test('SwarmFake::interceptSinkFailureHandler swaps the container binding to a recorder', function (): void {
+    $recorder = SwarmFake::interceptSinkFailureHandler();
+
+    expect(app(SinkFailureHandler::class))->toBe($recorder);
+});
+
+test('SwarmFake::interceptSwarmAuditSigner swaps the container binding to a recorder', function (): void {
+    $recorder = SwarmFake::interceptSwarmAuditSigner();
+
+    expect(app(SwarmAuditSigner::class))->toBe($recorder);
+});
+
+test('intercept helpers flush the dispatcher singleton so it picks up new bindings', function (): void {
+    // Prime the singleton with the default bindings.
+    $first = app(SwarmAuditDispatcher::class);
+
+    SwarmFake::interceptCapturePolicy();
+
+    $second = app(SwarmAuditDispatcher::class);
+
+    expect($first)->not->toBe($second);
+});
+
+test('signer recorder is invoked by the real dispatcher during emit', function (): void {
+    $sink = new RecordingSwarmAuditSink;
+    app()->instance(SwarmAuditSink::class, $sink);
+
+    $signerRecorder = SwarmFake::interceptSwarmAuditSigner();
+
+    app(SwarmAuditDispatcher::class)->emit('run.started', ['run_id' => 'r-9']);
+
+    $signerRecorder->assertSigned('run.started');
+    expect($sink->allRecords())->toHaveCount(1);
+});
+
+test('sink failure handler recorder is invoked by the real dispatcher when the sink throws', function (): void {
+    $throwingSink = new class implements SwarmAuditSink
+    {
+        public function emit(string $category, array $payload): void
+        {
+            throw new RuntimeException('sink exploded');
+        }
+    };
+
+    app()->instance(SwarmAuditSink::class, $throwingSink);
+
+    $handlerRecorder = SwarmFake::interceptSinkFailureHandler();
+
+    app(SwarmAuditDispatcher::class)->emit('run.started', ['run_id' => 'r-10']);
+
+    $handlerRecorder->assertSinkFailureRouted();
+    $handlerRecorder->assertSinkFailureRoutedAs(SinkFailureDecision::Swallow, 'run.started');
+});


### PR DESCRIPTION
## Summary

- Adds `SwarmFake::interceptCapturePolicy()`, `interceptSinkFailureHandler()`, and `interceptSwarmAuditSigner()` — three static helpers that install recording decorators for the v0.4 audit-extension contracts and return a recorder with first-class assertion methods.
- Replaces the v0.4.3 "Testing Audit Extension Points" workaround documentation in `docs/testing.md` with a new leading section covering the intercepts. The original workaround patterns remain documented below as the right tool for in-isolation unit tests and full-envelope sink assertions.
- Tests in `tests/Unit/Testing/SwarmFakeAuditInterceptsTest.php` cover the recorders' default behavior, delegate forwarding, container-binding swap, dispatcher-singleton flush, and live integration with `SwarmAuditDispatcher::emit()` for both the signer and failure-handler paths.

## Design — option (a) intercepts, preserving "doesn't touch the dispatcher"

Per the issue's maintainer-locked decision this implements **option (a)**: SwarmFake intercepts. The constraint was that whatever ships must NOT compromise SwarmFake's "doesn't touch the dispatcher" design property — recording for assertions is fine; routing through the real dispatcher is not.

The recording layer satisfies that property cleanly:

- Each intercept is a thin **decorator** of the underlying contract (`RecordingCapturePolicy`, `RecordingSinkFailureHandler`, `RecordingSwarmAuditSigner`). The decorators implement the contract directly and either delegate to a user-supplied delegate or return a sensible neutral default (Full / Swallow / payload-unchanged).
- `SwarmFake::intercept*` swaps the container binding to the decorator and **forgets the `SwarmAuditDispatcher` singleton** so the next resolution constructs a dispatcher that sees the recorder. That is the entire mechanism.
- `SwarmFake` itself never constructs, calls, or holds a reference to `SwarmAuditDispatcher`. The dispatcher is still owned by the real runner; SwarmFake's existing `prompt() / run() / queue() / stream() / dispatchDurable()` paths continue to skip it entirely.
- Recording happens during **real (non-faked) swarm runs**, which is exactly the scenario the issue called out as gapped: callers who run their swarm through `SwarmRunner` and want to assert that their custom capture policy, signer, or failure handler was invoked with the expected category / decision.

This is functionally equivalent to "bind a recording sink" (the existing workaround documented in `docs/testing.md`), but extended to the three contracts that previously had no analogous helper, and with a first-class assertion API matching SwarmFake's existing style (`assertCaptured`, `assertSinkFailureRouted`, `assertSigned`, plus `Never*` variants).

`ActorResolver` is not covered: `SwarmFake::assertDispatchedWithActor()` and friends already cover the dispatch-time actor signal as of v0.4.3, and `ActorResolver` is otherwise a Laravel `Context` adapter best covered by `tests/Unit/Audit/DefaultActorResolverTest.php`-style unit tests. No follow-up deferred.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)