### PR TITLE
chore(ci): scope GITHUB_TOKEN to contents:read in tests-real-db workflow

### DIFF
--- a/.github/workflows/tests-real-db.yml
+++ b/.github/workflows/tests-real-db.yml
@@ -20,6 +20,13 @@ on:
       - '*.x'
   pull_request:
 
+# Scope the GITHUB_TOKEN to least privilege. Both jobs only checkout the repo
+# and run tests against ephemeral service containers — no PR comments, no
+# release writes, no artifact uploads — so contents:read is sufficient.
+# Matches the pattern set by .github/workflows/branch-naming.yml.
+permissions:
+  contents: read
+
 jobs:
   tests-real-db-mysql:
     name: PHP 8.5 - real DB (mysql-8)


### PR DESCRIPTION
## Summary

CodeQL flagged both jobs in `.github/workflows/tests-real-db.yml` (the workflow that landed in #73 alongside the audit-outbox concurrency test):

- [Alert #6](https://github.com/builtbyberry/laravel-swarm/security/code-scanning/6) — `tests-real-db-mysql` job (line 97 in the original)
- [Alert #7](https://github.com/builtbyberry/laravel-swarm/security/code-scanning/7) — `tests-real-db-postgres` job (line 169)

Both are the same rule: **"Workflow does not contain permissions"** — the workflow inherits the broad default `GITHUB_TOKEN` scope instead of declaring least privilege.

## Fix

Top-level `permissions: contents: read` block. Both jobs only `actions/checkout` the repo and run tests against ephemeral MySQL and Postgres service containers — no PR comments, no release writes, no artifact uploads — so `contents: read` is sufficient.

Top-level placement (rather than per-job) gives a single point of policy and matches the pattern already set by `.github/workflows/branch-naming.yml` (which has `permissions: contents: read` at the top).

```yaml
permissions:
  contents: read
```

## Why during the release wrap

Both alerts surface against the new workflow that landed during v0.7.0's wave-1 (#73, [`46002e5`](https://github.com/builtbyberry/laravel-swarm/commit/46002e5)). CodeQL didn't surface them in the multi-expert review (#81) or the readiness review (#83) because those run against PHP source, not workflow YAML — they're surfaced now that the merged commits hit `release/v0.7.0` and CodeQL re-scanned the integration branch.

This counts as a small targeted readiness-phase fix (security tool output, one-line YAML change, no behavior change). Per AGENTS.md the existing `chore/0.7.0-readiness-followups` slug already merged, so this rides on a sibling `chore/0.7.0-codeql-permissions` topic branch.

## Verification

- YAML parses cleanly (validated via `ruby -ryaml`).
- No code changes; no test changes.
- After this merges, the next CodeQL re-scan on the release branch should clear both alerts. If the alerts don't auto-dismiss, mark them as fixed in the security tab.

## Release-wrap impact

PR #70 (the release-to-main PR) was marked ready for review at the end of `/release-wrap` Phase 3. This PR addresses a security finding surfaced *after* that mark-ready step. After it merges:

- The `release/v0.7.0` branch will include this fix.
- PR #70's diff updates automatically.
- Hold the merge on #70 until this lands.

Closes CodeQL alerts #6 and #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)