### PR TITLE
feat(memory): SwarmMemory foundation — contracts + default stores + tests

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -18,4 +18,5 @@ parameters:
                 - src/Persistence/DatabaseDurableRunStore.php
                 - src/Persistence/DatabaseRunHistoryStore.php
                 - src/Persistence/DatabaseContextStore.php
+                - src/Memory/DatabaseMemoryStore.php
                 - src/Pulse/Livewire/SwarmSteps.php

--- a/src/Contracts/MemoryStore.php
+++ b/src/Contracts/MemoryStore.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Contracts;
+
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Memory\MemoryEntry;
+
+/**
+ * Persistence driver for Swarm memory entries.
+ *
+ * Implementations own the storage backend (database, in-memory, vector store
+ * via a companion package, etc.). They handle one entry at a time, keyed by
+ * the `(scope, scope_id, key)` tuple, and do not interpret scope semantics
+ * beyond using it as an indexed dimension.
+ *
+ * The default binding is `DatabaseMemoryStore`. Companion packages or
+ * applications may bind a different implementation in the container to swap
+ * backends without changing the calling code.
+ *
+ * Stores are responsible for plain-data normalization on write and timestamp
+ * stamping. They must round-trip `MemoryEntry` instances faithfully: writing
+ * an entry and reading it back yields equal scope, scope_id, key, value, and
+ * metadata.
+ */
+interface MemoryStore
+{
+    /**
+     * Persist an entry, inserting or updating by `(scope, scope_id, key)`.
+     *
+     * Returns the persisted entry with `createdAt` and `updatedAt` populated.
+     */
+    public function put(MemoryEntry $entry): MemoryEntry;
+
+    /**
+     * Fetch a single entry by its address, or null when absent.
+     */
+    public function get(MemoryScope $scope, string $scopeId, string $key): ?MemoryEntry;
+
+    /**
+     * Delete an entry by its address. Returns true when a row was removed.
+     */
+    public function forget(MemoryScope $scope, string $scopeId, string $key): bool;
+
+    /**
+     * Return every entry under a given `(scope, scope_id)`.
+     *
+     * Order is not guaranteed across drivers. Callers that need a specific
+     * order must sort the result themselves.
+     *
+     * @return array<int, MemoryEntry>
+     */
+    public function all(MemoryScope $scope, string $scopeId): array;
+}

--- a/src/Contracts/SwarmMemory.php
+++ b/src/Contracts/SwarmMemory.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Contracts;
+
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Memory\MemoryEntry;
+
+/**
+ * Application-facing facade for Swarm memory.
+ *
+ * Where {@see MemoryStore} is the storage driver (entry-shaped, low-level),
+ * `SwarmMemory` is the ergonomic surface application code, runners, and
+ * agent tools use. It accepts and returns values directly — the entry shape
+ * is an implementation detail except when callers need metadata or
+ * timestamps.
+ *
+ * Resolve via the container (`app(SwarmMemory::class)`) or the
+ * `Swarm::memory()` helper.
+ *
+ * Implementations delegate persistence to a `MemoryStore` driver and apply
+ * cross-cutting concerns layered on top (capture policy redaction, lifecycle
+ * events, scope validation). The contract intentionally keeps a small
+ * surface — scoped propagation and snapshot-on-invocation live on separate
+ * contracts so this facade stays usable from any context.
+ */
+interface SwarmMemory
+{
+    /**
+     * Read the value at `(scope, scopeId, key)`, or null when absent.
+     *
+     * Returns the value directly. Use {@see entry()} when metadata or
+     * timestamps are needed alongside the value.
+     */
+    public function get(MemoryScope $scope, string $scopeId, string $key): mixed;
+
+    /**
+     * Read the full entry at `(scope, scopeId, key)`, or null when absent.
+     */
+    public function entry(MemoryScope $scope, string $scopeId, string $key): ?MemoryEntry;
+
+    /**
+     * Write a value at `(scope, scopeId, key)`, inserting or updating.
+     *
+     * Returns the persisted entry so callers can read back timestamps and
+     * any policy-applied metadata.
+     *
+     * @param  array<string, mixed>  $metadata
+     */
+    public function put(
+        MemoryScope $scope,
+        string $scopeId,
+        string $key,
+        mixed $value,
+        array $metadata = [],
+    ): MemoryEntry;
+
+    /**
+     * Delete the entry at `(scope, scopeId, key)`. Returns true when a row
+     * was removed.
+     */
+    public function forget(MemoryScope $scope, string $scopeId, string $key): bool;
+
+    /**
+     * Return every entry under a given `(scope, scopeId)`.
+     *
+     * Order is not guaranteed. Callers that need a specific order must sort
+     * the result themselves.
+     *
+     * @return array<int, MemoryEntry>
+     */
+    public function all(MemoryScope $scope, string $scopeId): array;
+}

--- a/src/Enums/MemoryScope.php
+++ b/src/Enums/MemoryScope.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Enums;
+
+/**
+ * Addressing scope for a Swarm memory entry.
+ *
+ * Every memory entry lives in exactly one scope. The scope determines the
+ * lifetime and visibility of the entry and pairs with a `scope_id` (the
+ * concrete run id, conversation id, agent class, or swarm class) to form the
+ * full address.
+ *
+ * - `Run`          — bounded to a single swarm run. Cleared with the run.
+ * - `Conversation` — shared across runs in the same conversation thread.
+ * - `Agent`        — per-agent-class persistent state (knowledge, preferences).
+ * - `Swarm`        — shared across all agents in a swarm class.
+ *
+ * Propagation policy (v0.10) decides which scopes a worker agent sees when
+ * invoked. Capture policy applies redaction uniformly across scopes.
+ */
+enum MemoryScope: string
+{
+    case Run = 'run';
+
+    case Conversation = 'conversation';
+
+    case Agent = 'agent';
+
+    case Swarm = 'swarm';
+}

--- a/src/Memory/CacheMemoryStore.php
+++ b/src/Memory/CacheMemoryStore.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Memory;
+
+use BuiltByBerry\LaravelSwarm\Contracts\MemoryStore;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Persistence\Concerns\ResolvesSwarmCacheStore;
+use Carbon\CarbonImmutable;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+
+/**
+ * Cache-backed {@see MemoryStore} implementation.
+ *
+ * Default driver when `swarm.persistence.driver` is `cache`. Best for
+ * development, testing, and ephemeral workloads — production deployments
+ * needing audit-grade durability should run the `database` driver instead.
+ *
+ * Entries are keyed `swarm:memory:{scope}:{scope_id}:{key}` and live for
+ * `swarm.memory.ttl_seconds` (default 24h). A sibling index entry at
+ * `swarm:memory:{scope}:{scope_id}:__index` tracks the key set under each
+ * `(scope, scope_id)` so {@see all()} can enumerate without driver-specific
+ * listing primitives.
+ *
+ * @internal
+ */
+final class CacheMemoryStore implements MemoryStore
+{
+    use ResolvesSwarmCacheStore;
+
+    public function __construct(
+        protected CacheFactory $cacheFactory,
+        protected ConfigRepository $config,
+    ) {}
+
+    public function put(MemoryEntry $entry): MemoryEntry
+    {
+        $now = CarbonImmutable::now('UTC');
+        $createdAt = $entry->createdAt ?? $now;
+        $persisted = $entry->withTimestamps($createdAt, $now);
+
+        $this->store()->put(
+            $this->entryKey($entry->scope, $entry->scopeId, $entry->key),
+            $this->encode($persisted),
+            $this->ttl(),
+        );
+
+        $this->appendToIndex($entry->scope, $entry->scopeId, $entry->key);
+
+        return $persisted;
+    }
+
+    public function get(MemoryScope $scope, string $scopeId, string $key): ?MemoryEntry
+    {
+        /** @var array<string, mixed>|null $payload */
+        $payload = $this->store()->get($this->entryKey($scope, $scopeId, $key));
+
+        return $payload === null ? null : $this->decode($payload);
+    }
+
+    public function forget(MemoryScope $scope, string $scopeId, string $key): bool
+    {
+        $existed = $this->store()->has($this->entryKey($scope, $scopeId, $key));
+
+        $this->store()->forget($this->entryKey($scope, $scopeId, $key));
+        $this->removeFromIndex($scope, $scopeId, $key);
+
+        return $existed;
+    }
+
+    public function all(MemoryScope $scope, string $scopeId): array
+    {
+        $entries = [];
+
+        foreach ($this->index($scope, $scopeId) as $key) {
+            $entry = $this->get($scope, $scopeId, $key);
+
+            if ($entry !== null) {
+                $entries[] = $entry;
+            }
+        }
+
+        return $entries;
+    }
+
+    protected function entryKey(MemoryScope $scope, string $scopeId, string $key): string
+    {
+        return $this->prefix().$scope->value.':'.$scopeId.':'.$key;
+    }
+
+    protected function indexKey(MemoryScope $scope, string $scopeId): string
+    {
+        return $this->prefix().$scope->value.':'.$scopeId.':__index';
+    }
+
+    protected function prefix(): string
+    {
+        return (string) $this->config->get('swarm.memory.prefix', 'swarm:memory:');
+    }
+
+    protected function ttl(): int
+    {
+        return (int) $this->config->get('swarm.memory.ttl_seconds', 86400);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function index(MemoryScope $scope, string $scopeId): array
+    {
+        /** @var array<int, string>|null $index */
+        $index = $this->store()->get($this->indexKey($scope, $scopeId));
+
+        return $index ?? [];
+    }
+
+    protected function appendToIndex(MemoryScope $scope, string $scopeId, string $key): void
+    {
+        $index = $this->index($scope, $scopeId);
+
+        if (! in_array($key, $index, true)) {
+            $index[] = $key;
+            $this->store()->put($this->indexKey($scope, $scopeId), $index, $this->ttl());
+        }
+    }
+
+    protected function removeFromIndex(MemoryScope $scope, string $scopeId, string $key): void
+    {
+        $index = array_values(array_filter(
+            $this->index($scope, $scopeId),
+            static fn (string $candidate): bool => $candidate !== $key,
+        ));
+
+        if ($index === []) {
+            $this->store()->forget($this->indexKey($scope, $scopeId));
+
+            return;
+        }
+
+        $this->store()->put($this->indexKey($scope, $scopeId), $index, $this->ttl());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function encode(MemoryEntry $entry): array
+    {
+        return [
+            'scope' => $entry->scope->value,
+            'scope_id' => $entry->scopeId,
+            'key' => $entry->key,
+            'value' => $entry->value,
+            'metadata' => $entry->metadata,
+            'created_at' => $entry->createdAt?->toIso8601String(),
+            'updated_at' => $entry->updatedAt?->toIso8601String(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    protected function decode(array $payload): MemoryEntry
+    {
+        /** @var string $scopeValue */
+        $scopeValue = $payload['scope'];
+        /** @var string $scopeId */
+        $scopeId = $payload['scope_id'];
+        /** @var string $key */
+        $key = $payload['key'];
+        /** @var array<string, mixed> $metadata */
+        $metadata = $payload['metadata'] ?? [];
+        /** @var string|null $createdAt */
+        $createdAt = $payload['created_at'] ?? null;
+        /** @var string|null $updatedAt */
+        $updatedAt = $payload['updated_at'] ?? null;
+
+        return new MemoryEntry(
+            scope: MemoryScope::from($scopeValue),
+            scopeId: $scopeId,
+            key: $key,
+            value: $payload['value'] ?? null,
+            metadata: $metadata,
+            createdAt: $createdAt !== null ? CarbonImmutable::parse($createdAt) : null,
+            updatedAt: $updatedAt !== null ? CarbonImmutable::parse($updatedAt) : null,
+        );
+    }
+
+    protected function store(): CacheRepository
+    {
+        return $this->resolveCacheStore($this->cacheFactory, $this->config, 'memory');
+    }
+}

--- a/src/Memory/DatabaseMemoryStore.php
+++ b/src/Memory/DatabaseMemoryStore.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Memory;
+
+use BuiltByBerry\LaravelSwarm\Contracts\MemoryStore;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Persistence\Concerns\InteractsWithJsonColumns;
+use Carbon\CarbonImmutable;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Builder;
+
+/**
+ * Database-backed {@see MemoryStore} implementation.
+ *
+ * Default driver when `swarm.persistence.driver` is `database`. The
+ * `swarm_memories` table schema lands separately as part of #109
+ * (`memory-entries-schema`); until that migration runs, this store will error
+ * loudly with a missing-table message rather than silently fail.
+ *
+ * Each row holds one entry, keyed `(scope, scope_id, key)` with a uniqueness
+ * constraint on the tuple. `value` and `metadata` are JSON columns to support
+ * arbitrary plain-data shapes.
+ *
+ * @internal
+ */
+final class DatabaseMemoryStore implements MemoryStore
+{
+    use InteractsWithJsonColumns;
+
+    public function __construct(
+        protected Connection $connection,
+        protected ConfigRepository $config,
+    ) {}
+
+    public function put(MemoryEntry $entry): MemoryEntry
+    {
+        $now = CarbonImmutable::now('UTC');
+        $existing = $this->table()
+            ->where('scope', $entry->scope->value)
+            ->where('scope_id', $entry->scopeId)
+            ->where('key', $entry->key)
+            ->first();
+
+        $createdAt = $existing !== null
+            ? CarbonImmutable::parse((string) $existing->created_at)
+            : ($entry->createdAt ?? $now);
+
+        $this->table()->upsert(
+            [[
+                'scope' => $entry->scope->value,
+                'scope_id' => $entry->scopeId,
+                'key' => $entry->key,
+                'value' => $this->encodeJson($entry->value),
+                'metadata' => $this->encodeJson($entry->metadata),
+                'created_at' => $createdAt,
+                'updated_at' => $now,
+            ]],
+            ['scope', 'scope_id', 'key'],
+            ['value', 'metadata', 'updated_at'],
+        );
+
+        return $entry->withTimestamps($createdAt, $now);
+    }
+
+    public function get(MemoryScope $scope, string $scopeId, string $key): ?MemoryEntry
+    {
+        /** @var object|null $record */
+        $record = $this->table()
+            ->where('scope', $scope->value)
+            ->where('scope_id', $scopeId)
+            ->where('key', $key)
+            ->first();
+
+        return $record === null ? null : $this->hydrate($record);
+    }
+
+    public function forget(MemoryScope $scope, string $scopeId, string $key): bool
+    {
+        $deleted = $this->table()
+            ->where('scope', $scope->value)
+            ->where('scope_id', $scopeId)
+            ->where('key', $key)
+            ->delete();
+
+        return $deleted > 0;
+    }
+
+    public function all(MemoryScope $scope, string $scopeId): array
+    {
+        return $this->table()
+            ->where('scope', $scope->value)
+            ->where('scope_id', $scopeId)
+            ->get()
+            ->map(fn (object $record): MemoryEntry => $this->hydrate($record))
+            ->all();
+    }
+
+    protected function table(): Builder
+    {
+        return $this->connection->table(
+            (string) $this->config->get('swarm.tables.memories', 'swarm_memories'),
+        );
+    }
+
+    protected function hydrate(object $record): MemoryEntry
+    {
+        /** @var array<string, mixed> $metadata */
+        $metadata = $this->decodeJson($record->metadata, []);
+
+        return new MemoryEntry(
+            scope: MemoryScope::from((string) $record->scope),
+            scopeId: (string) $record->scope_id,
+            key: (string) $record->key,
+            value: $this->decodeJson($record->value, null),
+            metadata: $metadata,
+            createdAt: CarbonImmutable::parse((string) $record->created_at),
+            updatedAt: CarbonImmutable::parse((string) $record->updated_at),
+        );
+    }
+}

--- a/src/Memory/DefaultSwarmMemory.php
+++ b/src/Memory/DefaultSwarmMemory.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Memory;
+
+use BuiltByBerry\LaravelSwarm\Contracts\MemoryStore;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmMemory;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+
+/**
+ * Default {@see SwarmMemory} facade implementation.
+ *
+ * Thin coordinator over a {@see MemoryStore} driver. The facade trades the
+ * driver's entry-shaped surface for a value-shaped one so callers don't have
+ * to construct or unpack `MemoryEntry` objects unless they need metadata or
+ * timestamps. Cross-cutting concerns layered on top of memory (capture-policy
+ * redaction in v0.10, lifecycle events from #115) live alongside this class
+ * rather than inside drivers, so every driver — Cache, Database, vector
+ * companion, third-party — gets them for free.
+ *
+ * @internal
+ */
+final class DefaultSwarmMemory implements SwarmMemory
+{
+    public function __construct(
+        protected MemoryStore $store,
+    ) {}
+
+    public function get(MemoryScope $scope, string $scopeId, string $key): mixed
+    {
+        return $this->store->get($scope, $scopeId, $key)?->value;
+    }
+
+    public function entry(MemoryScope $scope, string $scopeId, string $key): ?MemoryEntry
+    {
+        return $this->store->get($scope, $scopeId, $key);
+    }
+
+    public function put(
+        MemoryScope $scope,
+        string $scopeId,
+        string $key,
+        mixed $value,
+        array $metadata = [],
+    ): MemoryEntry {
+        return $this->store->put(new MemoryEntry(
+            scope: $scope,
+            scopeId: $scopeId,
+            key: $key,
+            value: $value,
+            metadata: $metadata,
+        ));
+    }
+
+    public function forget(MemoryScope $scope, string $scopeId, string $key): bool
+    {
+        return $this->store->forget($scope, $scopeId, $key);
+    }
+
+    public function all(MemoryScope $scope, string $scopeId): array
+    {
+        return $this->store->all($scope, $scopeId);
+    }
+}

--- a/src/Memory/MemoryEntry.php
+++ b/src/Memory/MemoryEntry.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Memory;
+
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use Carbon\CarbonImmutable;
+
+/**
+ * Immutable value object representing a single Swarm memory entry.
+ *
+ * An entry is addressed by the tuple `(scope, scope_id, key)`:
+ *
+ * - `scope`    is one of the {@see MemoryScope} cases.
+ * - `scopeId`  is the concrete identifier within that scope (run id,
+ *              conversation id, agent class, swarm class).
+ * - `key`      is the entry name within the scoped namespace.
+ *
+ * `value` is plain-data (string, int, float, bool, null, or nested arrays of
+ * the same). Stores normalize via `PlainData::value()` before persistence.
+ *
+ * `metadata` is an associative array of plain-data fields. Reserved for
+ * implementation-defined annotations (e.g. capture-policy outcome, source).
+ *
+ * `createdAt` and `updatedAt` are populated by the store on persist. They are
+ * nullable so callers can construct prospective entries before they hit a
+ * store.
+ */
+final readonly class MemoryEntry
+{
+    /**
+     * @param  array<string, mixed>  $metadata
+     */
+    public function __construct(
+        public MemoryScope $scope,
+        public string $scopeId,
+        public string $key,
+        public mixed $value,
+        public array $metadata = [],
+        public ?CarbonImmutable $createdAt = null,
+        public ?CarbonImmutable $updatedAt = null,
+    ) {}
+
+    /**
+     * Return a copy of this entry with a new value (and optional metadata).
+     *
+     * @param  array<string, mixed>|null  $metadata  Replaces metadata when non-null; preserved otherwise.
+     */
+    public function withValue(mixed $value, ?array $metadata = null): self
+    {
+        return new self(
+            scope: $this->scope,
+            scopeId: $this->scopeId,
+            key: $this->key,
+            value: $value,
+            metadata: $metadata ?? $this->metadata,
+            createdAt: $this->createdAt,
+            updatedAt: $this->updatedAt,
+        );
+    }
+
+    /**
+     * Return a copy of this entry with persistence timestamps applied.
+     *
+     * Stores call this after writing the row so the returned entry reflects
+     * what was actually persisted.
+     */
+    public function withTimestamps(CarbonImmutable $createdAt, CarbonImmutable $updatedAt): self
+    {
+        return new self(
+            scope: $this->scope,
+            scopeId: $this->scopeId,
+            key: $this->key,
+            value: $this->value,
+            metadata: $this->metadata,
+            createdAt: $createdAt,
+            updatedAt: $updatedAt,
+        );
+    }
+}

--- a/src/Runners/SwarmRunner.php
+++ b/src/Runners/SwarmRunner.php
@@ -14,6 +14,7 @@ use BuiltByBerry\LaravelSwarm\Contracts\HaltsSwarmExecution;
 use BuiltByBerry\LaravelSwarm\Contracts\RunHistoryStore;
 use BuiltByBerry\LaravelSwarm\Contracts\StreamEventStore;
 use BuiltByBerry\LaravelSwarm\Contracts\Swarm;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmMemory;
 use BuiltByBerry\LaravelSwarm\Enums\CoordinationProfile;
 use BuiltByBerry\LaravelSwarm\Enums\ExecutionMode;
 use BuiltByBerry\LaravelSwarm\Enums\Topology;
@@ -84,6 +85,18 @@ class SwarmRunner
         protected DispatchValidator $validator,
         protected LeaseManager $leases,
     ) {}
+
+    /**
+     * Resolve the shared Swarm memory facade.
+     *
+     * Equivalent to `app(SwarmMemory::class)`; exposed here so the existing
+     * `Swarm::memory()` helper (via the facade `@mixin`) works consistently
+     * with the rest of the runtime accessor surface.
+     */
+    public function memory(): SwarmMemory
+    {
+        return Container::getInstance()->make(SwarmMemory::class);
+    }
 
     /**
      * @param  SwarmTaskInput  $task

--- a/src/SwarmServiceProvider.php
+++ b/src/SwarmServiceProvider.php
@@ -41,12 +41,17 @@ use BuiltByBerry\LaravelSwarm\Contracts\CapturePolicy;
 use BuiltByBerry\LaravelSwarm\Contracts\ContextStore;
 use BuiltByBerry\LaravelSwarm\Contracts\DurableOutbox;
 use BuiltByBerry\LaravelSwarm\Contracts\DurableRunStore;
+use BuiltByBerry\LaravelSwarm\Contracts\MemoryStore;
 use BuiltByBerry\LaravelSwarm\Contracts\RunHistoryStore;
 use BuiltByBerry\LaravelSwarm\Contracts\SinkFailureHandler;
 use BuiltByBerry\LaravelSwarm\Contracts\StreamEventStore;
 use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSigner;
 use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmMemory;
 use BuiltByBerry\LaravelSwarm\Contracts\SwarmTelemetrySink;
+use BuiltByBerry\LaravelSwarm\Memory\CacheMemoryStore;
+use BuiltByBerry\LaravelSwarm\Memory\DatabaseMemoryStore;
+use BuiltByBerry\LaravelSwarm\Memory\DefaultSwarmMemory;
 use BuiltByBerry\LaravelSwarm\Persistence\CacheArtifactRepository;
 use BuiltByBerry\LaravelSwarm\Persistence\CacheContextStore;
 use BuiltByBerry\LaravelSwarm\Persistence\CacheRunHistoryStore;
@@ -243,6 +248,14 @@ class SwarmServiceProvider extends ServiceProvider
             CacheStreamEventStore::class,
             DatabaseStreamEventStore::class,
         ));
+
+        $this->app->singleton(MemoryStore::class, fn (Application $app): MemoryStore => $this->resolvePersistenceStore(
+            $app,
+            'memory',
+            CacheMemoryStore::class,
+            DatabaseMemoryStore::class,
+        ));
+        $this->app->singleton(SwarmMemory::class, DefaultSwarmMemory::class);
     }
 
     /**

--- a/tests/Feature/Memory/CacheMemoryStoreTest.php
+++ b/tests/Feature/Memory/CacheMemoryStoreTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Contracts\MemoryStore;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Memory\CacheMemoryStore;
+use BuiltByBerry\LaravelSwarm\Memory\MemoryEntry;
+use Illuminate\Contracts\Cache\Factory;
+
+beforeEach(function () {
+    /** @var Factory $cacheFactory */
+    $cacheFactory = $this->app->make('cache');
+    $cacheFactory->store('array')->flush();
+});
+
+test('the cache store is bound as the default MemoryStore when persistence is cache', function () {
+    $store = $this->app->make(MemoryStore::class);
+
+    expect($store)->toBeInstanceOf(CacheMemoryStore::class);
+});
+
+test('put persists an entry and stamps timestamps', function () {
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $persisted = $store->put(new MemoryEntry(
+        scope: MemoryScope::Run,
+        scopeId: 'run-1',
+        key: 'last_output',
+        value: 'agent A said hello',
+    ));
+
+    expect($persisted->createdAt)->not->toBeNull();
+    expect($persisted->updatedAt)->not->toBeNull();
+    expect($persisted->createdAt?->toIso8601String())->toBe($persisted->updatedAt?->toIso8601String());
+});
+
+test('get returns the persisted entry when present, null otherwise', function () {
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    expect($store->get(MemoryScope::Run, 'run-1', 'missing'))->toBeNull();
+
+    $store->put(new MemoryEntry(
+        scope: MemoryScope::Run,
+        scopeId: 'run-1',
+        key: 'present',
+        value: ['nested' => true],
+        metadata: ['source' => 'test'],
+    ));
+
+    $fetched = $store->get(MemoryScope::Run, 'run-1', 'present');
+
+    expect($fetched)->not->toBeNull();
+    expect($fetched?->value)->toBe(['nested' => true]);
+    expect($fetched?->metadata)->toBe(['source' => 'test']);
+});
+
+test('put overwrites the previous value for the same address', function () {
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'k', 'first'));
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'k', 'second'));
+
+    expect($store->get(MemoryScope::Run, 'run-1', 'k')?->value)->toBe('second');
+});
+
+test('forget removes the entry and returns true when it existed, false when absent', function () {
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    expect($store->forget(MemoryScope::Run, 'run-1', 'absent'))->toBeFalse();
+
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'present', 'x'));
+
+    expect($store->forget(MemoryScope::Run, 'run-1', 'present'))->toBeTrue();
+    expect($store->get(MemoryScope::Run, 'run-1', 'present'))->toBeNull();
+});
+
+test('all returns every entry under a given (scope, scope_id) and nothing else', function () {
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'a', 1));
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'b', 2));
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-2', 'a', 'other-run'));
+    $store->put(new MemoryEntry(MemoryScope::Conversation, 'run-1', 'a', 'other-scope'));
+
+    $all = $store->all(MemoryScope::Run, 'run-1');
+
+    expect($all)->toHaveCount(2);
+
+    $byKey = collect($all)->keyBy(fn (MemoryEntry $entry): string => $entry->key);
+    expect($byKey['a']->value)->toBe(1);
+    expect($byKey['b']->value)->toBe(2);
+});
+
+test('scope isolation: same scope_id and key across different scopes do not collide', function () {
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $store->put(new MemoryEntry(MemoryScope::Run, 'shared-id', 'profile', 'run-value'));
+    $store->put(new MemoryEntry(MemoryScope::Conversation, 'shared-id', 'profile', 'convo-value'));
+    $store->put(new MemoryEntry(MemoryScope::Agent, 'shared-id', 'profile', 'agent-value'));
+    $store->put(new MemoryEntry(MemoryScope::Swarm, 'shared-id', 'profile', 'swarm-value'));
+
+    expect($store->get(MemoryScope::Run, 'shared-id', 'profile')?->value)->toBe('run-value');
+    expect($store->get(MemoryScope::Conversation, 'shared-id', 'profile')?->value)->toBe('convo-value');
+    expect($store->get(MemoryScope::Agent, 'shared-id', 'profile')?->value)->toBe('agent-value');
+    expect($store->get(MemoryScope::Swarm, 'shared-id', 'profile')?->value)->toBe('swarm-value');
+});
+
+test('scope_id isolation: same scope and key across different scope_ids do not collide', function () {
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-A', 'last_output', 'A-output'));
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-B', 'last_output', 'B-output'));
+
+    expect($store->get(MemoryScope::Run, 'run-A', 'last_output')?->value)->toBe('A-output');
+    expect($store->get(MemoryScope::Run, 'run-B', 'last_output')?->value)->toBe('B-output');
+});
+
+test('forget only removes the targeted entry under (scope, scope_id, key)', function () {
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'a', 1));
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'b', 2));
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-2', 'a', 3));
+
+    $store->forget(MemoryScope::Run, 'run-1', 'a');
+
+    expect($store->get(MemoryScope::Run, 'run-1', 'a'))->toBeNull();
+    expect($store->get(MemoryScope::Run, 'run-1', 'b')?->value)->toBe(2);
+    expect($store->get(MemoryScope::Run, 'run-2', 'a')?->value)->toBe(3);
+});
+
+test('all returns an empty array for an empty (scope, scope_id)', function () {
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    expect($store->all(MemoryScope::Run, 'never-written'))->toBe([]);
+});
+
+test('the index is cleaned up when all keys under a (scope, scope_id) are forgotten', function () {
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'only', 'value'));
+    expect($store->all(MemoryScope::Run, 'run-1'))->toHaveCount(1);
+
+    $store->forget(MemoryScope::Run, 'run-1', 'only');
+    expect($store->all(MemoryScope::Run, 'run-1'))->toHaveCount(0);
+
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'newly-added', 'value'));
+    expect($store->all(MemoryScope::Run, 'run-1'))->toHaveCount(1);
+});

--- a/tests/Feature/Memory/SwarmMemoryFacadeTest.php
+++ b/tests/Feature/Memory/SwarmMemoryFacadeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmMemory;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Facades\Swarm;
+use BuiltByBerry\LaravelSwarm\Memory\DefaultSwarmMemory;
+use Illuminate\Contracts\Cache\Factory;
+
+beforeEach(function () {
+    /** @var Factory $cacheFactory */
+    $cacheFactory = $this->app->make('cache');
+    $cacheFactory->store('array')->flush();
+});
+
+test('the SwarmMemory contract is bound to DefaultSwarmMemory', function () {
+    expect($this->app->make(SwarmMemory::class))->toBeInstanceOf(DefaultSwarmMemory::class);
+});
+
+test('Swarm::memory() returns the bound SwarmMemory instance', function () {
+    $memory = Swarm::memory();
+
+    expect($memory)->toBeInstanceOf(SwarmMemory::class);
+    expect($memory)->toBe($this->app->make(SwarmMemory::class));
+});
+
+test('Swarm::memory() round-trips a value through the cache-backed default store', function () {
+    Swarm::memory()->put(MemoryScope::Run, 'run-facade', 'greeting', 'hello world');
+
+    expect(Swarm::memory()->get(MemoryScope::Run, 'run-facade', 'greeting'))->toBe('hello world');
+});

--- a/tests/Unit/Memory/DefaultSwarmMemoryTest.php
+++ b/tests/Unit/Memory/DefaultSwarmMemoryTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Contracts\MemoryStore;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Memory\DefaultSwarmMemory;
+use BuiltByBerry\LaravelSwarm\Memory\MemoryEntry;
+
+/**
+ * In-memory MemoryStore double for facade-impl tests. Lets us verify the
+ * delegation semantics without booting the application.
+ */
+final class ArrayMemoryStore implements MemoryStore
+{
+    /**
+     * @var array<string, MemoryEntry>
+     */
+    private array $entries = [];
+
+    public function put(MemoryEntry $entry): MemoryEntry
+    {
+        $this->entries[$this->key($entry->scope, $entry->scopeId, $entry->key)] = $entry;
+
+        return $entry;
+    }
+
+    public function get(MemoryScope $scope, string $scopeId, string $key): ?MemoryEntry
+    {
+        return $this->entries[$this->key($scope, $scopeId, $key)] ?? null;
+    }
+
+    public function forget(MemoryScope $scope, string $scopeId, string $key): bool
+    {
+        $address = $this->key($scope, $scopeId, $key);
+        $existed = array_key_exists($address, $this->entries);
+        unset($this->entries[$address]);
+
+        return $existed;
+    }
+
+    public function all(MemoryScope $scope, string $scopeId): array
+    {
+        return array_values(array_filter(
+            $this->entries,
+            fn (MemoryEntry $entry): bool => $entry->scope === $scope && $entry->scopeId === $scopeId,
+        ));
+    }
+
+    private function key(MemoryScope $scope, string $scopeId, string $key): string
+    {
+        return $scope->value.':'.$scopeId.':'.$key;
+    }
+}
+
+test('get returns the value from the underlying store, or null when absent', function () {
+    $store = new ArrayMemoryStore;
+    $memory = new DefaultSwarmMemory($store);
+
+    expect($memory->get(MemoryScope::Run, 'run-1', 'missing'))->toBeNull();
+
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'present', 'hello'));
+
+    expect($memory->get(MemoryScope::Run, 'run-1', 'present'))->toBe('hello');
+});
+
+test('entry returns the full entry, not just the value', function () {
+    $store = new ArrayMemoryStore;
+    $memory = new DefaultSwarmMemory($store);
+
+    $store->put(new MemoryEntry(
+        scope: MemoryScope::Conversation,
+        scopeId: 'conv-1',
+        key: 'tone',
+        value: 'casual',
+        metadata: ['source' => 'classifier'],
+    ));
+
+    $entry = $memory->entry(MemoryScope::Conversation, 'conv-1', 'tone');
+
+    expect($entry)->toBeInstanceOf(MemoryEntry::class);
+    expect($entry?->value)->toBe('casual');
+    expect($entry?->metadata)->toBe(['source' => 'classifier']);
+});
+
+test('put wraps the value in a MemoryEntry and delegates to the store', function () {
+    $store = new ArrayMemoryStore;
+    $memory = new DefaultSwarmMemory($store);
+
+    $persisted = $memory->put(MemoryScope::Run, 'run-1', 'k', 'v', metadata: ['captured' => 'full']);
+
+    expect($persisted)->toBeInstanceOf(MemoryEntry::class);
+    expect($persisted->scope)->toBe(MemoryScope::Run);
+    expect($persisted->scopeId)->toBe('run-1');
+    expect($persisted->key)->toBe('k');
+    expect($persisted->value)->toBe('v');
+    expect($persisted->metadata)->toBe(['captured' => 'full']);
+
+    expect($store->get(MemoryScope::Run, 'run-1', 'k')?->value)->toBe('v');
+});
+
+test('forget delegates to the store and returns its boolean result', function () {
+    $store = new ArrayMemoryStore;
+    $memory = new DefaultSwarmMemory($store);
+
+    expect($memory->forget(MemoryScope::Run, 'run-1', 'absent'))->toBeFalse();
+
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'present', 'x'));
+
+    expect($memory->forget(MemoryScope::Run, 'run-1', 'present'))->toBeTrue();
+    expect($memory->get(MemoryScope::Run, 'run-1', 'present'))->toBeNull();
+});
+
+test('all returns the entry list from the underlying store', function () {
+    $store = new ArrayMemoryStore;
+    $memory = new DefaultSwarmMemory($store);
+
+    $memory->put(MemoryScope::Run, 'run-1', 'a', 1);
+    $memory->put(MemoryScope::Run, 'run-1', 'b', 2);
+    $memory->put(MemoryScope::Run, 'run-2', 'a', 3);
+
+    $entries = $memory->all(MemoryScope::Run, 'run-1');
+
+    expect($entries)->toHaveCount(2);
+    expect(collect($entries)->pluck('value')->all())->toEqualCanonicalizing([1, 2]);
+});

--- a/tests/Unit/Memory/MemoryEntryTest.php
+++ b/tests/Unit/Memory/MemoryEntryTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Memory\MemoryEntry;
+use Carbon\CarbonImmutable;
+
+test('constructs with required fields and defaulted metadata + timestamps', function () {
+    $entry = new MemoryEntry(
+        scope: MemoryScope::Run,
+        scopeId: 'run-abc',
+        key: 'user_preference',
+        value: 'dark',
+    );
+
+    expect($entry->scope)->toBe(MemoryScope::Run);
+    expect($entry->scopeId)->toBe('run-abc');
+    expect($entry->key)->toBe('user_preference');
+    expect($entry->value)->toBe('dark');
+    expect($entry->metadata)->toBe([]);
+    expect($entry->createdAt)->toBeNull();
+    expect($entry->updatedAt)->toBeNull();
+});
+
+test('withValue returns a new instance with the new value, preserving the address', function () {
+    $original = new MemoryEntry(
+        scope: MemoryScope::Conversation,
+        scopeId: 'conv-1',
+        key: 'tone',
+        value: 'formal',
+        metadata: ['source' => 'classifier'],
+    );
+
+    $updated = $original->withValue('casual');
+
+    expect($updated)->not->toBe($original);
+    expect($updated->value)->toBe('casual');
+    expect($updated->scope)->toBe($original->scope);
+    expect($updated->scopeId)->toBe($original->scopeId);
+    expect($updated->key)->toBe($original->key);
+    expect($updated->metadata)->toBe(['source' => 'classifier']);
+});
+
+test('withValue can replace metadata when an array is supplied', function () {
+    $original = new MemoryEntry(
+        scope: MemoryScope::Run,
+        scopeId: 'run-1',
+        key: 'x',
+        value: 1,
+        metadata: ['old' => true],
+    );
+
+    $updated = $original->withValue(2, metadata: ['new' => true]);
+
+    expect($updated->value)->toBe(2);
+    expect($updated->metadata)->toBe(['new' => true]);
+});
+
+test('withTimestamps stamps both timestamps without mutating the source', function () {
+    $original = new MemoryEntry(
+        scope: MemoryScope::Agent,
+        scopeId: 'App\\Agents\\Coach',
+        key: 'persona',
+        value: ['style' => 'friendly'],
+    );
+
+    $createdAt = CarbonImmutable::parse('2026-05-21T12:00:00Z');
+    $updatedAt = CarbonImmutable::parse('2026-05-21T12:30:00Z');
+
+    $persisted = $original->withTimestamps($createdAt, $updatedAt);
+
+    expect($persisted->createdAt)->toEqual($createdAt);
+    expect($persisted->updatedAt)->toEqual($updatedAt);
+    expect($original->createdAt)->toBeNull();
+    expect($original->updatedAt)->toBeNull();
+});
+
+test('accepts plain-data values: string, int, float, bool, null, nested arrays', function () {
+    $cases = [
+        'string' => 'hello',
+        'int' => 42,
+        'float' => 3.14,
+        'bool' => true,
+        'null' => null,
+        'nested' => ['a' => 1, 'b' => [2, 3, 4]],
+    ];
+
+    foreach ($cases as $label => $value) {
+        $entry = new MemoryEntry(
+            scope: MemoryScope::Swarm,
+            scopeId: 'App\\Swarms\\Triage',
+            key: $label,
+            value: $value,
+        );
+
+        expect($entry->value)->toEqual($value, "value [{$label}] preserved as-is");
+    }
+});


### PR DESCRIPTION
## Summary

- Introduces the Swarm Memory subsystem contract surface: `SwarmMemory` facade, `MemoryStore` driver contract, `MemoryScope` enum (Run / Conversation / Agent / Swarm), `MemoryEntry` immutable value object.
- Ships two default driver implementations following the established `ContextStore` pattern: `CacheMemoryStore` (Laravel Cache-backed, default when `swarm.persistence.driver=cache`) and `DatabaseMemoryStore` (targets `swarm_memories`, becomes functional once #109 lands the migration).
- Wires the service provider, the `Swarm::memory()` facade helper, and a 24-test compliance suite covering contract methods, scope-isolation edge cases, and the `Swarm::memory()` integration path. Full suite stays at 981 passing / 3991 assertions.

## Notable design choices

- **`DefaultSwarmMemory` is a thin facade over `MemoryStore`.** Value-shaped surface (`get` returns the value, `put` accepts a value) sits on top of the entry-shaped driver. The v0.10 capture-policy redaction and #115 lifecycle events will layer here rather than per-driver so vector and third-party drivers inherit them.
- **`CacheMemoryStore` maintains a per-`(scope, scope_id)` index entry** to support `all()` without driver-specific listing primitives. Index is cleaned up automatically when the last key under a `(scope, scope_id)` is forgotten.
- **PHPStan**: `DatabaseMemoryStore` joins the existing `property.notFound` ignore list — same rationale documented inline (query-builder rows are `stdClass`; naming every column shape across persistence stores is not practical).

## Out of scope (planned for follow-ups)

- `swarm_memories` migration → #109
- `swarm_memory_snapshots` migration → #110
- Snapshot mechanism → #111
- Replay-from-snapshot determinism → #112
- `RunContext` refactor onto SwarmMemory (BREAKING) → #113
- `swarm:install:memory` sub-installer → #114
- Lifecycle events (`MemoryWritten`, `MemoryRead`, etc.) → #115
- `docs/memory.md` keystone page → #116
- Determinism test suite → #118

CHANGELOG entry deferred to release wrap, per the v0.8 convention.

## Closes

Closes #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)