### PR TITLE
chore(release): v0.8.0 readiness gate followups

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "0.7.x-dev"
+            "dev-main": "0.8.x-dev"
         },
         "laravel": {
             "providers": [


### PR DESCRIPTION
## Summary

Phase 3 of \`/release-wrap\` — addresses the single finding from the release-readiness review on \`release/v0.8.0\`.

## Finding addressed

### F1 · medium · Semver Guardian (+ Open Source Steward via synthesis)

- **Where:** \`composer.json\` line 57-59
- **Issue:** \`branch-alias.dev-main\` still declared \`0.7.x-dev\` — needed to advance to \`0.8.x-dev\` to match the about-to-ship release line. Standard release-hygiene step per the v0.6.0 precedent (\`87a73a0\`). Without the bump, downstream consumers pulling \`dev-main\` would get a stale dev-tip version constraint.
- **Fix:** One-line edit, \`0.7.x-dev\` → \`0.8.x-dev\`.

## Verification

- Composer constraint change only; no test impact.
- Recorded as \`branch-alias-bump\` (status: fixed) in \`.claude/release-state.json\`.

## Next step

Once this merges, the three-phase wrap is complete. \`/release-wrap\` will:
1. Detect Phase 1, 2, 3 all clean.
2. Convert draft PR [#94](https://github.com/builtbyberry/laravel-swarm/pull/94) to ready-for-review.
3. Report the exact tag command for after the release PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)