### PR TITLE
feat(memory): add swarm_memories migration for memory entries

### DIFF
--- a/config/swarm.php
+++ b/config/swarm.php
@@ -351,5 +351,6 @@ return [
         'durable_webhook_idempotency' => env('SWARM_DURABLE_WEBHOOK_IDEMPOTENCY_TABLE', 'swarm_durable_webhook_idempotency'),
         'durable_outbox' => env('SWARM_DURABLE_OUTBOX_TABLE', 'swarm_durable_outbox'),
         'audit_outbox' => env('SWARM_AUDIT_OUTBOX_TABLE', 'swarm_audit_outbox'),
+        'memories' => env('SWARM_MEMORIES_TABLE', 'swarm_memories'),
     ],
 ];

--- a/database/migrations/2026_05_21_000002_create_swarm_memories_table.php
+++ b/database/migrations/2026_05_21_000002_create_swarm_memories_table.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Live memory entries for the database-backed SwarmMemory driver.
+ *
+ * One row per entry, addressed by the natural key `(scope, scope_id, key)`.
+ * `value` and `metadata` are JSON columns to support arbitrary plain-data
+ * shapes. Timestamps drive retention purges and propagation freshness
+ * heuristics layered on later.
+ *
+ * Indexing strategy mirrors the three hot paths the driver and policy layer
+ * exercise against this table:
+ *
+ *   - `(scope, scope_id)`  — propagation reads on agent invocation.
+ *   - `(scope, key)`       — value lookups across scope_ids (e.g. "every
+ *                            Run-scoped `last_output` written in the last hour").
+ *   - `created_at`         — retention purges via the v0.10 `swarm:memory:purge`
+ *                            command (#124).
+ *
+ * The composite `(scope, scope_id, key)` unique index also enforces one-row
+ * per-address semantics that {@see DatabaseMemoryStore::put()} relies on for
+ * its `upsert(..., ['scope', 'scope_id', 'key'], ...)` call.
+ *
+ * Foreign-key design decision: no FK.
+ *
+ * `scope_id` is polymorphic across four scopes — for `MemoryScope::Run` it
+ * holds a `swarm_run_histories.run_id`, for `Conversation` an opaque
+ * conversation id, for `Agent` a fully-qualified agent class string, and for
+ * `Swarm` a fully-qualified swarm class string. Only the Run-scoped subset is
+ * a referential candidate; the rest are not even rows in any swarm table.
+ * Conditional foreign keys aren't portable across MySQL/Postgres/SQLite, and
+ * splitting the table by scope to enable a per-scope FK fragments propagation
+ * reads (the hottest path).
+ *
+ * Trade-off accepted: Run-scoped entries are not cascade-deleted when their
+ * parent `swarm_run_histories` row is purged. The v0.10 `swarm:memory:purge`
+ * command (#124) reaps them via `created_at` retention, and the same window
+ * applies uniformly to all scopes. Operators who need stricter coupling can
+ * add an FK in an application migration.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('swarm_memories', function (Blueprint $table): void {
+            $table->id();
+            $table->string('scope');
+            $table->string('scope_id');
+            $table->string('key');
+            $table->json('value');
+            $table->json('metadata');
+            $table->timestamps();
+
+            // One row per address. Also serves the (scope, scope_id, key)
+            // index hit for point reads.
+            $table->unique(['scope', 'scope_id', 'key']);
+
+            // Propagation reads on agent invocation: "every entry in this
+            // (scope, scope_id) namespace".
+            $table->index(['scope', 'scope_id'], 'swarm_memories_scope_scope_id_index');
+
+            // Value lookups across scope_ids: "every `last_output` written
+            // under Run scope".
+            $table->index(['scope', 'key'], 'swarm_memories_scope_key_index');
+
+            // Retention purges by age.
+            $table->index('created_at', 'swarm_memories_created_at_index');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('swarm_memories');
+    }
+};

--- a/tests/Feature/Memory/DatabaseMemoryStoreTest.php
+++ b/tests/Feature/Memory/DatabaseMemoryStoreTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Contracts\MemoryStore;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Memory\DatabaseMemoryStore;
+use BuiltByBerry\LaravelSwarm\Memory\MemoryEntry;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * DatabaseMemoryStore compliance suite, mirroring CacheMemoryStoreTest.
+ *
+ * Exercises the same scenarios against the database driver to confirm
+ * behavioral parity across drivers, plus DB-specific concerns (JSON
+ * cast round-trip, upsert semantics that preserve created_at across
+ * overwrites).
+ */
+beforeEach(function () {
+    config()->set('swarm.persistence.driver', 'database');
+});
+
+test('the database store is bound as the default MemoryStore when persistence is database', function () {
+    $store = $this->app->make(MemoryStore::class);
+
+    expect($store)->toBeInstanceOf(DatabaseMemoryStore::class);
+});
+
+test('put persists an entry and stamps timestamps', function () {
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $persisted = $store->put(new MemoryEntry(
+        scope: MemoryScope::Run,
+        scopeId: 'run-1',
+        key: 'last_output',
+        value: 'agent A said hello',
+    ));
+
+    expect($persisted->createdAt)->not->toBeNull();
+    expect($persisted->updatedAt)->not->toBeNull();
+    expect($persisted->createdAt?->toIso8601String())->toBe($persisted->updatedAt?->toIso8601String());
+});
+
+test('get returns the persisted entry when present, null otherwise', function () {
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    expect($store->get(MemoryScope::Run, 'run-1', 'missing'))->toBeNull();
+
+    $store->put(new MemoryEntry(
+        scope: MemoryScope::Run,
+        scopeId: 'run-1',
+        key: 'present',
+        value: ['nested' => true],
+        metadata: ['source' => 'test'],
+    ));
+
+    $fetched = $store->get(MemoryScope::Run, 'run-1', 'present');
+
+    expect($fetched)->not->toBeNull();
+    expect($fetched?->value)->toBe(['nested' => true]);
+    expect($fetched?->metadata)->toBe(['source' => 'test']);
+});
+
+test('put overwrites the previous value for the same address', function () {
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'k', 'first'));
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'k', 'second'));
+
+    expect($store->get(MemoryScope::Run, 'run-1', 'k')?->value)->toBe('second');
+
+    // Single row per address — unique constraint upheld via upsert.
+    expect(DB::table('swarm_memories')->count())->toBe(1);
+});
+
+test('forget removes the entry and returns true when it existed, false when absent', function () {
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    expect($store->forget(MemoryScope::Run, 'run-1', 'absent'))->toBeFalse();
+
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'present', 'x'));
+
+    expect($store->forget(MemoryScope::Run, 'run-1', 'present'))->toBeTrue();
+    expect($store->get(MemoryScope::Run, 'run-1', 'present'))->toBeNull();
+});
+
+test('all returns every entry under a given (scope, scope_id) and nothing else', function () {
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'a', 1));
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'b', 2));
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-2', 'a', 'other-run'));
+    $store->put(new MemoryEntry(MemoryScope::Conversation, 'run-1', 'a', 'other-scope'));
+
+    $all = $store->all(MemoryScope::Run, 'run-1');
+
+    expect($all)->toHaveCount(2);
+
+    $byKey = collect($all)->keyBy(fn (MemoryEntry $entry): string => $entry->key);
+    expect($byKey['a']->value)->toBe(1);
+    expect($byKey['b']->value)->toBe(2);
+});
+
+test('scope isolation: same scope_id and key across different scopes do not collide', function () {
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $store->put(new MemoryEntry(MemoryScope::Run, 'shared-id', 'profile', 'run-value'));
+    $store->put(new MemoryEntry(MemoryScope::Conversation, 'shared-id', 'profile', 'convo-value'));
+    $store->put(new MemoryEntry(MemoryScope::Agent, 'shared-id', 'profile', 'agent-value'));
+    $store->put(new MemoryEntry(MemoryScope::Swarm, 'shared-id', 'profile', 'swarm-value'));
+
+    expect($store->get(MemoryScope::Run, 'shared-id', 'profile')?->value)->toBe('run-value');
+    expect($store->get(MemoryScope::Conversation, 'shared-id', 'profile')?->value)->toBe('convo-value');
+    expect($store->get(MemoryScope::Agent, 'shared-id', 'profile')?->value)->toBe('agent-value');
+    expect($store->get(MemoryScope::Swarm, 'shared-id', 'profile')?->value)->toBe('swarm-value');
+});
+
+test('scope_id isolation: same scope and key across different scope_ids do not collide', function () {
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-A', 'last_output', 'A-output'));
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-B', 'last_output', 'B-output'));
+
+    expect($store->get(MemoryScope::Run, 'run-A', 'last_output')?->value)->toBe('A-output');
+    expect($store->get(MemoryScope::Run, 'run-B', 'last_output')?->value)->toBe('B-output');
+});
+
+test('forget only removes the targeted entry under (scope, scope_id, key)', function () {
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'a', 1));
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'b', 2));
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-2', 'a', 3));
+
+    $store->forget(MemoryScope::Run, 'run-1', 'a');
+
+    expect($store->get(MemoryScope::Run, 'run-1', 'a'))->toBeNull();
+    expect($store->get(MemoryScope::Run, 'run-1', 'b')?->value)->toBe(2);
+    expect($store->get(MemoryScope::Run, 'run-2', 'a')?->value)->toBe(3);
+});
+
+test('all returns an empty array for an empty (scope, scope_id)', function () {
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    expect($store->all(MemoryScope::Run, 'never-written'))->toBe([]);
+});
+
+test('plain-data value shapes round-trip through the JSON cast', function () {
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $shapes = [
+        'string' => 'hello',
+        'int' => 42,
+        'float' => 3.14,
+        'bool_true' => true,
+        'bool_false' => false,
+        'null' => null,
+        'list' => [1, 2, 3],
+        'nested' => ['outer' => ['inner' => ['k' => 'v', 'n' => 5]]],
+    ];
+
+    foreach ($shapes as $key => $value) {
+        $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', $key, $value));
+    }
+
+    foreach ($shapes as $key => $value) {
+        expect($store->get(MemoryScope::Run, 'run-1', $key)?->value)->toEqual($value);
+    }
+});
+
+test('overwriting an entry preserves its created_at but advances updated_at', function () {
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $initial = $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'k', 'first'));
+
+    // Force a clock tick so updated_at can demonstrably differ from the
+    // original created_at across the upsert.
+    usleep(1100);
+
+    $updated = $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'k', 'second'));
+
+    expect($updated->createdAt?->toIso8601String())->toBe($initial->createdAt?->toIso8601String());
+    expect($updated->updatedAt?->greaterThanOrEqualTo($initial->updatedAt))->toBeTrue();
+});
+
+test('metadata defaults to an empty array when not provided', function () {
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'k', 'v'));
+
+    $fetched = $store->get(MemoryScope::Run, 'run-1', 'k');
+    expect($fetched?->metadata)->toBe([]);
+});

--- a/tests/Feature/Memory/MemoriesSchemaTest.php
+++ b/tests/Feature/Memory/MemoriesSchemaTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Verifies the swarm_memories schema added by the
+ * 2026_05_21_000002_create_swarm_memories_table migration.
+ *
+ * Targets the three indexed hot paths (propagation reads, value lookups,
+ * retention purges) plus the unique-address invariant the DatabaseMemoryStore
+ * relies on for upsert semantics.
+ */
+beforeEach(function () {
+    Artisan::call('migrate:fresh', ['--database' => 'testing']);
+});
+
+// ---------------------------------------------------------------------------
+// Schema shape
+// ---------------------------------------------------------------------------
+
+test('the swarm_memories table exists with the expected columns', function () {
+    expect(Schema::hasTable('swarm_memories'))->toBeTrue();
+
+    expect(Schema::hasColumns('swarm_memories', [
+        'id',
+        'scope',
+        'scope_id',
+        'key',
+        'value',
+        'metadata',
+        'created_at',
+        'updated_at',
+    ]))->toBeTrue();
+});
+
+test('migration up/down is idempotent', function () {
+    // Top of the stack — rolling back step=1 removes the memories table
+    // (and only the memories table; #110's snapshots migration is below us).
+    Artisan::call('migrate:rollback', ['--database' => 'testing', '--step' => 1]);
+    expect(Schema::hasTable('swarm_memories'))->toBeFalse();
+
+    // And re-running migrate brings it back cleanly.
+    Artisan::call('migrate', ['--database' => 'testing']);
+    expect(Schema::hasTable('swarm_memories'))->toBeTrue();
+});
+
+// ---------------------------------------------------------------------------
+// Index existence — covering the three hot paths
+// ---------------------------------------------------------------------------
+
+test('the propagation-read composite index (scope, scope_id) exists', function () {
+    $indexes = collect(Schema::getIndexes('swarm_memories'))
+        ->map(fn (array $index): array => $index['columns']);
+
+    expect($indexes->contains(fn (array $cols): bool => $cols === ['scope', 'scope_id']))->toBeTrue();
+});
+
+test('the value-lookup composite index (scope, key) exists', function () {
+    $indexes = collect(Schema::getIndexes('swarm_memories'))
+        ->map(fn (array $index): array => $index['columns']);
+
+    expect($indexes->contains(fn (array $cols): bool => $cols === ['scope', 'key']))->toBeTrue();
+});
+
+test('the retention-purge index on created_at exists', function () {
+    $indexes = collect(Schema::getIndexes('swarm_memories'))
+        ->map(fn (array $index): array => $index['columns']);
+
+    expect($indexes->contains(fn (array $cols): bool => $cols === ['created_at']))->toBeTrue();
+});
+
+test('the unique (scope, scope_id, key) index exists and is marked unique', function () {
+    $uniques = collect(Schema::getIndexes('swarm_memories'))
+        ->filter(fn (array $index): bool => $index['unique'] === true)
+        ->map(fn (array $index): array => $index['columns'])
+        ->values();
+
+    expect($uniques->contains(fn (array $cols): bool => $cols === ['scope', 'scope_id', 'key']))->toBeTrue();
+});
+
+// ---------------------------------------------------------------------------
+// JSON column round-trip
+// ---------------------------------------------------------------------------
+
+test('value and metadata JSON columns round-trip arbitrary plain-data shapes', function () {
+    $now = now();
+
+    $value = ['nested' => ['list' => [1, 2, 3], 'flag' => true, 'maybe' => null]];
+    $metadata = ['source' => 'unit-test', 'redacted_fields' => ['pii.email']];
+
+    DB::table('swarm_memories')->insert([
+        'scope' => 'run',
+        'scope_id' => 'run-json',
+        'key' => 'pref',
+        'value' => json_encode($value),
+        'metadata' => json_encode($metadata),
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    /** @var object $row */
+    $row = DB::table('swarm_memories')->where('scope_id', 'run-json')->first();
+
+    expect(json_decode((string) $row->value, true))->toEqual($value);
+    expect(json_decode((string) $row->metadata, true))->toEqual($metadata);
+});
+
+// ---------------------------------------------------------------------------
+// Uniqueness — one row per (scope, scope_id, key)
+// ---------------------------------------------------------------------------
+
+test('a second row with the same (scope, scope_id, key) fails the unique constraint', function () {
+    $now = now();
+
+    DB::table('swarm_memories')->insert([
+        'scope' => 'run',
+        'scope_id' => 'run-1',
+        'key' => 'last_output',
+        'value' => json_encode('first'),
+        'metadata' => json_encode([]),
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    expect(fn () => DB::table('swarm_memories')->insert([
+        'scope' => 'run',
+        'scope_id' => 'run-1',
+        'key' => 'last_output',
+        'value' => json_encode('second'),
+        'metadata' => json_encode([]),
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]))->toThrow(QueryException::class);
+});
+
+test('the same key is allowed under a different scope', function () {
+    $now = now();
+
+    DB::table('swarm_memories')->insert([
+        'scope' => 'run',
+        'scope_id' => 'shared-id',
+        'key' => 'pref',
+        'value' => json_encode('run-value'),
+        'metadata' => json_encode([]),
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    DB::table('swarm_memories')->insert([
+        'scope' => 'conversation',
+        'scope_id' => 'shared-id',
+        'key' => 'pref',
+        'value' => json_encode('convo-value'),
+        'metadata' => json_encode([]),
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    expect(DB::table('swarm_memories')->count())->toBe(2);
+});
+
+test('the same key is allowed under a different scope_id', function () {
+    $now = now();
+
+    DB::table('swarm_memories')->insert([
+        'scope' => 'run',
+        'scope_id' => 'run-A',
+        'key' => 'last_output',
+        'value' => json_encode('A'),
+        'metadata' => json_encode([]),
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    DB::table('swarm_memories')->insert([
+        'scope' => 'run',
+        'scope_id' => 'run-B',
+        'key' => 'last_output',
+        'value' => json_encode('B'),
+        'metadata' => json_encode([]),
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    expect(DB::table('swarm_memories')->count())->toBe(2);
+});

--- a/tests/Feature/Memory/MemorySnapshotsSchemaTest.php
+++ b/tests/Feature/Memory/MemorySnapshotsSchemaTest.php
@@ -59,9 +59,10 @@ test('the swarm_memory_snapshots table exists with the expected columns', functi
 });
 
 test('migration rolls back cleanly', function () {
-    // Rolls back the snapshots migration only. The migration we just added is
-    // top of the stack so --step=1 removes it.
-    Artisan::call('migrate:rollback', ['--database' => 'testing', '--step' => 1]);
+    // The snapshots migration sits one below the memories migration added by
+    // #109, so rolling back the top two steps removes both. We only assert the
+    // snapshots table here; the memories migration owns its own rollback test.
+    Artisan::call('migrate:rollback', ['--database' => 'testing', '--step' => 2]);
 
     expect(Schema::hasTable('swarm_memory_snapshots'))->toBeFalse();
 });

--- a/tests/Feature/RunIdForeignKeysTest.php
+++ b/tests/Feature/RunIdForeignKeysTest.php
@@ -44,11 +44,11 @@ test('run_id FK migration adds all expected foreign key constraints', function (
 });
 
 test('FK migration rolls back cleanly', function () {
-    // Step 5 rolls back: memory-snapshots (v0.9), audit-outbox, durable-outbox-indexes,
-    // durable-outbox-table, and the FK migration itself. The FK migration is the
-    // fifth-most-recent now that v0.9 added the memory snapshots table on top of
-    // the v0.5 audit + durable outbox stack.
-    Artisan::call('migrate:rollback', ['--database' => 'testing', '--step' => 5]);
+    // Step 6 rolls back: memories (v0.9), memory-snapshots (v0.9), audit-outbox,
+    // durable-outbox-indexes, durable-outbox-table, and the FK migration itself.
+    // The FK migration is the sixth-most-recent now that v0.9 added both memory
+    // tables on top of the v0.5 audit + durable outbox stack.
+    Artisan::call('migrate:rollback', ['--database' => 'testing', '--step' => 6]);
 
     // Tables still exist; FK constraints are just removed. Insert into a child
     // table without a parent row — should succeed now that FKs are dropped.


### PR DESCRIPTION
## Summary

Adds the `swarm_memories` table for the database-backed `SwarmMemory` driver. One row per entry, addressed by `(scope, scope_id, key)` with JSON `value` and `metadata` columns and Laravel timestamps.

Indexes target the three hot paths:

- Composite `(scope, scope_id)` — propagation reads on agent invocation.
- Composite `(scope, key)` — value lookups across scope_ids.
- `created_at` — retention purges for the v0.10 `swarm:memory:purge` command (#124).

`(scope, scope_id, key)` is also enforced unique so `DatabaseMemoryStore::put()`'s upsert maintains one-row-per-address semantics.

The `DatabaseMemoryStore` shipped in #108 was waiting on this table; its full compliance suite (mirroring `CacheMemoryStoreTest`) lands here too.

## FK design decision: no FK

`scope_id` is polymorphic across all four scopes:

- `MemoryScope::Run` → `swarm_run_histories.run_id`
- `MemoryScope::Conversation` → opaque conversation id (no swarm-owned table)
- `MemoryScope::Agent` → fully-qualified agent class string
- `MemoryScope::Swarm` → fully-qualified swarm class string

Only Run-scoped entries are referential candidates. Conditional FKs aren't portable across MySQL/Postgres/SQLite, and splitting this table by scope to enable a per-scope FK would fragment the propagation hot path (the single most-trafficked query against this table).

Trade-off accepted: Run-scoped entries are not cascade-deleted when their parent `swarm_run_histories` row is purged. The v0.10 `swarm:memory:purge` command (#124) reaps stale entries via `created_at` retention, applied uniformly across scopes. Operators who need cascade semantics can add the FK in an application migration.

The decision is also documented in the migration's docblock so future readers don't have to reconstruct it from the PR.

## Changes

- `database/migrations/2026_05_21_000002_create_swarm_memories_table.php` — the new migration.
- `config/swarm.php` — adds `swarm.tables.memories` (env `SWARM_MEMORIES_TABLE`) for parity with the rest of the `tables` block; the store already reads this key.
- `tests/Feature/Memory/MemoriesSchemaTest.php` — 10 tests covering schema shape, up/down idempotency, the three indexes + unique constraint, JSON round-trip, and uniqueness across scope/scope_id boundaries.
- `tests/Feature/Memory/DatabaseMemoryStoreTest.php` — 13 tests mirroring `CacheMemoryStoreTest` plus DB-specific checks for JSON cast shape round-trip and `created_at` preservation across upserts.
- `tests/Feature/Memory/MemorySnapshotsSchemaTest.php` + `tests/Feature/RunIdForeignKeysTest.php` — bump step counts now that this migration sits on top of the stack.

## Verification

- `composer test` → **1012 passed (4052 assertions)** in 126s
- `composer lint` → `pint passed`
- `composer analyse` → `[OK] No errors`

New test count: 23 tests / 50 assertions in the two new files.

## Out of scope (deferred)

- Wiring into `swarm:install:memory` (#114).
- `docs/memory.md` cross-link (#116).
- `swarm:memory:purge` retention command (#124, v0.10).
- CHANGELOG entry (per v0.8 convention, deferred to release wrap).

Closes #109