### PR TITLE
feat(memory): dispatch lifecycle events for memory operations

### DIFF
--- a/src/Events/Memory/MemoryForgotten.php
+++ b/src/Events/Memory/MemoryForgotten.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Events\Memory;
+
+use BuiltByBerry\LaravelSwarm\Contracts\MemoryStore;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Memory\CacheMemoryStore;
+use BuiltByBerry\LaravelSwarm\Memory\DatabaseMemoryStore;
+use BuiltByBerry\LaravelSwarm\Memory\DefaultSwarmMemory;
+
+/**
+ * Fired after a memory entry is removed from a {@see MemoryStore}.
+ *
+ * Dispatched by the bundled store implementations
+ * ({@see CacheMemoryStore} and
+ * {@see DatabaseMemoryStore}) on every
+ * `forget()` call, regardless of whether an entry actually existed at the
+ * address. Listeners can hook in for app-level audit trails, custom metrics,
+ * or downstream cleanup automation.
+ *
+ * Companion / third-party {@see MemoryStore}
+ * drivers are expected to dispatch this event from their own `forget()`
+ * implementations to keep the listener contract uniform across drivers. See
+ * the dispatch-layer note on {@see DefaultSwarmMemory}
+ * for the rationale.
+ */
+final class MemoryForgotten
+{
+    public function __construct(
+        public readonly MemoryScope $scope,
+        public readonly string $scopeId,
+        public readonly string $key,
+    ) {}
+}

--- a/src/Events/Memory/MemoryRead.php
+++ b/src/Events/Memory/MemoryRead.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Events\Memory;
+
+use BuiltByBerry\LaravelSwarm\Contracts\MemoryStore;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Memory\CacheMemoryStore;
+use BuiltByBerry\LaravelSwarm\Memory\DatabaseMemoryStore;
+use BuiltByBerry\LaravelSwarm\Memory\DefaultSwarmMemory;
+
+/**
+ * Fired after a memory entry is read from a {@see MemoryStore}.
+ *
+ * Dispatched by the bundled store implementations
+ * ({@see CacheMemoryStore} and
+ * {@see DatabaseMemoryStore}) on every
+ * `get()` call — regardless of whether the entry was present. Listeners can
+ * hook in for app-level audit trails (e.g. PII access logging), custom
+ * metrics, or security monitoring.
+ *
+ * No value payload is exposed on the event. Subscribers needing the value
+ * should re-read through the store under their own access controls; this
+ * keeps the event surface compatible with redaction policy in v0.10.
+ *
+ * Companion / third-party {@see MemoryStore}
+ * drivers are expected to dispatch this event from their own `get()`
+ * implementations to keep the listener contract uniform across drivers. See
+ * the dispatch-layer note on {@see DefaultSwarmMemory}
+ * for the rationale.
+ */
+final class MemoryRead
+{
+    public function __construct(
+        public readonly MemoryScope $scope,
+        public readonly string $scopeId,
+        public readonly string $key,
+    ) {}
+}

--- a/src/Events/Memory/MemorySnapshotted.php
+++ b/src/Events/Memory/MemorySnapshotted.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Events\Memory;
+
+/**
+ * Fired after a per-step memory snapshot is captured for run replay.
+ *
+ * The snapshot mechanism itself ships separately as part of issue #111
+ * (replay-friendly memory snapshots). This event class defines the stable
+ * payload shape so app listeners can be authored ahead of the snapshot
+ * implementation landing, and so other store implementations or future
+ * snapshot drivers can dispatch a uniform event when they capture a snapshot.
+ *
+ * Once #111 lands, the snapshot mechanism will dispatch this event after
+ * persisting each snapshot row to `swarm_memory_snapshots`. Until then no
+ * production code path in this package emits the event — it is intentionally
+ * defined here so the listener contract is part of the v0.9.0 surface.
+ *
+ * Payload:
+ *
+ * - `runId`      — the swarm run whose memory was snapshotted.
+ * - `stepIndex`  — the zero-based step index the snapshot was taken at.
+ * - `snapshotId` — opaque identifier for the persisted snapshot row.
+ */
+final class MemorySnapshotted
+{
+    public function __construct(
+        public readonly string $runId,
+        public readonly int $stepIndex,
+        public readonly string $snapshotId,
+    ) {}
+}

--- a/src/Events/Memory/MemoryWritten.php
+++ b/src/Events/Memory/MemoryWritten.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Events\Memory;
+
+use BuiltByBerry\LaravelSwarm\Contracts\MemoryStore;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Memory\CacheMemoryStore;
+use BuiltByBerry\LaravelSwarm\Memory\DatabaseMemoryStore;
+use BuiltByBerry\LaravelSwarm\Memory\DefaultSwarmMemory;
+use BuiltByBerry\LaravelSwarm\Memory\MemoryEntry;
+
+/**
+ * Fired after a memory entry is successfully persisted by a {@see MemoryStore}.
+ *
+ * Dispatched by the bundled store implementations
+ * ({@see CacheMemoryStore} and
+ * {@see DatabaseMemoryStore}) on every
+ * successful `put()`. Listeners can hook in for app-level audit trails, custom
+ * metrics, security monitoring, or downstream automation.
+ *
+ * `metadata` carries the entry's metadata array as persisted by the store —
+ * the same shape that ends up on the returned {@see MemoryEntry}.
+ *
+ * Companion / third-party {@see MemoryStore}
+ * drivers are expected to dispatch this event from their own `put()`
+ * implementations to keep the listener contract uniform across drivers. See
+ * the dispatch-layer note on {@see DefaultSwarmMemory}
+ * for the rationale.
+ */
+final class MemoryWritten
+{
+    /**
+     * @param  array<string, mixed>  $metadata
+     */
+    public function __construct(
+        public readonly MemoryScope $scope,
+        public readonly string $scopeId,
+        public readonly string $key,
+        public readonly array $metadata = [],
+    ) {}
+}

--- a/src/Memory/CacheMemoryStore.php
+++ b/src/Memory/CacheMemoryStore.php
@@ -6,11 +6,15 @@ namespace BuiltByBerry\LaravelSwarm\Memory;
 
 use BuiltByBerry\LaravelSwarm\Contracts\MemoryStore;
 use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Events\Memory\MemoryForgotten;
+use BuiltByBerry\LaravelSwarm\Events\Memory\MemoryRead;
+use BuiltByBerry\LaravelSwarm\Events\Memory\MemoryWritten;
 use BuiltByBerry\LaravelSwarm\Persistence\Concerns\ResolvesSwarmCacheStore;
 use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Events\Dispatcher;
 
 /**
  * Cache-backed {@see MemoryStore} implementation.
@@ -34,6 +38,7 @@ final class CacheMemoryStore implements MemoryStore
     public function __construct(
         protected CacheFactory $cacheFactory,
         protected ConfigRepository $config,
+        protected Dispatcher $events,
     ) {}
 
     public function put(MemoryEntry $entry): MemoryEntry
@@ -50,6 +55,13 @@ final class CacheMemoryStore implements MemoryStore
 
         $this->appendToIndex($entry->scope, $entry->scopeId, $entry->key);
 
+        $this->events->dispatch(new MemoryWritten(
+            scope: $persisted->scope,
+            scopeId: $persisted->scopeId,
+            key: $persisted->key,
+            metadata: $persisted->metadata,
+        ));
+
         return $persisted;
     }
 
@@ -57,6 +69,12 @@ final class CacheMemoryStore implements MemoryStore
     {
         /** @var array<string, mixed>|null $payload */
         $payload = $this->store()->get($this->entryKey($scope, $scopeId, $key));
+
+        $this->events->dispatch(new MemoryRead(
+            scope: $scope,
+            scopeId: $scopeId,
+            key: $key,
+        ));
 
         return $payload === null ? null : $this->decode($payload);
     }
@@ -68,6 +86,12 @@ final class CacheMemoryStore implements MemoryStore
         $this->store()->forget($this->entryKey($scope, $scopeId, $key));
         $this->removeFromIndex($scope, $scopeId, $key);
 
+        $this->events->dispatch(new MemoryForgotten(
+            scope: $scope,
+            scopeId: $scopeId,
+            key: $key,
+        ));
+
         return $existed;
     }
 
@@ -75,11 +99,13 @@ final class CacheMemoryStore implements MemoryStore
     {
         $entries = [];
 
+        // Bypass get() here so listing does not emit a MemoryRead per entry.
         foreach ($this->index($scope, $scopeId) as $key) {
-            $entry = $this->get($scope, $scopeId, $key);
+            /** @var array<string, mixed>|null $payload */
+            $payload = $this->store()->get($this->entryKey($scope, $scopeId, $key));
 
-            if ($entry !== null) {
-                $entries[] = $entry;
+            if ($payload !== null) {
+                $entries[] = $this->decode($payload);
             }
         }
 

--- a/src/Memory/DatabaseMemoryStore.php
+++ b/src/Memory/DatabaseMemoryStore.php
@@ -6,9 +6,13 @@ namespace BuiltByBerry\LaravelSwarm\Memory;
 
 use BuiltByBerry\LaravelSwarm\Contracts\MemoryStore;
 use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Events\Memory\MemoryForgotten;
+use BuiltByBerry\LaravelSwarm\Events\Memory\MemoryRead;
+use BuiltByBerry\LaravelSwarm\Events\Memory\MemoryWritten;
 use BuiltByBerry\LaravelSwarm\Persistence\Concerns\InteractsWithJsonColumns;
 use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Builder;
 
@@ -33,6 +37,7 @@ final class DatabaseMemoryStore implements MemoryStore
     public function __construct(
         protected Connection $connection,
         protected ConfigRepository $config,
+        protected Dispatcher $events,
     ) {}
 
     public function put(MemoryEntry $entry): MemoryEntry
@@ -62,7 +67,16 @@ final class DatabaseMemoryStore implements MemoryStore
             ['value', 'metadata', 'updated_at'],
         );
 
-        return $entry->withTimestamps($createdAt, $now);
+        $persisted = $entry->withTimestamps($createdAt, $now);
+
+        $this->events->dispatch(new MemoryWritten(
+            scope: $persisted->scope,
+            scopeId: $persisted->scopeId,
+            key: $persisted->key,
+            metadata: $persisted->metadata,
+        ));
+
+        return $persisted;
     }
 
     public function get(MemoryScope $scope, string $scopeId, string $key): ?MemoryEntry
@@ -74,6 +88,12 @@ final class DatabaseMemoryStore implements MemoryStore
             ->where('key', $key)
             ->first();
 
+        $this->events->dispatch(new MemoryRead(
+            scope: $scope,
+            scopeId: $scopeId,
+            key: $key,
+        ));
+
         return $record === null ? null : $this->hydrate($record);
     }
 
@@ -84,6 +104,12 @@ final class DatabaseMemoryStore implements MemoryStore
             ->where('scope_id', $scopeId)
             ->where('key', $key)
             ->delete();
+
+        $this->events->dispatch(new MemoryForgotten(
+            scope: $scope,
+            scopeId: $scopeId,
+            key: $key,
+        ));
 
         return $deleted > 0;
     }

--- a/src/Memory/DefaultSwarmMemory.php
+++ b/src/Memory/DefaultSwarmMemory.php
@@ -7,6 +7,9 @@ namespace BuiltByBerry\LaravelSwarm\Memory;
 use BuiltByBerry\LaravelSwarm\Contracts\MemoryStore;
 use BuiltByBerry\LaravelSwarm\Contracts\SwarmMemory;
 use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Events\Memory\MemoryForgotten;
+use BuiltByBerry\LaravelSwarm\Events\Memory\MemoryRead;
+use BuiltByBerry\LaravelSwarm\Events\Memory\MemoryWritten;
 
 /**
  * Default {@see SwarmMemory} facade implementation.
@@ -14,10 +17,19 @@ use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
  * Thin coordinator over a {@see MemoryStore} driver. The facade trades the
  * driver's entry-shaped surface for a value-shaped one so callers don't have
  * to construct or unpack `MemoryEntry` objects unless they need metadata or
- * timestamps. Cross-cutting concerns layered on top of memory (capture-policy
- * redaction in v0.10, lifecycle events from #115) live alongside this class
- * rather than inside drivers, so every driver — Cache, Database, vector
- * companion, third-party — gets them for free.
+ * timestamps.
+ *
+ * Dispatch-layer decision for memory lifecycle events ({@see MemoryWritten},
+ * {@see MemoryRead},
+ * {@see MemoryForgotten}): events are
+ * dispatched at the {@see MemoryStore} layer, not from this facade. That way
+ * callers who resolve a store directly (or use a custom driver outside the
+ * facade) still get the lifecycle event stream. The trade-off is that custom
+ * {@see MemoryStore} drivers must dispatch the events themselves to be
+ * uniform with the bundled Cache + Database stores — there is no automatic
+ * wrapping. Capture-policy redaction (v0.10) is the cross-cutting concern
+ * that will live here at the facade layer, since redaction needs the
+ * pre-store value shape.
  *
  * @internal
  */

--- a/tests/Feature/Memory/MemoryEventsTest.php
+++ b/tests/Feature/Memory/MemoryEventsTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Contracts\MemoryStore;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmMemory;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Events\Memory\MemoryForgotten;
+use BuiltByBerry\LaravelSwarm\Events\Memory\MemoryRead;
+use BuiltByBerry\LaravelSwarm\Events\Memory\MemoryWritten;
+use BuiltByBerry\LaravelSwarm\Memory\CacheMemoryStore;
+use BuiltByBerry\LaravelSwarm\Memory\DatabaseMemoryStore;
+use BuiltByBerry\LaravelSwarm\Memory\MemoryEntry;
+use Illuminate\Contracts\Cache\Factory;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Lifecycle event dispatch tests for the bundled memory stores.
+ *
+ * Events fire at the store layer (not at the SwarmMemory facade) so any path
+ * that reaches a store — including direct store resolution and future
+ * companion drivers — emits the same lifecycle stream.
+ */
+beforeEach(function () {
+    /** @var Factory $cacheFactory */
+    $cacheFactory = $this->app->make('cache');
+    $cacheFactory->store('array')->flush();
+});
+
+// ---------------------------------------------------------------------------
+// CacheMemoryStore
+// ---------------------------------------------------------------------------
+
+test('cache store dispatches MemoryWritten on put with scope, scope_id, key, metadata', function () {
+    Event::fake([MemoryWritten::class, MemoryRead::class, MemoryForgotten::class]);
+
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+    expect($store)->toBeInstanceOf(CacheMemoryStore::class);
+
+    $store->put(new MemoryEntry(
+        scope: MemoryScope::Run,
+        scopeId: 'run-1',
+        key: 'last_output',
+        value: 'agent A said hello',
+        metadata: ['source' => 'test', 'redacted' => false],
+    ));
+
+    Event::assertDispatched(MemoryWritten::class, fn (MemoryWritten $event): bool => $event->scope === MemoryScope::Run
+        && $event->scopeId === 'run-1'
+        && $event->key === 'last_output'
+        && $event->metadata === ['source' => 'test', 'redacted' => false]);
+
+    Event::assertNotDispatched(MemoryRead::class);
+    Event::assertNotDispatched(MemoryForgotten::class);
+});
+
+test('cache store dispatches MemoryRead on get whether or not the entry exists', function () {
+    Event::fake([MemoryRead::class]);
+
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $store->get(MemoryScope::Run, 'run-1', 'missing');
+
+    Event::assertDispatched(MemoryRead::class, fn (MemoryRead $event): bool => $event->scope === MemoryScope::Run
+        && $event->scopeId === 'run-1'
+        && $event->key === 'missing');
+
+    Event::assertDispatchedTimes(MemoryRead::class, 1);
+
+    $store->put(new MemoryEntry(MemoryScope::Conversation, 'conv-1', 'present', 'value'));
+    $store->get(MemoryScope::Conversation, 'conv-1', 'present');
+
+    Event::assertDispatchedTimes(MemoryRead::class, 2);
+    Event::assertDispatched(MemoryRead::class, fn (MemoryRead $event): bool => $event->scope === MemoryScope::Conversation
+        && $event->scopeId === 'conv-1'
+        && $event->key === 'present');
+});
+
+test('cache store dispatches MemoryForgotten on forget whether or not the entry existed', function () {
+    Event::fake([MemoryForgotten::class]);
+
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $store->forget(MemoryScope::Run, 'run-1', 'absent');
+
+    Event::assertDispatched(MemoryForgotten::class, fn (MemoryForgotten $event): bool => $event->scope === MemoryScope::Run
+        && $event->scopeId === 'run-1'
+        && $event->key === 'absent');
+
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'present', 'x'));
+    $store->forget(MemoryScope::Run, 'run-1', 'present');
+
+    Event::assertDispatchedTimes(MemoryForgotten::class, 2);
+});
+
+test('cache store all() does not emit MemoryRead per entry', function () {
+    Event::fake([MemoryRead::class]);
+
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'a', 1));
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'b', 2));
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'c', 3));
+
+    $entries = $store->all(MemoryScope::Run, 'run-1');
+
+    expect($entries)->toHaveCount(3);
+    Event::assertNotDispatched(MemoryRead::class);
+});
+
+test('cache store emits one event per operation (no extras for repeated puts)', function () {
+    Event::fake([MemoryWritten::class]);
+
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'k', 'first'));
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'k', 'second'));
+
+    Event::assertDispatchedTimes(MemoryWritten::class, 2);
+});
+
+// ---------------------------------------------------------------------------
+// DatabaseMemoryStore
+// ---------------------------------------------------------------------------
+
+function makeSwarmMemoriesTable(): void
+{
+    if (Schema::hasTable('swarm_memories')) {
+        return;
+    }
+
+    Schema::create('swarm_memories', function (Blueprint $table): void {
+        $table->id();
+        $table->string('scope');
+        $table->string('scope_id');
+        $table->string('key');
+        $table->json('value')->nullable();
+        $table->json('metadata')->nullable();
+        $table->timestamp('created_at')->useCurrent();
+        $table->timestamp('updated_at')->useCurrent();
+        $table->unique(['scope', 'scope_id', 'key']);
+    });
+}
+
+test('database store dispatches MemoryWritten on put with metadata payload', function () {
+    config()->set('swarm.persistence.driver', 'database');
+    makeSwarmMemoriesTable();
+
+    Event::fake([MemoryWritten::class]);
+
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+    expect($store)->toBeInstanceOf(DatabaseMemoryStore::class);
+
+    $store->put(new MemoryEntry(
+        scope: MemoryScope::Agent,
+        scopeId: 'AgentX',
+        key: 'pref',
+        value: ['mode' => 'verbose'],
+        metadata: ['source' => 'unit-test'],
+    ));
+
+    Event::assertDispatched(MemoryWritten::class, fn (MemoryWritten $event): bool => $event->scope === MemoryScope::Agent
+        && $event->scopeId === 'AgentX'
+        && $event->key === 'pref'
+        && $event->metadata === ['source' => 'unit-test']);
+});
+
+test('database store dispatches MemoryRead on get whether the row exists or not', function () {
+    config()->set('swarm.persistence.driver', 'database');
+    makeSwarmMemoriesTable();
+
+    Event::fake([MemoryRead::class]);
+
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $store->get(MemoryScope::Run, 'r1', 'absent');
+    $store->put(new MemoryEntry(MemoryScope::Run, 'r1', 'present', 'v'));
+    $store->get(MemoryScope::Run, 'r1', 'present');
+
+    Event::assertDispatchedTimes(MemoryRead::class, 2);
+    Event::assertDispatched(MemoryRead::class, fn (MemoryRead $e): bool => $e->scope === MemoryScope::Run && $e->key === 'absent');
+    Event::assertDispatched(MemoryRead::class, fn (MemoryRead $e): bool => $e->scope === MemoryScope::Run && $e->key === 'present');
+});
+
+test('database store dispatches MemoryForgotten on forget whether row existed or not', function () {
+    config()->set('swarm.persistence.driver', 'database');
+    makeSwarmMemoriesTable();
+
+    Event::fake([MemoryForgotten::class]);
+
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $store->forget(MemoryScope::Swarm, 'SwarmA', 'absent');
+    $store->put(new MemoryEntry(MemoryScope::Swarm, 'SwarmA', 'present', 'v'));
+    $store->forget(MemoryScope::Swarm, 'SwarmA', 'present');
+
+    Event::assertDispatchedTimes(MemoryForgotten::class, 2);
+    Event::assertDispatched(MemoryForgotten::class, fn (MemoryForgotten $e): bool => $e->key === 'absent' && $e->scope === MemoryScope::Swarm);
+    Event::assertDispatched(MemoryForgotten::class, fn (MemoryForgotten $e): bool => $e->key === 'present' && $e->scope === MemoryScope::Swarm);
+});
+
+// ---------------------------------------------------------------------------
+// Facade pass-through — events fire from the store layer even when invoked
+// via the SwarmMemory facade.
+// ---------------------------------------------------------------------------
+
+test('events fire when memory is accessed via the SwarmMemory facade', function () {
+    Event::fake([MemoryWritten::class, MemoryRead::class, MemoryForgotten::class]);
+
+    /** @var SwarmMemory $memory */
+    $memory = $this->app->make(SwarmMemory::class);
+
+    $memory->put(MemoryScope::Run, 'run-facade', 'k', 'v', ['m' => 1]);
+    $memory->get(MemoryScope::Run, 'run-facade', 'k');
+    $memory->forget(MemoryScope::Run, 'run-facade', 'k');
+
+    Event::assertDispatched(MemoryWritten::class, fn (MemoryWritten $e): bool => $e->key === 'k' && $e->metadata === ['m' => 1]);
+    Event::assertDispatched(MemoryRead::class, fn (MemoryRead $e): bool => $e->key === 'k');
+    Event::assertDispatched(MemoryForgotten::class, fn (MemoryForgotten $e): bool => $e->key === 'k');
+});

--- a/tests/Unit/Memory/MemorySnapshottedEventTest.php
+++ b/tests/Unit/Memory/MemorySnapshottedEventTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Events\Memory\MemorySnapshotted;
+use Illuminate\Support\Facades\Event;
+
+/**
+ * Shape-only tests for the MemorySnapshotted event.
+ *
+ * The snapshot mechanism itself ships with issue #111 — this v0.9.0 commit
+ * only defines the event so app-level listeners can be authored against a
+ * stable payload before the dispatching code lands.
+ */
+test('MemorySnapshotted exposes runId, stepIndex, and snapshotId as readonly properties', function () {
+    $event = new MemorySnapshotted(
+        runId: 'run-42',
+        stepIndex: 3,
+        snapshotId: 'snap-abc',
+    );
+
+    expect($event->runId)->toBe('run-42');
+    expect($event->stepIndex)->toBe(3);
+    expect($event->snapshotId)->toBe('snap-abc');
+});
+
+test('MemorySnapshotted can be dispatched through the Laravel event bus', function () {
+    Event::fake([MemorySnapshotted::class]);
+
+    Event::dispatch(new MemorySnapshotted('run-1', 0, 'snap-1'));
+
+    Event::assertDispatched(MemorySnapshotted::class, fn (MemorySnapshotted $e): bool => $e->runId === 'run-1'
+        && $e->stepIndex === 0
+        && $e->snapshotId === 'snap-1');
+});


### PR DESCRIPTION
## Summary

Dispatches Laravel events for memory operations so app-level listeners can hook in cleanly — for audit trails, custom metrics, security monitoring, or downstream automation.

- **Four new event classes** under `BuiltByBerry\LaravelSwarm\Events\Memory\`:
  - `MemoryWritten` (scope, scope_id, key, metadata)
  - `MemoryRead` (scope, scope_id, key)
  - `MemoryForgotten` (scope, scope_id, key)
  - `MemorySnapshotted` (run_id, step_index, snapshot_id) — shape only; the snapshot mechanism that dispatches it ships in #111
- **Wiring in both v0.9.0 stores**: `CacheMemoryStore` and `DatabaseMemoryStore` both accept `Illuminate\Contracts\Events\Dispatcher` via constructor injection and emit on `put` / `get` / `forget`.
- **`all()` does not emit per-entry reads**: `CacheMemoryStore::all()` was refactored to bypass the public `get()` path so enumeration stays quiet on the event bus.
- **PHPDoc** on each event class documents payload + the dispatch-layer expectation for companion drivers. Full `docs/memory.md` is deferred to #116, per the issue scope.

Closes #115.

## Design decision — dispatch layer

Events fire at the **store layer**, not from the `DefaultSwarmMemory` facade. This is documented in PHPDoc on `DefaultSwarmMemory`.

- **Store-layer (chosen).** Any path that reaches a store — including direct store resolution by the application or future companion drivers like `laravel-swarm-memory-vector` — emits the same lifecycle stream. Trade-off: custom `MemoryStore` drivers must dispatch the events from their own implementations to stay uniform with the bundled stores.
- **Facade-layer (rejected).** Would keep stores pure but means custom drivers used directly would silently skip the event stream. The previous PHPDoc on `DefaultSwarmMemory` hinted at this direction; that doc block has been updated to reflect the new choice and to note that capture-policy redaction (v0.10) is the cross-cutting concern that *will* live at the facade layer, since redaction needs the pre-store value shape.

## Verification

- ` composer test` → **1000 passed (4030 assertions)**, including 11 new tests / 30 new assertions covering dispatch + payload shape for both bundled stores and the snapshot event class.
- `composer lint` → passed (pint clean)
- `composer analyse` → No errors (phpstan clean)

## Test plan

- [x] `MemoryWritten` dispatched on `put` with `(scope, scope_id, key, metadata)` for both Cache and Database stores
- [x] `MemoryRead` dispatched on `get` for hits and misses, on both stores
- [x] `MemoryForgotten` dispatched on `forget` whether or not the row existed, on both stores
- [x] `CacheMemoryStore::all()` does not emit a `MemoryRead` per entry
- [x] Events fire from store layer when accessed via the `SwarmMemory` facade
- [x] `MemorySnapshotted` exposes readonly `runId` / `stepIndex` / `snapshotId` and round-trips through the Laravel event bus
- [x] No CHANGELOG entry (deferred to release wrap, per v0.8 convention)
- [x] No `docs/memory.md` update (deferred to #116)