### PR TITLE
chore(memory): publish memory_snapshots table config + env hygiene

### DIFF
--- a/config/swarm.php
+++ b/config/swarm.php
@@ -331,6 +331,12 @@ return [
 
     // These table names are honored by the database repositories at runtime.
     // If you change them, publish and update the package migrations as well.
+    //
+    // Table-name overrides are configuration-only: the SWARM_*_TABLE env vars
+    // below are not seeded into .env by swarm:install. Operators who need to
+    // rename a Swarm table (e.g. multi-tenant schemas) declare the env var in
+    // .env themselves, or override the value directly in config/swarm.php
+    // after publishing.
     'tables' => [
         'contexts' => env('SWARM_CONTEXTS_TABLE', 'swarm_contexts'),
         'artifacts' => env('SWARM_ARTIFACTS_TABLE', 'swarm_artifacts'),
@@ -352,5 +358,6 @@ return [
         'durable_outbox' => env('SWARM_DURABLE_OUTBOX_TABLE', 'swarm_durable_outbox'),
         'audit_outbox' => env('SWARM_AUDIT_OUTBOX_TABLE', 'swarm_audit_outbox'),
         'memories' => env('SWARM_MEMORIES_TABLE', 'swarm_memories'),
+        'memory_snapshots' => env('SWARM_MEMORY_SNAPSHOTS_TABLE', 'swarm_memory_snapshots'),
     ],
 ];

--- a/tests/Unit/Config/SwarmConfigTest.php
+++ b/tests/Unit/Config/SwarmConfigTest.php
@@ -51,3 +51,28 @@ test('encrypt at rest defaults on when a per store database driver override is c
 
     expect($config['persistence']['encrypt_at_rest'])->toBeTrue();
 });
+
+test('memory_snapshots table key is published with the canonical default', function () {
+    $config = withEnvironment([
+        'SWARM_MEMORY_SNAPSHOTS_TABLE' => null,
+    ], fn (): array => require __DIR__.'/../../../config/swarm.php');
+
+    expect($config['tables'])->toHaveKey('memory_snapshots')
+        ->and($config['tables']['memory_snapshots'])->toBe('swarm_memory_snapshots');
+});
+
+test('memory_snapshots table name honors SWARM_MEMORY_SNAPSHOTS_TABLE override', function () {
+    $config = withEnvironment([
+        'SWARM_MEMORY_SNAPSHOTS_TABLE' => 'tenant42_swarm_memory_snapshots',
+    ], fn (): array => require __DIR__.'/../../../config/swarm.php');
+
+    expect($config['tables']['memory_snapshots'])->toBe('tenant42_swarm_memory_snapshots');
+});
+
+test('memories table name honors SWARM_MEMORIES_TABLE override', function () {
+    $config = withEnvironment([
+        'SWARM_MEMORIES_TABLE' => 'tenant42_swarm_memories',
+    ], fn (): array => require __DIR__.'/../../../config/swarm.php');
+
+    expect($config['tables']['memories'])->toBe('tenant42_swarm_memories');
+});


### PR DESCRIPTION
## Summary

- **F4 (config asymmetry)** — `config/swarm.php`'s `tables` array now publishes a `memory_snapshots` key (default `swarm_memory_snapshots`, override via `SWARM_MEMORY_SNAPSHOTS_TABLE`). The `DatabaseMemorySnapshotRecorder` already reads `swarm.tables.memory_snapshots`; this closes the gap so the snapshots table sits beside `memories` in the same place every other Swarm table is declared.
- **F9 decision: config-only, no installer seed.** I audited the installer's canonical `.env` block (`InstallCommand::ENV_DEFAULTS`) and confirmed that **none** of the existing `SWARM_*_TABLE` env vars (`SWARM_CONTEXTS_TABLE`, `SWARM_RUN_HISTORIES_TABLE`, the 18 `SWARM_DURABLE_*_TABLE` keys, `SWARM_AUDIT_OUTBOX_TABLE`, `SWARM_MEMORIES_TABLE`, etc.) are seeded. Consistency wins — table-name overrides remain a niche multi-tenant escape hatch declared in `.env` by the operator. Instead of seeding the two new keys, I documented the contract directly in `config/swarm.php` above the `tables` array so operators reading the published config know where to declare overrides without grepping for a non-existent env entry.
- **Tests** — added three coverage cases in `tests/Unit/Config/SwarmConfigTest.php`: the `memory_snapshots` key is present with the canonical default, the `SWARM_MEMORY_SNAPSHOTS_TABLE` env var rewrites it, and `SWARM_MEMORIES_TABLE` likewise rewrites the `memories` entry (the latter had no prior config-level test).

## Test plan

- [x] `composer test` — 1026 passed (4084 assertions)
- [x] `composer lint` — pint passed
- [x] `composer analyse` — PHPStan no errors

## Notes

- `src/Memory/DatabaseMemorySnapshotRecorder.php` is not yet on `release/v0.9.0` (it lands via the snapshot-recorder branch). Once that branch merges, the new `swarm.tables.memory_snapshots` key in `config/swarm.php` will be the one and only declaration the recorder reads.
- No changes to the installer or installer tests. The `SWARM_MEMORIES_TABLE` + `SWARM_MEMORY_SNAPSHOTS_TABLE` env vars are config-only by design — see the new comment in `config/swarm.php`.