### PR TITLE
feat(memory): add existed flag to MemoryForgotten event

### DIFF
--- a/src/Events/Memory/MemoryForgotten.php
+++ b/src/Events/Memory/MemoryForgotten.php
@@ -20,6 +20,22 @@ use BuiltByBerry\LaravelSwarm\Memory\DefaultSwarmMemory;
  * address. Listeners can hook in for app-level audit trails, custom metrics,
  * or downstream cleanup automation.
  *
+ * The `$existed` flag distinguishes the two possible outcomes:
+ *
+ * - `$existed === true` — an entry was present at the address and a row was
+ *   actually removed by the store. This is the case audit-trail listeners
+ *   typically care about ("show me every Run-scoped deletion in Q3").
+ * - `$existed === false` — no entry was present at the address; the
+ *   `forget()` call was a no-op probe. The event is still dispatched so the
+ *   listener contract stays uniform across calls, but consumers building
+ *   compliance / audit reports will usually want to filter these out to
+ *   avoid noisy false positives.
+ *
+ * Listeners doing audit-trail capture should typically filter by
+ * `$existed === true` to avoid no-op noise. Monitoring listeners (for
+ * example, security probing detection that wants to see callers poking at
+ * addresses they have no right to delete) may want to observe both states.
+ *
  * Companion / third-party {@see MemoryStore}
  * drivers are expected to dispatch this event from their own `forget()`
  * implementations to keep the listener contract uniform across drivers. See
@@ -32,5 +48,6 @@ final class MemoryForgotten
         public readonly MemoryScope $scope,
         public readonly string $scopeId,
         public readonly string $key,
+        public readonly bool $existed,
     ) {}
 }

--- a/src/Memory/CacheMemoryStore.php
+++ b/src/Memory/CacheMemoryStore.php
@@ -90,6 +90,7 @@ final class CacheMemoryStore implements MemoryStore
             scope: $scope,
             scopeId: $scopeId,
             key: $key,
+            existed: $existed,
         ));
 
         return $existed;

--- a/src/Memory/DatabaseMemoryStore.php
+++ b/src/Memory/DatabaseMemoryStore.php
@@ -109,6 +109,7 @@ final class DatabaseMemoryStore implements MemoryStore
             scope: $scope,
             scopeId: $scopeId,
             key: $key,
+            existed: $deleted > 0,
         ));
 
         return $deleted > 0;

--- a/tests/Feature/Memory/MemoryEventsTest.php
+++ b/tests/Feature/Memory/MemoryEventsTest.php
@@ -90,12 +90,41 @@ test('cache store dispatches MemoryForgotten on forget whether or not the entry 
 
     Event::assertDispatched(MemoryForgotten::class, fn (MemoryForgotten $event): bool => $event->scope === MemoryScope::Run
         && $event->scopeId === 'run-1'
-        && $event->key === 'absent');
+        && $event->key === 'absent'
+        && $event->existed === false);
 
     $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'present', 'x'));
     $store->forget(MemoryScope::Run, 'run-1', 'present');
 
     Event::assertDispatchedTimes(MemoryForgotten::class, 2);
+    Event::assertDispatched(MemoryForgotten::class, fn (MemoryForgotten $event): bool => $event->scope === MemoryScope::Run
+        && $event->scopeId === 'run-1'
+        && $event->key === 'present'
+        && $event->existed === true);
+});
+
+test('cache store MemoryForgotten exposes existed flag distinguishing real deletions from no-op probes', function () {
+    Event::fake([MemoryForgotten::class]);
+
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    // No-op probe — nothing at the address.
+    $store->forget(MemoryScope::Run, 'run-1', 'never-was');
+
+    // Real deletion — write, then forget.
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-1', 'real', 'value'));
+    $store->forget(MemoryScope::Run, 'run-1', 'real');
+
+    Event::assertDispatchedTimes(MemoryForgotten::class, 2);
+    Event::assertDispatched(
+        MemoryForgotten::class,
+        fn (MemoryForgotten $event): bool => $event->key === 'never-was' && $event->existed === false,
+    );
+    Event::assertDispatched(
+        MemoryForgotten::class,
+        fn (MemoryForgotten $event): bool => $event->key === 'real' && $event->existed === true,
+    );
 });
 
 test('cache store all() does not emit MemoryRead per entry', function () {
@@ -205,8 +234,35 @@ test('database store dispatches MemoryForgotten on forget whether row existed or
     $store->forget(MemoryScope::Swarm, 'SwarmA', 'present');
 
     Event::assertDispatchedTimes(MemoryForgotten::class, 2);
-    Event::assertDispatched(MemoryForgotten::class, fn (MemoryForgotten $e): bool => $e->key === 'absent' && $e->scope === MemoryScope::Swarm);
-    Event::assertDispatched(MemoryForgotten::class, fn (MemoryForgotten $e): bool => $e->key === 'present' && $e->scope === MemoryScope::Swarm);
+    Event::assertDispatched(MemoryForgotten::class, fn (MemoryForgotten $e): bool => $e->key === 'absent' && $e->scope === MemoryScope::Swarm && $e->existed === false);
+    Event::assertDispatched(MemoryForgotten::class, fn (MemoryForgotten $e): bool => $e->key === 'present' && $e->scope === MemoryScope::Swarm && $e->existed === true);
+});
+
+test('database store MemoryForgotten exposes existed flag distinguishing real deletions from no-op probes', function () {
+    config()->set('swarm.persistence.driver', 'database');
+    makeSwarmMemoriesTable();
+
+    Event::fake([MemoryForgotten::class]);
+
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    // No-op probe — no row at the address.
+    $store->forget(MemoryScope::Swarm, 'SwarmB', 'never-was');
+
+    // Real deletion — insert, then delete.
+    $store->put(new MemoryEntry(MemoryScope::Swarm, 'SwarmB', 'real', 'v'));
+    $store->forget(MemoryScope::Swarm, 'SwarmB', 'real');
+
+    Event::assertDispatchedTimes(MemoryForgotten::class, 2);
+    Event::assertDispatched(
+        MemoryForgotten::class,
+        fn (MemoryForgotten $e): bool => $e->key === 'never-was' && $e->existed === false,
+    );
+    Event::assertDispatched(
+        MemoryForgotten::class,
+        fn (MemoryForgotten $e): bool => $e->key === 'real' && $e->existed === true,
+    );
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `MemoryForgotten` currently fires on every `forget()` regardless of whether an entry actually existed at the address. Compliance listeners answering "show me every Run-scoped deletion in Q3" get a noisy stream that mixes real deletions with no-op probes, because the dispatch contract intentionally fires both. Audit pipelines have to reach into the store themselves to filter, which defeats the point of a lifecycle event.
- This PR adds `public readonly bool $existed` to the event. `existed === true` means a row was actually removed; `existed === false` means the `forget()` call was a no-op probe. Both bundled stores already compute this value internally (`CacheMemoryStore` via `has()` before the delete, `DatabaseMemoryStore` via the `delete()` row count) — the PR just plumbs it through to the event constructor and documents the contract on the class docblock. Audit-trail listeners can now filter by `$existed === true`; monitoring listeners (e.g. security probing detection) can still observe both states.
- Contract note: this adds a required constructor parameter to a v0.9.0 event class. `MemoryForgotten` was introduced in #135 (merged) but no v0.9.0 tag has shipped yet, so the event has zero downstream consumers and the change is safe within the v0.9.0 release window. Addresses finding F11 from the multi-expert review.

## Test plan

- [x] `composer test` — 1025 tests pass (added 2 regression tests, one per store, asserting `existed === false` on no-op probes and `existed === true` after a real put → forget).
- [x] `composer lint` — pint passes.
- [x] `composer analyse` — phpstan: no errors.
- [x] Existing `cache store dispatches MemoryForgotten on forget whether or not the entry existed` and `database store dispatches MemoryForgotten on forget whether row existed or not` tests updated to assert both `existed` states.