### PR TITLE
chore(release): v0.7.0 readiness gate followups

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,7 @@ Use [Persistence And History](docs/persistence-and-history.md), [Maintenance](do
 - Avoid secrets in metadata. Capture redaction does not sanitize arbitrary developer-supplied metadata. Set `SWARM_MAX_METADATA_BYTES` to enforce a hard size cap.
 - Build run inspection around `run_id`, lifecycle events, `SwarmHistory`, and durable runtime state.
 - Bookmark the [Operator Runbook: Audit Outbox Triage](docs/operator-runbook-audit-outbox.md) before going live. It is the 3 a.m. decision tree for dead-letter rows, stale pending rows, and sink outages — and it assumes the reader has not just re-read the reference docs.
+- Use `php artisan swarm:trace <run_id>` (v0.7+) to reconstruct a single run's audit chain across run history, the audit outbox, and the bound sink. Read-only, on-demand, with `--json` for monitoring and `--include-payloads` for full envelopes. See [Audit Evidence Contract](docs/audit-evidence-contract.md#reading-the-audit-chain), including the **Security and retention** subsection covering how the command unseals encrypted-at-rest data on output.
 
 ### Audit Extension Points
 
@@ -504,6 +505,10 @@ Regulated deployments can replace four audit contracts in the container:
 - `CapturePolicy` — decides which run fields are captured, redacted, or omitted before evidence is emitted.
 - `SinkFailureHandler` — handles `SwarmAuditSink` write failures (log, retry, halt, or escalate).
 - `SwarmAuditSigner` — produces the cryptographic signature attached to each envelope for tamper-evident export.
+
+One optional extension contract (v0.7+):
+
+- `ReadableSwarmAuditSink` — extends `SwarmAuditSink` with `forRun(string $runId): iterable<array>` so the sink can participate in `swarm:trace`. Opt-in; the shipped `NoOpSwarmAuditSink` does not implement it and existing custom sinks remain valid.
 
 Two environment knobs control strict-mode behavior:
 

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "0.6.x-dev"
+            "dev-main": "0.7.x-dev"
         },
         "laravel": {
             "providers": [


### PR DESCRIPTION
## Summary

Phase 3 of `/release-wrap` for v0.7.0. Closes the two findings from the release-readiness review (verdict: `ship-with-followups · non-blocker`) and records the SCHEMA_VERSION canary verification that was run as part of the readiness pass.

## Findings addressed

| Ref | Severity | Lens | Resolution |
| --- | --- | --- | --- |
| **F1** | medium | Semver Guardian (+ Open Source Steward) | Bumped `composer.json` `extra.branch-alias.dev-main` from `"0.6.x-dev"` to `"0.7.x-dev"`. Standard readiness-phase fix; same one-line bump as v0.6.0's readiness F2 (commit `87a73a0`). |
| **F3** | low | Docs Engineer (+ Open Source Steward) | Added Production Checklist bullet for `swarm:trace` cross-linking the new **Security and retention** subsection. Added "One optional extension contract (v0.7+)" subsection to Audit Extension Points naming `ReadableSwarmAuditSink` with opt-in + back-compat framing. |

## Verification performed: SCHEMA_VERSION canary tamper test

The readiness review's stretch option was to verify that `tests/Unit/Audit/EvidenceSchemaVersionTest.php` (the regression test shipped in #78) actually fails fast when `EvidenceEnvelope::SCHEMA_VERSION` drifts. Performed locally; no code committed.

**Tamper:** `src/Telemetry/EvidenceEnvelope.php` line 16 — `'2'` → `'3'`.

**Result:** 3 of 4 canary tests failed as expected:

- `EvidenceEnvelope::SCHEMA_VERSION is "2" — bumped in v0.5.0` — fails (expected `"2"`, got `"3"`).
- `every audit category dispatched through SwarmAuditDispatcher carries schema_version "2"` — fails on every category (37 categories all report `"3"`).
- `dispatcher emit does not let a caller-supplied schema_version override the envelope` — fails (caller's deliberate `"1"` is overridden to `"3"`, not `"2"`).

The 1 passing test was `SwarmAuditDispatcher::SCHEMA_VERSION mirrors EvidenceEnvelope::SCHEMA_VERSION` — correctly passes because both moved to `"3"` together. The mirror test is a *coordination* check (the deprecated dispatcher constant must track the envelope constant), not a bump guard.

**Scope note for the audit trail.** The canary guards the dispatcher path completely — that's the only production path that emits envelopes. Any future stale `"1"` emitter that *bypasses* `SwarmAuditDispatcher` would not be caught by this canary; that surface is covered out-of-band by the manual audit in #76, which scanned `src/`, `tests/`, `examples/`, and `database/` and found zero stale emitters. The two layers compose into reasonable defense-in-depth.

After the tamper test the constant was reverted to `"2"`; full suite reconfirmed green (867 passed, 3463 assertions).

## Open gaps (carried forward)

- **OG1** — At readiness review time the GH Actions `tests` job for the release tip was still in progress. Previous run on an earlier commit was green; real-DB matrix + branch-naming were green on the latest. Wait for the in-flight job to complete before tagging; if it goes red, this PR should be held.

## Verification

- `composer test`: 867 passed, 3463 assertions
- `composer lint`: pint clean
- Tamper test (see above): canary fails fast on bump, full suite back to green after revert

## Next phase

After this merges, the release wrap-up is complete:

- [x] All topic PRs merged (#71, #72, #73, #74, #77, #78, #79, #80)
- [x] Multi-expert review run (#81 merged)
- [x] CHANGELOG + UPGRADING filled (#82 merged)
- [x] Release-readiness review run (this PR addresses both findings; SCHEMA_VERSION canary verified)
- [ ] Ready for merge + tag

After this PR merges and OG1's `tests` job goes green, the next steps per [AGENTS.md → Release Workflow](../blob/main/AGENTS.md#release-workflow):

```bash
# 1. Merge release/v0.7.0 → main via PR #70 (the long-lived draft release PR)
# 2. After that PR merges to main:
git switch main && git pull && git tag v0.7.0 && git push origin v0.7.0
```

Tag on main, never on the release branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)