### PR TITLE
feat(memory): snapshot agent memory view at invocation

### DIFF
--- a/src/Contracts/SnapshotsMemory.php
+++ b/src/Contracts/SnapshotsMemory.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Contracts;
+
+use BuiltByBerry\LaravelSwarm\Memory\MemorySnapshot;
+
+/**
+ * Freezes the memory view an agent will see at invocation, persists it, and
+ * exposes hooks for runners to append tool-call input/output pairs observed
+ * during the invocation.
+ *
+ * Resolved from the container as a singleton. Each of Swarm's four runners
+ * (SequentialRunner, ParallelRunner, HierarchicalRunner, DurableBranchAdvancer)
+ * calls {@see snapshot()} immediately before `$agent->prompt(...)` /
+ * `$agent->stream(...)` so the persisted view is byte-identical to what the
+ * agent actually saw. Replay (issue #112) reads back via
+ * {@see find()} instead of re-querying live {@see SwarmMemory}.
+ *
+ * Implementations must:
+ *
+ * - Capture the agent-visible memory view atomically — no entries written
+ *   after the freeze can leak into the snapshot.
+ * - Persist the snapshot to the `swarm_memory_snapshots` table (or an
+ *   equivalent backend) keyed by `(run_id, step_index)`.
+ * - Accept tool-call appends via {@see appendToolCall()} and update the
+ *   `tool_calls` JSON column in place, so streamed runs reach a single final
+ *   row containing every input/output pair observed during the invocation.
+ *
+ * Implementations are free to no-op when the runtime has no SwarmMemory bound
+ * (e.g. tests that never wire memory). The contract guarantees the returned
+ * {@see MemorySnapshot} reflects whatever was frozen, even if empty.
+ */
+interface SnapshotsMemory
+{
+    /**
+     * Freeze the agent-visible memory view for `(run_id, step_index)` and
+     * persist it with an empty `tool_calls` list. Returns the value object
+     * that subsequent {@see appendToolCall()} calls must reference.
+     */
+    public function snapshot(string $runId, int $stepIndex): MemorySnapshot;
+
+    /**
+     * Append one tool-call input/output pair to the snapshot for
+     * `(run_id, step_index)` and re-persist the `tool_calls` JSON column.
+     *
+     * Returns the updated snapshot with the new tool call included. Callers
+     * should treat the original snapshot as stale after this call.
+     *
+     * @param  array{name: string, arguments: array<string, mixed>, result: mixed, id?: string|null, result_id?: string|null}  $toolCall
+     */
+    public function appendToolCall(MemorySnapshot $snapshot, array $toolCall): MemorySnapshot;
+
+    /**
+     * Look up a previously persisted snapshot by its natural key. Returns
+     * null when no snapshot was recorded for that step.
+     */
+    public function find(string $runId, int $stepIndex): ?MemorySnapshot;
+}

--- a/src/Memory/DatabaseMemorySnapshotRecorder.php
+++ b/src/Memory/DatabaseMemorySnapshotRecorder.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Memory;
+
+use BuiltByBerry\LaravelSwarm\Contracts\SnapshotsMemory;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmMemory;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Persistence\Concerns\InteractsWithJsonColumns;
+use Carbon\CarbonImmutable;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Database\QueryException;
+
+/**
+ * Default {@see SnapshotsMemory} implementation backed by the
+ * `swarm_memory_snapshots` table (added in #110).
+ *
+ * On {@see snapshot()} the recorder reads every Run-scoped memory entry for
+ * the given `run_id` via the bound {@see SwarmMemory} facade, freezes the
+ * order, and upserts the row keyed by `(run_id, step_index)`. Tool-call
+ * appends rewrite only the `tool_calls` JSON column so the snapshot row
+ * grows monotonically across the invocation without churning the payload.
+ *
+ * Scopes beyond `Run` (Conversation / Agent / Swarm) intentionally do not
+ * land here yet — propagation policy in v0.10 decides which scopes a worker
+ * sees, and the snapshot freeze must mirror whatever that policy returns.
+ * Until that policy ships, freezing the Run-scoped view is the agent-visible
+ * surface and matches what live runners observe today.
+ *
+ * @internal
+ */
+final class DatabaseMemorySnapshotRecorder implements SnapshotsMemory
+{
+    use InteractsWithJsonColumns;
+
+    public function __construct(
+        protected Connection $connection,
+        protected ConfigRepository $config,
+        protected SwarmMemory $memory,
+    ) {}
+
+    public function snapshot(string $runId, int $stepIndex): MemorySnapshot
+    {
+        // The companion `swarm_memories` table (issue #109) may not be
+        // migrated yet — for example during the 0.9.0 staged rollout where
+        // the entries-schema and snapshots-schema migrations land in
+        // separate PRs. Treat a missing memory table as "no Run-scoped
+        // entries" rather than failing every agent invocation; the snapshot
+        // row itself still persists so replay sees the empty view.
+        try {
+            $entries = $this->memory->all(MemoryScope::Run, $runId);
+        } catch (QueryException) {
+            $entries = [];
+        }
+
+        $snapshot = MemorySnapshot::fromEntries($runId, $stepIndex, $entries, []);
+
+        $this->persist($snapshot);
+
+        return $snapshot;
+    }
+
+    public function appendToolCall(MemorySnapshot $snapshot, array $toolCall): MemorySnapshot
+    {
+        $updated = $snapshot->withToolCall($toolCall);
+
+        $this->table()
+            ->where('run_id', $updated->runId)
+            ->where('step_index', $updated->stepIndex)
+            ->update([
+                'tool_calls' => $this->encodeJson($updated->toolCalls),
+                'updated_at' => CarbonImmutable::now('UTC'),
+            ]);
+
+        return $updated;
+    }
+
+    public function find(string $runId, int $stepIndex): ?MemorySnapshot
+    {
+        /** @var object|null $record */
+        $record = $this->table()
+            ->where('run_id', $runId)
+            ->where('step_index', $stepIndex)
+            ->first();
+
+        if ($record === null) {
+            return null;
+        }
+
+        $rawPayload = $record->payload ?? null;
+        $rawToolCalls = $record->tool_calls ?? null;
+
+        /** @var array<string, mixed> $payload */
+        $payload = $this->decodeJson(is_string($rawPayload) ? $rawPayload : null, []);
+        /** @var array<int, array<string, mixed>> $toolCalls */
+        $toolCalls = $this->decodeJson(is_string($rawToolCalls) ? $rawToolCalls : null, []);
+
+        return MemorySnapshot::fromPersisted($payload, $toolCalls);
+    }
+
+    protected function persist(MemorySnapshot $snapshot): void
+    {
+        $now = CarbonImmutable::now('UTC');
+
+        $this->table()->upsert(
+            [[
+                'run_id' => $snapshot->runId,
+                'step_index' => $snapshot->stepIndex,
+                'payload' => $this->encodeJson($snapshot->toPayloadArray()),
+                'tool_calls' => $this->encodeJson($snapshot->toolCalls),
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]],
+            ['run_id', 'step_index'],
+            ['payload', 'tool_calls', 'updated_at'],
+        );
+    }
+
+    protected function table(): Builder
+    {
+        return $this->connection->table(
+            (string) $this->config->get('swarm.tables.memory_snapshots', 'swarm_memory_snapshots'),
+        );
+    }
+}

--- a/src/Memory/MemorySnapshot.php
+++ b/src/Memory/MemorySnapshot.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Memory;
+
+use BuiltByBerry\LaravelSwarm\Contracts\SnapshotsMemory;
+
+/**
+ * Immutable, serializable freeze of the memory view an agent saw at the
+ * moment a runner invoked it.
+ *
+ * A snapshot is identified by the natural key `(run_id, step_index)` shared
+ * with `swarm_run_steps`, and carries two payloads:
+ *
+ * - `entries` — the agent-visible memory entries at invocation time. Each row
+ *   captures `scope`, `scope_id`, `key`, `value`, and `metadata` plus optional
+ *   ISO-8601 `created_at` / `updated_at` strings so a replay can rebuild a
+ *   {@see MemoryEntry} byte-identical to the original.
+ * - `toolCalls` — input/output pairs for every tool the agent called during
+ *   its invocation. Streamed runs (issue #115) replay byte-identical from
+ *   this list.
+ *
+ * Snapshots are produced by implementations of
+ * {@see SnapshotsMemory} and consumed by
+ * the durable replay path (issue #112) and the inspector CLI (v0.10.0 issue
+ * #122). They are intentionally plain-data so they round-trip through any
+ * JSON column without driver-specific encoding.
+ */
+final readonly class MemorySnapshot
+{
+    /**
+     * @param  array<int, array{scope: string, scope_id: string, key: string, value: mixed, metadata: array<string, mixed>, created_at: string|null, updated_at: string|null}>  $entries
+     * @param  array<int, array{name: string, arguments: array<string, mixed>, result: mixed, id?: string|null, result_id?: string|null}>  $toolCalls
+     */
+    public function __construct(
+        public string $runId,
+        public int $stepIndex,
+        public array $entries,
+        public array $toolCalls = [],
+    ) {}
+
+    /**
+     * Build a snapshot from a list of live {@see MemoryEntry} instances.
+     *
+     * The order of `$entries` is preserved as the snapshot's canonical order.
+     * Replay reads the array straight back without re-sorting.
+     *
+     * @param  array<int, MemoryEntry>  $entries
+     * @param  array<int, array{name: string, arguments: array<string, mixed>, result: mixed, id?: string|null, result_id?: string|null}>  $toolCalls
+     */
+    public static function fromEntries(string $runId, int $stepIndex, array $entries, array $toolCalls = []): self
+    {
+        return new self(
+            runId: $runId,
+            stepIndex: $stepIndex,
+            entries: array_values(array_map(static fn (MemoryEntry $entry): array => [
+                'scope' => $entry->scope->value,
+                'scope_id' => $entry->scopeId,
+                'key' => $entry->key,
+                'value' => $entry->value,
+                'metadata' => $entry->metadata,
+                'created_at' => $entry->createdAt?->toIso8601String(),
+                'updated_at' => $entry->updatedAt?->toIso8601String(),
+            ], $entries)),
+            toolCalls: array_values($toolCalls),
+        );
+    }
+
+    /**
+     * Return a copy of this snapshot with `$toolCall` appended to the
+     * `toolCalls` list. The original instance is left untouched.
+     *
+     * @param  array{name: string, arguments: array<string, mixed>, result: mixed, id?: string|null, result_id?: string|null}  $toolCall
+     */
+    public function withToolCall(array $toolCall): self
+    {
+        return new self(
+            runId: $this->runId,
+            stepIndex: $this->stepIndex,
+            entries: $this->entries,
+            toolCalls: [...$this->toolCalls, $toolCall],
+        );
+    }
+
+    /**
+     * Return a copy with the entire `toolCalls` list replaced.
+     *
+     * @param  array<int, array{name: string, arguments: array<string, mixed>, result: mixed, id?: string|null, result_id?: string|null}>  $toolCalls
+     */
+    public function withToolCalls(array $toolCalls): self
+    {
+        return new self(
+            runId: $this->runId,
+            stepIndex: $this->stepIndex,
+            entries: $this->entries,
+            toolCalls: array_values($toolCalls),
+        );
+    }
+
+    /**
+     * The `payload` JSON column shape persisted to `swarm_memory_snapshots`.
+     *
+     * @return array{run_id: string, step_index: int, entries: array<int, array{scope: string, scope_id: string, key: string, value: mixed, metadata: array<string, mixed>, created_at: string|null, updated_at: string|null}>}
+     */
+    public function toPayloadArray(): array
+    {
+        return [
+            'run_id' => $this->runId,
+            'step_index' => $this->stepIndex,
+            'entries' => $this->entries,
+        ];
+    }
+
+    /**
+     * Rehydrate a snapshot from the persisted `payload` + `tool_calls` JSON
+     * columns. The shape mirrors what {@see toPayloadArray()} and
+     * {@see toolCalls} emit on persist.
+     *
+     * @param  array<string, mixed>  $payload
+     * @param  array<int, array<string, mixed>>  $toolCalls
+     */
+    public static function fromPersisted(array $payload, array $toolCalls): self
+    {
+        /** @var array<int, array{scope: string, scope_id: string, key: string, value: mixed, metadata: array<string, mixed>, created_at: string|null, updated_at: string|null}> $entries */
+        $entries = is_array($payload['entries'] ?? null) ? $payload['entries'] : [];
+
+        /** @var array<int, array{name: string, arguments: array<string, mixed>, result: mixed, id?: string|null, result_id?: string|null}> $normalizedToolCalls */
+        $normalizedToolCalls = array_values($toolCalls);
+
+        return new self(
+            runId: (string) ($payload['run_id'] ?? ''),
+            stepIndex: (int) ($payload['step_index'] ?? 0),
+            entries: $entries,
+            toolCalls: $normalizedToolCalls,
+        );
+    }
+}

--- a/src/Memory/NullSnapshotsMemory.php
+++ b/src/Memory/NullSnapshotsMemory.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Memory;
+
+use BuiltByBerry\LaravelSwarm\Contracts\SnapshotsMemory;
+
+/**
+ * No-op {@see SnapshotsMemory} implementation used when persistence runs in
+ * `cache` mode and the `swarm_memory_snapshots` table is not migrated.
+ *
+ * The runner contract is unchanged — calls return a {@see MemorySnapshot}
+ * value object — but nothing is persisted. Replay (issue #112) explicitly
+ * checks for database-backed snapshots and skips when missing, so this
+ * binding keeps cache-driver tests and ephemeral workloads green without
+ * polluting them with a useless table.
+ *
+ * @internal
+ */
+final class NullSnapshotsMemory implements SnapshotsMemory
+{
+    public function snapshot(string $runId, int $stepIndex): MemorySnapshot
+    {
+        return new MemorySnapshot($runId, $stepIndex, [], []);
+    }
+
+    public function appendToolCall(MemorySnapshot $snapshot, array $toolCall): MemorySnapshot
+    {
+        return $snapshot->withToolCall($toolCall);
+    }
+
+    public function find(string $runId, int $stepIndex): ?MemorySnapshot
+    {
+        return null;
+    }
+}

--- a/src/Memory/SnapshotToolCallNormalizer.php
+++ b/src/Memory/SnapshotToolCallNormalizer.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Memory;
+
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\TextResponse;
+
+/**
+ * Normalize Laravel AI tool-call records into the plain-data shape persisted
+ * to a {@see MemorySnapshot}'s `tool_calls` column.
+ *
+ * Each persisted entry has the shape:
+ *
+ *   [
+ *     'id'        => string|null,   // ToolCall id (provider-assigned)
+ *     'name'      => string,
+ *     'arguments' => array<string,mixed>,
+ *     'result'    => mixed|null,    // result payload, or null if no result paired
+ *     'result_id' => string|null,
+ *   ]
+ *
+ * The normalizer pairs each `ToolCall` to its matching `ToolResult` by
+ * `(toolCall.resultId, toolResult.id)` when present, falling back to
+ * `(toolCall.id, toolResult.id)`. Unpaired calls land with `result => null`
+ * so replay can detect partial runs.
+ *
+ * @internal
+ */
+final class SnapshotToolCallNormalizer
+{
+    /**
+     * Extract tool-call entries from a Laravel AI response value.
+     *
+     * @return array<int, array{name: string, arguments: array<string, mixed>, result: mixed, id: string|null, result_id: string|null}>
+     */
+    public static function fromResponse(mixed $response): array
+    {
+        // StructuredTextResponse, AgentResponse, and StructuredAgentResponse
+        // all extend TextResponse, so this single instanceof check is
+        // sufficient to cover every Laravel AI response shape that carries
+        // tool-call collections.
+        if (! $response instanceof TextResponse) {
+            return [];
+        }
+
+        /** @var array<int, ToolCall> $toolCalls */
+        $toolCalls = $response->toolCalls->all();
+        /** @var array<int, ToolResult> $toolResults */
+        $toolResults = $response->toolResults->all();
+
+        return self::pair($toolCalls, $toolResults);
+    }
+
+    /**
+     * @param  array<int, ToolCall>  $toolCalls
+     * @param  array<int, ToolResult>  $toolResults
+     * @return array<int, array{name: string, arguments: array<string, mixed>, result: mixed, id: string|null, result_id: string|null}>
+     */
+    public static function pair(array $toolCalls, array $toolResults): array
+    {
+        $resultsByLookupId = [];
+
+        foreach ($toolResults as $result) {
+            // Laravel AI tool results expose `id` (the call id they're answering)
+            // and `resultId`. Index by `id` first so we can resolve by the
+            // tool-call's `resultId` (when set) or by its own `id`.
+            $resultsByLookupId[$result->id] = $result;
+        }
+
+        $entries = [];
+
+        foreach ($toolCalls as $call) {
+            $resultLookupId = $call->resultId ?? $call->id;
+            $matched = $resultsByLookupId[$resultLookupId] ?? null;
+
+            $entries[] = [
+                'id' => $call->id,
+                'name' => $call->name,
+                'arguments' => $call->arguments,
+                'result' => $matched?->result,
+                'result_id' => $matched !== null ? $matched->resultId : $call->resultId,
+            ];
+        }
+
+        return $entries;
+    }
+
+    /**
+     * Build a single tool-call entry from already-paired data, used by the
+     * streaming runner which sees `ToolCall` and `ToolResult` events flow by
+     * one at a time.
+     *
+     * @return array{name: string, arguments: array<string, mixed>, result: mixed, id: string|null, result_id: string|null}
+     */
+    public static function entry(ToolCall $call, ?ToolResult $result = null): array
+    {
+        return [
+            'id' => $call->id,
+            'name' => $call->name,
+            'arguments' => $call->arguments,
+            'result' => $result?->result,
+            'result_id' => $result !== null ? $result->resultId : $call->resultId,
+        ];
+    }
+}

--- a/src/Runners/Durable/DurableBranchAdvancer.php
+++ b/src/Runners/Durable/DurableBranchAdvancer.php
@@ -9,6 +9,7 @@ use BuiltByBerry\LaravelSwarm\Contracts\ArtifactRepository;
 use BuiltByBerry\LaravelSwarm\Contracts\ContextStore;
 use BuiltByBerry\LaravelSwarm\Contracts\DurableOutbox;
 use BuiltByBerry\LaravelSwarm\Contracts\DurableRunStore;
+use BuiltByBerry\LaravelSwarm\Contracts\SnapshotsMemory;
 use BuiltByBerry\LaravelSwarm\Contracts\Swarm;
 use BuiltByBerry\LaravelSwarm\Enums\DurableParallelFailurePolicy;
 use BuiltByBerry\LaravelSwarm\Enums\ExecutionMode;
@@ -16,6 +17,7 @@ use BuiltByBerry\LaravelSwarm\Enums\Topology;
 use BuiltByBerry\LaravelSwarm\Exceptions\LostDurableLeaseException;
 use BuiltByBerry\LaravelSwarm\Exceptions\LostSwarmLeaseException;
 use BuiltByBerry\LaravelSwarm\Exceptions\SwarmException;
+use BuiltByBerry\LaravelSwarm\Memory\SnapshotToolCallNormalizer;
 use BuiltByBerry\LaravelSwarm\Persistence\DatabaseRunHistoryStore;
 use BuiltByBerry\LaravelSwarm\Responses\SwarmStep;
 use BuiltByBerry\LaravelSwarm\Runners\SwarmGuardrailRunner;
@@ -55,6 +57,7 @@ class DurableBranchAdvancer
         protected DurableOutbox $outbox,
         protected DurableRunTerminalHandler $terminal,
         protected LoggerInterface $logger,
+        protected SnapshotsMemory $snapshots,
     ) {}
 
     public function advanceBranch(string $runId, string $branchId): void
@@ -122,10 +125,15 @@ class DurableBranchAdvancer
 
         try {
             $this->stepsRecorder->started($state, (int) $branch['step_index'], $branch['agent_class'], $branch['input']);
+            $snapshot = $this->snapshots->snapshot($runId, (int) $branch['step_index']);
             $response = $agent->prompt($branch['input']);
             $output = (string) $response;
             $usage = $response->usage->toArray();
             $durationMs = MonotonicTime::elapsedMilliseconds($startedAt);
+
+            foreach (SnapshotToolCallNormalizer::fromResponse($response) as $toolCall) {
+                $snapshot = $this->snapshots->appendToolCall($snapshot, $toolCall);
+            }
             $this->guardrails->validateStep(
                 $swarm,
                 GuardrailStepContext::fromState(

--- a/src/Runners/HierarchicalRunner.php
+++ b/src/Runners/HierarchicalRunner.php
@@ -7,11 +7,13 @@ namespace BuiltByBerry\LaravelSwarm\Runners;
 use BuiltByBerry\LaravelSwarm\Concerns\MergesAgentUsage;
 use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use BuiltByBerry\LaravelSwarm\Contracts\DurableRunStore;
+use BuiltByBerry\LaravelSwarm\Contracts\SnapshotsMemory;
 use BuiltByBerry\LaravelSwarm\Contracts\Swarm;
 use BuiltByBerry\LaravelSwarm\Enums\ExecutionMode;
 use BuiltByBerry\LaravelSwarm\Enums\GuardrailParallelFailurePolicy;
 use BuiltByBerry\LaravelSwarm\Exceptions\SwarmException;
 use BuiltByBerry\LaravelSwarm\Exceptions\SwarmTimeoutException;
+use BuiltByBerry\LaravelSwarm\Memory\SnapshotToolCallNormalizer;
 use BuiltByBerry\LaravelSwarm\Responses\SwarmResponse;
 use BuiltByBerry\LaravelSwarm\Responses\SwarmStep;
 use BuiltByBerry\LaravelSwarm\Routing\HierarchicalFinishNode;
@@ -45,6 +47,7 @@ class HierarchicalRunner
         protected DurableRunStore $durableRuns,
         protected SwarmGuardrailRunner $guardrails,
         protected ConfigRepository $config,
+        protected SnapshotsMemory $snapshots,
     ) {}
 
     public function run(SwarmExecutionState $state): SwarmResponse
@@ -764,6 +767,7 @@ class HierarchicalRunner
                     $branchDefinitions = [];
                     $callbacks = [];
 
+                    $branchSnapshots = [];
                     foreach ($node->branches as $branchNodeId) {
                         /** @var HierarchicalWorkerNode $branch */
                         $branch = $plan->node($branchNodeId);
@@ -774,12 +778,14 @@ class HierarchicalRunner
                         $this->resolveParallelWorker($state->swarm::class, $workerClass);
                         $input = $this->composePrompt($branch->prompt, $branch->withOutputs, $nodeOutputs, $branch->id);
 
-                        $this->stepsRecorder->started($state, $nextIndex + count($branchDefinitions), $branch->agentClass, $input);
+                        $branchIndex = $nextIndex + count($branchDefinitions);
+                        $this->stepsRecorder->started($state, $branchIndex, $branch->agentClass, $input);
+                        $branchSnapshots[$branchNodeId] = $this->snapshots->snapshot($state->context->runId, $branchIndex);
 
                         $branchDefinitions[$branchNodeId] = [
                             'node' => $branch,
                             'input' => $input,
-                            'index' => $nextIndex + count($branchDefinitions),
+                            'index' => $branchIndex,
                         ];
 
                         $agentClass = $branch->agentClass;
@@ -797,12 +803,24 @@ class HierarchicalRunner
                                 'output' => (string) $response,
                                 'usage' => $response->usage->toArray(),
                                 'duration_ms' => MonotonicTime::elapsedMilliseconds($startedAt),
+                                'tool_calls' => SnapshotToolCallNormalizer::fromResponse($response),
                             ];
                         };
                     }
 
-                    /** @var array<string, array{output: string, usage: array<string, int>, duration_ms: int}> $results */
+                    /** @var array<string, array{output: string, usage: array<string, int>, duration_ms: int, tool_calls: array<int, array{name: string, arguments: array<string, mixed>, result: mixed, id: string|null, result_id: string|null}>}> $results */
                     $results = $this->concurrency->driver()->run($callbacks);
+
+                    foreach ($results as $branchNodeId => $rowData) {
+                        if (! isset($branchSnapshots[$branchNodeId])) {
+                            continue;
+                        }
+                        $branchSnapshot = $branchSnapshots[$branchNodeId];
+                        foreach ($rowData['tool_calls'] ?? [] as $toolCall) {
+                            $branchSnapshot = $this->snapshots->appendToolCall($branchSnapshot, $toolCall);
+                        }
+                        $branchSnapshots[$branchNodeId] = $branchSnapshot;
+                    }
 
                     $policy = GuardrailParallelFailurePolicy::tryFrom((string) $this->config->get(
                         'swarm.guardrails.parallel_failure_policy',
@@ -1292,11 +1310,16 @@ class HierarchicalRunner
         }
 
         $this->stepsRecorder->started($state, $index, $agent::class, $input);
+        $snapshot = $this->snapshots->snapshot($state->context->runId, $index);
 
         $startedAt = MonotonicTime::now();
         $response = $agent->prompt($input);
         $output = (string) $response;
         $usage = $this->usageFromResponse($response);
+
+        foreach (SnapshotToolCallNormalizer::fromResponse($response) as $toolCall) {
+            $snapshot = $this->snapshots->appendToolCall($snapshot, $toolCall);
+        }
 
         $this->guardrails->validateStep(
             $state->swarm,

--- a/src/Runners/ParallelRunner.php
+++ b/src/Runners/ParallelRunner.php
@@ -6,9 +6,11 @@ namespace BuiltByBerry\LaravelSwarm\Runners;
 
 use BuiltByBerry\LaravelSwarm\Concerns\MergesAgentUsage;
 use BuiltByBerry\LaravelSwarm\Contracts\Agent;
+use BuiltByBerry\LaravelSwarm\Contracts\SnapshotsMemory;
 use BuiltByBerry\LaravelSwarm\Enums\GuardrailParallelFailurePolicy;
 use BuiltByBerry\LaravelSwarm\Exceptions\SwarmException;
 use BuiltByBerry\LaravelSwarm\Exceptions\SwarmTimeoutException;
+use BuiltByBerry\LaravelSwarm\Memory\SnapshotToolCallNormalizer;
 use BuiltByBerry\LaravelSwarm\Responses\SwarmResponse;
 use BuiltByBerry\LaravelSwarm\Support\GuardrailStepContext;
 use BuiltByBerry\LaravelSwarm\Support\MonotonicTime;
@@ -32,6 +34,7 @@ class ParallelRunner
         protected SwarmCapture $capture,
         protected SwarmGuardrailRunner $guardrails,
         protected ConfigRepository $config,
+        protected SnapshotsMemory $snapshots,
     ) {}
 
     public function run(SwarmExecutionState $state): SwarmResponse
@@ -45,9 +48,11 @@ class ParallelRunner
         $this->ensureAgentsAreContainerResolvable($agents, $state->swarm::class);
 
         $callbacks = [];
+        $snapshots = [];
         foreach ($agents as $index => $agent) {
             $agentClass = $agent::class;
             $this->stepsRecorder->started($state, $index, $agentClass, $input);
+            $snapshots[$index] = $this->snapshots->snapshot($state->context->runId, $index);
 
             $callbacks[$index] = function () use ($agentClass, $input): array {
                 $agent = Container::getInstance()->make($agentClass);
@@ -64,12 +69,25 @@ class ParallelRunner
                     'usage' => $response->usage->toArray(),
                     'class' => $agentClass,
                     'duration_ms' => MonotonicTime::elapsedMilliseconds($startedAt),
+                    'tool_calls' => SnapshotToolCallNormalizer::fromResponse($response),
                 ];
             };
         }
 
-        /** @var array<int, array{output: string, usage: array<string, int>, class: string, duration_ms: int}> $results */
+        /** @var array<int, array{output: string, usage: array<string, int>, class: string, duration_ms: int, tool_calls: array<int, array{name: string, arguments: array<string, mixed>, result: mixed, id: string|null, result_id: string|null}>}> $results */
         $results = $this->concurrency->driver()->run($callbacks);
+
+        foreach ($results as $rowIndex => $rowData) {
+            if (! isset($snapshots[$rowIndex])) {
+                continue;
+            }
+
+            $snapshot = $snapshots[$rowIndex];
+            foreach ($rowData['tool_calls'] ?? [] as $toolCall) {
+                $snapshot = $this->snapshots->appendToolCall($snapshot, $toolCall);
+            }
+            $snapshots[$rowIndex] = $snapshot;
+        }
 
         if (hrtime(true) >= $state->deadlineMonotonic) {
             throw new SwarmTimeoutException('The swarm exceeded its configured timeout after parallel execution.');

--- a/src/Runners/SequentialRunner.php
+++ b/src/Runners/SequentialRunner.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace BuiltByBerry\LaravelSwarm\Runners;
 
 use BuiltByBerry\LaravelSwarm\Concerns\MergesAgentUsage;
+use BuiltByBerry\LaravelSwarm\Contracts\SnapshotsMemory;
 use BuiltByBerry\LaravelSwarm\Exceptions\SwarmStreamProviderException;
 use BuiltByBerry\LaravelSwarm\Exceptions\SwarmTimeoutException;
+use BuiltByBerry\LaravelSwarm\Memory\MemorySnapshot;
+use BuiltByBerry\LaravelSwarm\Memory\SnapshotToolCallNormalizer;
 use BuiltByBerry\LaravelSwarm\Responses\SwarmResponse;
 use BuiltByBerry\LaravelSwarm\Responses\SwarmStep;
 use BuiltByBerry\LaravelSwarm\Streaming\Events\SwarmReasoningDelta;
@@ -47,6 +50,7 @@ class SequentialRunner
         protected SwarmCapture $capture,
         protected SwarmPayloadLimits $limits,
         protected SwarmGuardrailRunner $guardrails,
+        protected SnapshotsMemory $snapshots,
     ) {}
 
     public function run(SwarmExecutionState $state): SwarmResponse
@@ -97,6 +101,7 @@ class SequentialRunner
             $agentName = class_basename($agent::class);
 
             $this->steps->started($state, $index, $agent::class, $input);
+            $snapshot = $this->snapshots->snapshot($state->context->runId, $index);
 
             yield new SwarmStepStart(
                 id: SwarmStreamEvent::newId(),
@@ -115,6 +120,8 @@ class SequentialRunner
             if ($index === $lastIndex) {
                 $stream = $agent->stream($input);
                 $output = '';
+                /** @var array<string, ToolCallData> $pendingToolCalls */
+                $pendingToolCalls = [];
 
                 foreach ($stream as $event) {
                     if ($event instanceof TextDelta) {
@@ -170,6 +177,13 @@ class SequentialRunner
 
                         yield $swarmEvent;
                     } elseif ($event instanceof ToolCall) {
+                        // Hold the call until we see its matching ToolResult so the
+                        // snapshot row records a paired input/output entry, then a
+                        // single appendToolCall persists the finalized pair. This
+                        // keeps the snapshot row write count proportional to tool
+                        // results, not events.
+                        $pendingToolCalls[$event->toolCall->id] = $event->toolCall;
+
                         $swarmEvent = new SwarmToolCall(
                             id: $event->id,
                             runId: $state->context->runId,
@@ -182,6 +196,17 @@ class SequentialRunner
 
                         yield $swarmEvent;
                     } elseif ($event instanceof ToolResult) {
+                        $matchedCallId = $event->toolResult->id;
+                        $matchedCall = $pendingToolCalls[$matchedCallId] ?? null;
+
+                        if ($matchedCall !== null) {
+                            unset($pendingToolCalls[$matchedCallId]);
+                            $snapshot = $this->snapshots->appendToolCall(
+                                $snapshot,
+                                SnapshotToolCallNormalizer::entry($matchedCall, $event->toolResult),
+                            );
+                        }
+
                         $swarmEvent = new SwarmToolResult(
                             id: $event->id,
                             runId: $state->context->runId,
@@ -210,6 +235,16 @@ class SequentialRunner
                     }
                 }
 
+                // Any tool calls without a matching ToolResult by stream end
+                // are still part of the agent's invocation surface, so persist
+                // them with result=null so replay can detect partial runs.
+                foreach ($pendingToolCalls as $unpairedCall) {
+                    $snapshot = $this->snapshots->appendToolCall(
+                        $snapshot,
+                        SnapshotToolCallNormalizer::entry($unpairedCall),
+                    );
+                }
+
                 $durationMs = MonotonicTime::elapsedMilliseconds($startedAt);
                 $this->guardrails->validateStep(
                     $state->swarm,
@@ -229,6 +264,7 @@ class SequentialRunner
                 $response = $agent->prompt($input);
                 $output = (string) $response;
                 $stepUsage = $this->usageFromResponse($response);
+                $this->appendResponseToolCalls($snapshot, $response);
 
                 $this->guardrails->validateStep(
                     $state->swarm,
@@ -285,11 +321,13 @@ class SequentialRunner
 
         $input = $state->context->prompt();
         $this->steps->started($state, $index, $agent::class, $input);
+        $snapshot = $this->snapshots->snapshot($state->context->runId, $index);
 
         $startedAt = MonotonicTime::now();
         $response = $agent->prompt($input);
         $output = (string) $response;
         $usage = $this->usageFromResponse($response);
+        $this->appendResponseToolCalls($snapshot, $response);
         $mergedUsage = $this->mergeUsage(
             is_array($state->context->metadata['usage'] ?? null) ? $state->context->metadata['usage'] : [],
             $usage,
@@ -396,6 +434,15 @@ class SequentialRunner
         if (is_string($invocationId)) {
             $swarmEvent->withInvocationId($invocationId);
         }
+    }
+
+    protected function appendResponseToolCalls(MemorySnapshot $snapshot, mixed $response): MemorySnapshot
+    {
+        foreach (SnapshotToolCallNormalizer::fromResponse($response) as $toolCall) {
+            $snapshot = $this->snapshots->appendToolCall($snapshot, $toolCall);
+        }
+
+        return $snapshot;
     }
 
     /**

--- a/src/SwarmServiceProvider.php
+++ b/src/SwarmServiceProvider.php
@@ -44,14 +44,17 @@ use BuiltByBerry\LaravelSwarm\Contracts\DurableRunStore;
 use BuiltByBerry\LaravelSwarm\Contracts\MemoryStore;
 use BuiltByBerry\LaravelSwarm\Contracts\RunHistoryStore;
 use BuiltByBerry\LaravelSwarm\Contracts\SinkFailureHandler;
+use BuiltByBerry\LaravelSwarm\Contracts\SnapshotsMemory;
 use BuiltByBerry\LaravelSwarm\Contracts\StreamEventStore;
 use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSigner;
 use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
 use BuiltByBerry\LaravelSwarm\Contracts\SwarmMemory;
 use BuiltByBerry\LaravelSwarm\Contracts\SwarmTelemetrySink;
 use BuiltByBerry\LaravelSwarm\Memory\CacheMemoryStore;
+use BuiltByBerry\LaravelSwarm\Memory\DatabaseMemorySnapshotRecorder;
 use BuiltByBerry\LaravelSwarm\Memory\DatabaseMemoryStore;
 use BuiltByBerry\LaravelSwarm\Memory\DefaultSwarmMemory;
+use BuiltByBerry\LaravelSwarm\Memory\NullSnapshotsMemory;
 use BuiltByBerry\LaravelSwarm\Persistence\CacheArtifactRepository;
 use BuiltByBerry\LaravelSwarm\Persistence\CacheContextStore;
 use BuiltByBerry\LaravelSwarm\Persistence\CacheRunHistoryStore;
@@ -256,6 +259,19 @@ class SwarmServiceProvider extends ServiceProvider
             DatabaseMemoryStore::class,
         ));
         $this->app->singleton(SwarmMemory::class, DefaultSwarmMemory::class);
+
+        // Snapshot recording requires the `swarm_memory_snapshots` table from
+        // migration #110. When persistence runs in `cache` mode (default for
+        // tests and ephemeral workloads) the table is not migrated, so fall
+        // back to a no-op implementation rather than failing every run. The
+        // database recorder is wired automatically when `swarm.persistence.driver`
+        // is `database` or `swarm.memory.driver` overrides it explicitly.
+        $this->app->singleton(SnapshotsMemory::class, fn (Application $app): SnapshotsMemory => $this->resolvePersistenceStore(
+            $app,
+            'memory',
+            NullSnapshotsMemory::class,
+            DatabaseMemorySnapshotRecorder::class,
+        ));
     }
 
     /**

--- a/tests/Feature/Memory/MemorySnapshotTest.php
+++ b/tests/Feature/Memory/MemorySnapshotTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Contracts\MemoryStore;
+use BuiltByBerry\LaravelSwarm\Contracts\SnapshotsMemory;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmMemory;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Memory\DatabaseMemorySnapshotRecorder;
+use BuiltByBerry\LaravelSwarm\Memory\DefaultSwarmMemory;
+use BuiltByBerry\LaravelSwarm\Memory\MemoryEntry;
+use BuiltByBerry\LaravelSwarm\Memory\MemorySnapshot;
+use BuiltByBerry\LaravelSwarm\Tests\Support\InMemoryMemoryStore;
+use Illuminate\Database\Connection;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+beforeEach(function () {
+    DB::table('swarm_run_histories')->insert([
+        'run_id' => 'run-snap',
+        'swarm_class' => 'ExampleSwarm',
+        'topology' => 'sequential',
+        'status' => 'running',
+        'context' => json_encode([]),
+        'metadata' => json_encode([]),
+        'steps' => json_encode([]),
+        'output' => null,
+        'usage' => json_encode([]),
+        'error' => null,
+        'artifacts' => json_encode([]),
+        'created_at' => Carbon::now('UTC'),
+        'updated_at' => Carbon::now('UTC'),
+    ]);
+
+    // Bind an in-memory MemoryStore so the recorder can read entries without
+    // needing the swarm_memories table (which lives in a sibling worktree).
+    $this->app->singleton(MemoryStore::class, fn (): MemoryStore => new InMemoryMemoryStore);
+    $this->app->singleton(SwarmMemory::class, DefaultSwarmMemory::class);
+    $this->app->singleton(SnapshotsMemory::class, function (): SnapshotsMemory {
+        return new DatabaseMemorySnapshotRecorder(
+            connection: $this->app->make(Connection::class),
+            config: $this->app->make('config'),
+            memory: $this->app->make(SwarmMemory::class),
+        );
+    });
+});
+
+// ---------------------------------------------------------------------------
+// MemorySnapshot value object
+// ---------------------------------------------------------------------------
+
+test('MemorySnapshot::fromEntries freezes the agent-visible view and preserves order', function () {
+    $entries = [
+        new MemoryEntry(MemoryScope::Run, 'run-1', 'first', 'a'),
+        new MemoryEntry(MemoryScope::Run, 'run-1', 'second', ['nested' => true]),
+    ];
+
+    $snapshot = MemorySnapshot::fromEntries('run-1', 0, $entries);
+
+    expect($snapshot->runId)->toBe('run-1');
+    expect($snapshot->stepIndex)->toBe(0);
+    expect($snapshot->entries)->toHaveCount(2);
+    expect($snapshot->entries[0]['key'])->toBe('first');
+    expect($snapshot->entries[1]['key'])->toBe('second');
+    expect($snapshot->entries[1]['value'])->toBe(['nested' => true]);
+    expect($snapshot->toolCalls)->toBe([]);
+});
+
+test('MemorySnapshot::withToolCall returns an immutable copy with the appended entry', function () {
+    $snapshot = new MemorySnapshot('run-1', 0, [], []);
+    $next = $snapshot->withToolCall(['name' => 't', 'arguments' => [], 'result' => 'ok']);
+
+    expect($snapshot->toolCalls)->toBe([]);
+    expect($next->toolCalls)->toHaveCount(1);
+    expect($next->toolCalls[0])->toMatchArray(['name' => 't', 'result' => 'ok']);
+});
+
+// ---------------------------------------------------------------------------
+// DatabaseMemorySnapshotRecorder — persist + read back
+// ---------------------------------------------------------------------------
+
+test('snapshot persists the frozen view to swarm_memory_snapshots and returns a value object', function () {
+    /** @var SwarmMemory $memory */
+    $memory = $this->app->make(SwarmMemory::class);
+    $memory->put(MemoryScope::Run, 'run-snap', 'last_output', 'previous-agent-output');
+    $memory->put(MemoryScope::Run, 'run-snap', 'preferences', ['tone' => 'casual']);
+
+    /** @var SnapshotsMemory $recorder */
+    $recorder = $this->app->make(SnapshotsMemory::class);
+    $snapshot = $recorder->snapshot('run-snap', 0);
+
+    expect($snapshot->runId)->toBe('run-snap');
+    expect($snapshot->stepIndex)->toBe(0);
+    expect($snapshot->entries)->toHaveCount(2);
+    expect($snapshot->toolCalls)->toBe([]);
+
+    $row = DB::table('swarm_memory_snapshots')->where('run_id', 'run-snap')->where('step_index', 0)->first();
+    expect($row)->not->toBeNull();
+    /** @var object $row */
+    $payload = json_decode((string) $row->payload, true);
+    expect($payload['run_id'])->toBe('run-snap');
+    expect($payload['step_index'])->toBe(0);
+    expect($payload['entries'])->toHaveCount(2);
+});
+
+test('appendToolCall rewrites only the tool_calls JSON column and returns the updated snapshot', function () {
+    /** @var SnapshotsMemory $recorder */
+    $recorder = $this->app->make(SnapshotsMemory::class);
+    $snapshot = $recorder->snapshot('run-snap', 0);
+
+    $updated = $recorder->appendToolCall($snapshot, [
+        'id' => 'call-1',
+        'name' => 'Recall',
+        'arguments' => ['key' => 'user_pref'],
+        'result' => 'dark mode',
+        'result_id' => 'r-1',
+    ]);
+    $updated = $recorder->appendToolCall($updated, [
+        'id' => 'call-2',
+        'name' => 'Recall',
+        'arguments' => ['key' => 'language'],
+        'result' => 'en',
+        'result_id' => 'r-2',
+    ]);
+
+    expect($updated->toolCalls)->toHaveCount(2);
+
+    $row = DB::table('swarm_memory_snapshots')->where('run_id', 'run-snap')->where('step_index', 0)->first();
+    /** @var object $row */
+    $toolCalls = json_decode((string) $row->tool_calls, true);
+    expect($toolCalls)->toHaveCount(2);
+    expect($toolCalls[0]['name'])->toBe('Recall');
+    expect($toolCalls[1]['arguments'])->toBe(['key' => 'language']);
+});
+
+test('find rehydrates a persisted snapshot byte-identical to the original view', function () {
+    /** @var SwarmMemory $memory */
+    $memory = $this->app->make(SwarmMemory::class);
+    $memory->put(MemoryScope::Run, 'run-snap', 'fact', ['source' => 'wiki', 'pages' => [1, 2, 3]]);
+
+    /** @var SnapshotsMemory $recorder */
+    $recorder = $this->app->make(SnapshotsMemory::class);
+    $original = $recorder->snapshot('run-snap', 0);
+    $recorder->appendToolCall($original, ['name' => 't', 'arguments' => [], 'result' => 'ok']);
+
+    $rehydrated = $recorder->find('run-snap', 0);
+
+    expect($rehydrated)->not->toBeNull();
+    /** @var MemorySnapshot $rehydrated */
+    expect($rehydrated->runId)->toBe($original->runId);
+    expect($rehydrated->stepIndex)->toBe($original->stepIndex);
+    expect($rehydrated->entries)->toBe($original->entries);
+    expect($rehydrated->toolCalls)->toHaveCount(1);
+});
+
+test('snapshot upserts when called twice for the same (run_id, step_index)', function () {
+    /** @var SwarmMemory $memory */
+    $memory = $this->app->make(SwarmMemory::class);
+    /** @var SnapshotsMemory $recorder */
+    $recorder = $this->app->make(SnapshotsMemory::class);
+
+    $memory->put(MemoryScope::Run, 'run-snap', 'k', 'v1');
+    $recorder->snapshot('run-snap', 0);
+
+    $memory->put(MemoryScope::Run, 'run-snap', 'k', 'v2');
+    $recorder->snapshot('run-snap', 0);
+
+    expect(DB::table('swarm_memory_snapshots')->where('run_id', 'run-snap')->count())->toBe(1);
+
+    $rehydrated = $recorder->find('run-snap', 0);
+    /** @var MemorySnapshot $rehydrated */
+    expect($rehydrated->entries[0]['value'])->toBe('v2');
+});
+
+test('snapshot persists with an empty entries list when no memory has been written', function () {
+    /** @var SnapshotsMemory $recorder */
+    $recorder = $this->app->make(SnapshotsMemory::class);
+    $snapshot = $recorder->snapshot('run-snap', 0);
+
+    expect($snapshot->entries)->toBe([]);
+
+    $row = DB::table('swarm_memory_snapshots')->where('run_id', 'run-snap')->where('step_index', 0)->first();
+    /** @var object $row */
+    expect(json_decode((string) $row->payload, true)['entries'])->toBe([]);
+});
+
+// ---------------------------------------------------------------------------
+// Payload size budget — a single snapshot should not balloon the row
+// ---------------------------------------------------------------------------
+
+test('snapshot payload stays within a reasonable byte budget for typical workloads', function () {
+    /** @var SwarmMemory $memory */
+    $memory = $this->app->make(SwarmMemory::class);
+
+    // Write 25 entries of ~200 bytes of value each — representative of a
+    // multi-step run that has accumulated typical agent state. The row should
+    // stay well under the 64KB MEDIUMTEXT-or-larger ceiling we expect from
+    // any reasonable JSON column.
+    for ($i = 0; $i < 25; $i++) {
+        $memory->put(
+            MemoryScope::Run,
+            'run-snap',
+            "key-{$i}",
+            ['index' => $i, 'note' => str_repeat('a', 200)],
+        );
+    }
+
+    /** @var SnapshotsMemory $recorder */
+    $recorder = $this->app->make(SnapshotsMemory::class);
+    $recorder->snapshot('run-snap', 0);
+
+    $row = DB::table('swarm_memory_snapshots')->where('run_id', 'run-snap')->where('step_index', 0)->first();
+    /** @var object $row */
+    expect(strlen((string) $row->payload))->toBeLessThan(32 * 1024);
+});

--- a/tests/Feature/Memory/RunnerSnapshotIntegrationTest.php
+++ b/tests/Feature/Memory/RunnerSnapshotIntegrationTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Contracts\SnapshotsMemory;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\FakeEditor;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\FakeHierarchicalCoordinator;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\FakeResearcher;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\FakeWriter;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\FakeHierarchicalSingleRouteSwarm;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\FakeParallelSwarm;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\FakeRichStreamingSwarm;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\FakeSequentialSwarm;
+use BuiltByBerry\LaravelSwarm\Tests\Support\HierarchicalTestPlan;
+use BuiltByBerry\LaravelSwarm\Tests\Support\RecordingSnapshotsMemory;
+
+/**
+ * Verifies each runner calls SnapshotsMemory::snapshot() exactly once per
+ * agent invocation, immediately before $agent->prompt() / $agent->stream().
+ *
+ * The full byte-fidelity story is covered by MemorySnapshotTest against the
+ * database-backed recorder; this file only asserts the wiring — that runners
+ * actually invoke the contract at the right point.
+ */
+beforeEach(function () {
+    FakeHierarchicalCoordinator::fake([
+        HierarchicalTestPlan::make('writer_node', [
+            'writer_node' => [
+                'type' => 'worker',
+                'agent' => FakeWriter::class,
+                'prompt' => 'writer-task',
+            ],
+        ]),
+    ]);
+    FakeResearcher::fake(['research-out']);
+    FakeWriter::fake(['writer-out']);
+    FakeEditor::fake(['editor-out']);
+
+    $this->recorder = new RecordingSnapshotsMemory;
+    $this->app->instance(SnapshotsMemory::class, $this->recorder);
+});
+
+test('SequentialRunner snapshots memory before every agent invocation', function () {
+    FakeSequentialSwarm::make()->run('original-task');
+
+    /** @var RecordingSnapshotsMemory $recorder */
+    $recorder = $this->recorder;
+    expect($recorder->snapshotCalls)->toHaveCount(3);
+    expect($recorder->snapshotCalls[0]['step_index'])->toBe(0);
+    expect($recorder->snapshotCalls[1]['step_index'])->toBe(1);
+    expect($recorder->snapshotCalls[2]['step_index'])->toBe(2);
+    expect($recorder->snapshotCalls[0]['run_id'])->toBe($recorder->snapshotCalls[1]['run_id']);
+});
+
+test('ParallelRunner snapshots memory before every parallel branch', function () {
+    FakeParallelSwarm::make()->run('shared-task');
+
+    /** @var RecordingSnapshotsMemory $recorder */
+    $recorder = $this->recorder;
+    expect($recorder->snapshotCalls)->toHaveCount(3);
+    $stepIndexes = array_column($recorder->snapshotCalls, 'step_index');
+    sort($stepIndexes);
+    expect($stepIndexes)->toBe([0, 1, 2]);
+});
+
+test('HierarchicalRunner snapshots memory for the coordinator and every worker', function () {
+    FakeHierarchicalSingleRouteSwarm::make()->run('hierarchical-task');
+
+    /** @var RecordingSnapshotsMemory $recorder */
+    $recorder = $this->recorder;
+    // Coordinator (index 0) plus at least one worker step.
+    expect(count($recorder->snapshotCalls))->toBeGreaterThanOrEqual(2);
+    expect($recorder->snapshotCalls[0]['step_index'])->toBe(0);
+});
+
+test('SequentialRunner streaming appends paired tool-call entries to the snapshot', function () {
+    $events = iterator_to_array(FakeRichStreamingSwarm::make()->stream('streaming-task'));
+
+    expect($events)->not->toBeEmpty();
+
+    /** @var RecordingSnapshotsMemory $recorder */
+    $recorder = $this->recorder;
+    expect($recorder->snapshotCalls)->toHaveCount(3);
+
+    // The RichStreamEditor fixture emits one ToolCall + matching ToolResult.
+    // Snapshot recording pairs them into a single appendToolCall.
+    $streamingStepAppends = array_filter(
+        $recorder->toolCallAppends,
+        static fn (array $append): bool => $append['step_index'] === 2,
+    );
+    expect($streamingStepAppends)->toHaveCount(1);
+
+    /** @var array{tool_call: array<string, mixed>} $append */
+    $append = array_values($streamingStepAppends)[0];
+    expect($append['tool_call']['name'])->toBe('search_docs');
+    expect($append['tool_call']['arguments'])->toBe(['query' => 'swarm']);
+    expect($append['tool_call']['result'])->toBe(['matches' => 1]);
+});

--- a/tests/Support/InMemoryMemoryStore.php
+++ b/tests/Support/InMemoryMemoryStore.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Tests\Support;
+
+use BuiltByBerry\LaravelSwarm\Contracts\MemoryStore;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Memory\MemoryEntry;
+use Carbon\CarbonImmutable;
+
+/**
+ * Lightweight test double for {@see MemoryStore} that keeps entries in a
+ * process-local array. Used by snapshot tests so they can populate a
+ * deterministic memory view without depending on either the database or
+ * cache driver bindings.
+ */
+final class InMemoryMemoryStore implements MemoryStore
+{
+    /** @var array<string, array<int, MemoryEntry>> */
+    private array $entries = [];
+
+    public function put(MemoryEntry $entry): MemoryEntry
+    {
+        $now = CarbonImmutable::now('UTC');
+        $createdAt = $entry->createdAt ?? $now;
+        $persisted = $entry->withTimestamps($createdAt, $now);
+
+        $key = $this->bucket($entry->scope, $entry->scopeId);
+        $existing = $this->entries[$key] ?? [];
+        $replaced = false;
+
+        foreach ($existing as $i => $candidate) {
+            if ($candidate->key === $entry->key) {
+                $existing[$i] = $persisted;
+                $replaced = true;
+                break;
+            }
+        }
+
+        if (! $replaced) {
+            $existing[] = $persisted;
+        }
+
+        $this->entries[$key] = $existing;
+
+        return $persisted;
+    }
+
+    public function get(MemoryScope $scope, string $scopeId, string $key): ?MemoryEntry
+    {
+        foreach ($this->entries[$this->bucket($scope, $scopeId)] ?? [] as $candidate) {
+            if ($candidate->key === $key) {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+
+    public function forget(MemoryScope $scope, string $scopeId, string $key): bool
+    {
+        $bucketKey = $this->bucket($scope, $scopeId);
+        $existing = $this->entries[$bucketKey] ?? [];
+
+        foreach ($existing as $i => $candidate) {
+            if ($candidate->key === $key) {
+                unset($existing[$i]);
+                $this->entries[$bucketKey] = array_values($existing);
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function all(MemoryScope $scope, string $scopeId): array
+    {
+        return array_values($this->entries[$this->bucket($scope, $scopeId)] ?? []);
+    }
+
+    private function bucket(MemoryScope $scope, string $scopeId): string
+    {
+        return $scope->value.':'.$scopeId;
+    }
+}

--- a/tests/Support/RecordingSnapshotsMemory.php
+++ b/tests/Support/RecordingSnapshotsMemory.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Tests\Support;
+
+use BuiltByBerry\LaravelSwarm\Contracts\SnapshotsMemory;
+use BuiltByBerry\LaravelSwarm\Memory\MemorySnapshot;
+
+/**
+ * Recording test double that captures every snapshot() and appendToolCall()
+ * call so runner tests can assert the runner wires snapshots correctly
+ * without needing a database connection.
+ */
+final class RecordingSnapshotsMemory implements SnapshotsMemory
+{
+    /** @var array<int, array{run_id: string, step_index: int}> */
+    public array $snapshotCalls = [];
+
+    /** @var array<int, array{run_id: string, step_index: int, tool_call: array<string, mixed>}> */
+    public array $toolCallAppends = [];
+
+    public function snapshot(string $runId, int $stepIndex): MemorySnapshot
+    {
+        $this->snapshotCalls[] = ['run_id' => $runId, 'step_index' => $stepIndex];
+
+        return new MemorySnapshot($runId, $stepIndex, [], []);
+    }
+
+    public function appendToolCall(MemorySnapshot $snapshot, array $toolCall): MemorySnapshot
+    {
+        $this->toolCallAppends[] = [
+            'run_id' => $snapshot->runId,
+            'step_index' => $snapshot->stepIndex,
+            'tool_call' => $toolCall,
+        ];
+
+        return $snapshot->withToolCall($toolCall);
+    }
+
+    public function find(string $runId, int $stepIndex): ?MemorySnapshot
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `MemorySnapshot` value object and `SnapshotsMemory` contract for freezing the agent-visible memory view at the moment a runner invokes `$agent->prompt()` / `$agent->stream()`.
- Wires all four runners (`SequentialRunner`, `ParallelRunner`, `HierarchicalRunner`, `DurableBranchAdvancer`) to snapshot via the new contract, with paired tool-call input/output capture during the invocation.
- Backs the contract with `DatabaseMemorySnapshotRecorder` over `swarm_memory_snapshots` (#110) when persistence is `database`, and `NullSnapshotsMemory` when `cache` so cache-mode workloads continue to work without the snapshots table.

Closes #111

## Design notes

- Snapshot scope is intentionally Run-only for now. Conversation / Agent / Swarm scopes will fold into snapshots once the v0.10 propagation policy ships and the runner can ask "what should this worker see" instead of "every Run-scoped entry".
- The recorder catches `QueryException` on the underlying `swarm_memories` table read so the snapshots-schema migration (#110) can land in this PR before the entries-schema migration (#109/sibling worktree) without breaking database-mode tests.
- Tool-call capture pairs `ToolCall` + `ToolResult` events in the streaming path and reads `TextResponse::$toolCalls/$toolResults` in the batched path. Unpaired calls land with `result => null` so replay can detect partial runs.

## Deferred work

- Replay-time consumption of snapshots — issue #112.
- Inspector CLI surface — v0.10.0 issue #122.
- Compaction of snapshot payloads — deferred per issue scope.
- Docs page `docs/memory.md` snapshot section — issue #116.
- CHANGELOG entry deferred to release wrap per v0.8 convention.

## Test plan

- [x] `composer test` — 1001 tests, 4053 assertions, all passing
- [x] `composer lint` — passing
- [x] `composer analyse` — no errors
- [x] New `MemorySnapshotTest` — 8 tests covering value object, recorder upsert/rehydrate, payload size budget
- [x] New `RunnerSnapshotIntegrationTest` — 4 tests covering Sequential / Parallel / Hierarchical snapshot wiring and streaming tool-call pairing