### PR TITLE
feat(memory): add run_id FK to swarm_memories for Run-scope cascade

### DIFF
--- a/database/migrations/2026_05_21_000003_add_run_id_to_swarm_memories_table.php
+++ b/database/migrations/2026_05_21_000003_add_run_id_to_swarm_memories_table.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Add a dedicated, nullable `run_id` column to `swarm_memories` with a
+ * foreign-key cascade to `swarm_run_histories.run_id`.
+ *
+ * Rationale: the original `swarm_memories` schema deliberately omitted any FK
+ * because `scope_id` is polymorphic across four scopes — Run, Conversation,
+ * Agent, Swarm — and only the Run-scoped subset is a referential candidate.
+ * That left a gap for regulated workloads: when a `swarm_run_histories` row is
+ * deleted (e.g. "delete me and my data" GDPR/CCPA request), Run-scoped memory
+ * rows persisted until the v0.10 `swarm:memory:purge` retention command swept
+ * them up. The window between history delete and purge run is non-zero and
+ * operationally awkward for compliance.
+ *
+ * Fix: keep `scope_id` polymorphic (it still holds the conversation id, agent
+ * class, or swarm class for the non-Run scopes), but add a dedicated, nullable
+ * `run_id` column that ONLY Run-scoped rows populate. The FK on that column
+ * cascades on delete so DB-level guarantees match the application-level
+ * intent: when a run history dies, its Run-scoped memories die with it.
+ *
+ * Mirrors the cascade pattern established by
+ * `2026_05_04_000001_add_run_id_foreign_keys_to_swarm_tables.php` for the
+ * history family (contexts, artifacts, run_steps, stream_events).
+ *
+ * Non-Run scopes leave `run_id` NULL; the FK does not constrain them.
+ *
+ * Applications publishing migrations under custom table names must mirror the
+ * equivalent column + FK in their published copy.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('swarm_memories', function (Blueprint $table): void {
+            $table->string('run_id')->nullable()->after('scope_id');
+
+            $table->index('run_id', 'swarm_memories_run_id_index');
+
+            $table->foreign('run_id')
+                ->references('run_id')->on('swarm_run_histories')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('swarm_memories', function (Blueprint $table): void {
+            $table->dropForeign(['run_id']);
+            $table->dropIndex('swarm_memories_run_id_index');
+            $table->dropColumn('run_id');
+        });
+    }
+};

--- a/src/Memory/DatabaseMemoryStore.php
+++ b/src/Memory/DatabaseMemoryStore.php
@@ -28,6 +28,18 @@ use Illuminate\Database\Query\Builder;
  * constraint on the tuple. `value` and `metadata` are JSON columns to support
  * arbitrary plain-data shapes.
  *
+ * Run-scope cascade denormalization:
+ *
+ * The `run_id` column is a denormalization of `scope_id` for Run-scoped rows
+ * only. It exists solely to carry a foreign-key cascade to
+ * `swarm_run_histories.run_id`, giving regulated workloads a DB-level
+ * guarantee that Run-scoped memories die synchronously with their parent
+ * history row (no waiting on the v0.10 retention purge). Non-Run scopes leave
+ * `run_id` NULL — `scope_id` remains polymorphic and is the authoritative
+ * identity carrier for every scope. The column is not part of
+ * {@see MemoryEntry}'s identity and is intentionally ignored by
+ * {@see DatabaseMemoryStore::hydrate()}.
+ *
  * @internal
  */
 final class DatabaseMemoryStore implements MemoryStore
@@ -57,6 +69,7 @@ final class DatabaseMemoryStore implements MemoryStore
             [[
                 'scope' => $entry->scope->value,
                 'scope_id' => $entry->scopeId,
+                'run_id' => $entry->scope === MemoryScope::Run ? $entry->scopeId : null,
                 'key' => $entry->key,
                 'value' => $this->encodeJson($entry->value),
                 'metadata' => $this->encodeJson($entry->metadata),
@@ -64,7 +77,7 @@ final class DatabaseMemoryStore implements MemoryStore
                 'updated_at' => $now,
             ]],
             ['scope', 'scope_id', 'key'],
-            ['value', 'metadata', 'updated_at'],
+            ['value', 'metadata', 'run_id', 'updated_at'],
         );
 
         $persisted = $entry->withTimestamps($createdAt, $now);

--- a/tests/Feature/Memory/DatabaseMemoryStoreTest.php
+++ b/tests/Feature/Memory/DatabaseMemoryStoreTest.php
@@ -18,6 +18,28 @@ use Illuminate\Support\Facades\DB;
  */
 beforeEach(function () {
     config()->set('swarm.persistence.driver', 'database');
+
+    // Run-scoped memory rows FK into swarm_run_histories.run_id via the
+    // 2026_05_21_000003 migration. Seed the run ids these tests put against
+    // so the FK insert succeeds. Conversation/Agent/Swarm scopes are FK-free.
+    $now = now('UTC');
+    foreach (['run-1', 'run-2', 'run-A', 'run-B', 'shared-id'] as $runId) {
+        DB::table('swarm_run_histories')->insert([
+            'run_id' => $runId,
+            'swarm_class' => 'ExampleSwarm',
+            'topology' => 'sequential',
+            'status' => 'running',
+            'context' => json_encode([]),
+            'metadata' => json_encode([]),
+            'steps' => json_encode([]),
+            'output' => null,
+            'usage' => json_encode([]),
+            'error' => null,
+            'artifacts' => json_encode([]),
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+    }
 });
 
 test('the database store is bound as the default MemoryStore when persistence is database', function () {
@@ -202,4 +224,55 @@ test('metadata defaults to an empty array when not provided', function () {
 
     $fetched = $store->get(MemoryScope::Run, 'run-1', 'k');
     expect($fetched?->metadata)->toBe([]);
+});
+
+// ---------------------------------------------------------------------------
+// run_id denormalization — Run-scoped puts populate the FK column; other
+// scopes leave it null. The column itself is not part of MemoryEntry identity
+// and is only used for the FK cascade to swarm_run_histories.
+// ---------------------------------------------------------------------------
+
+test('Run-scoped put populates the run_id column with the scope_id value', function () {
+    // Need a parent history row so the FK insert succeeds.
+    DB::table('swarm_run_histories')->insert([
+        'run_id' => 'run-with-fk',
+        'swarm_class' => 'ExampleSwarm',
+        'topology' => 'sequential',
+        'status' => 'running',
+        'context' => json_encode([]),
+        'metadata' => json_encode([]),
+        'steps' => json_encode([]),
+        'output' => null,
+        'usage' => json_encode([]),
+        'error' => null,
+        'artifacts' => json_encode([]),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $store->put(new MemoryEntry(MemoryScope::Run, 'run-with-fk', 'k', 'v'));
+
+    $row = DB::table('swarm_memories')->where('scope', 'run')->where('scope_id', 'run-with-fk')->first();
+    expect($row)->not->toBeNull()
+        ->and($row->run_id)->toBe('run-with-fk');
+});
+
+test('non-Run-scoped puts leave run_id null', function () {
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $store->put(new MemoryEntry(MemoryScope::Conversation, 'convo-1', 'k', 'v'));
+    $store->put(new MemoryEntry(MemoryScope::Agent, 'App\\Agents\\Foo', 'k', 'v'));
+    $store->put(new MemoryEntry(MemoryScope::Swarm, 'App\\Swarms\\Bar', 'k', 'v'));
+
+    $conversation = DB::table('swarm_memories')->where('scope', 'conversation')->first();
+    $agent = DB::table('swarm_memories')->where('scope', 'agent')->first();
+    $swarm = DB::table('swarm_memories')->where('scope', 'swarm')->first();
+
+    expect($conversation->run_id)->toBeNull()
+        ->and($agent->run_id)->toBeNull()
+        ->and($swarm->run_id)->toBeNull();
 });

--- a/tests/Feature/Memory/MemoriesSchemaTest.php
+++ b/tests/Feature/Memory/MemoriesSchemaTest.php
@@ -39,9 +39,9 @@ test('the swarm_memories table exists with the expected columns', function () {
 });
 
 test('migration up/down is idempotent', function () {
-    // Top of the stack — rolling back step=1 removes the memories table
-    // (and only the memories table; #110's snapshots migration is below us).
-    Artisan::call('migrate:rollback', ['--database' => 'testing', '--step' => 1]);
+    // Stack from the top: (1) memories.run_id FK column (review follow-up),
+    // (2) memories table itself. Step=2 drops the run_id FK then the table.
+    Artisan::call('migrate:rollback', ['--database' => 'testing', '--step' => 2]);
     expect(Schema::hasTable('swarm_memories'))->toBeFalse();
 
     // And re-running migrate brings it back cleanly.

--- a/tests/Feature/Memory/MemoryEventsTest.php
+++ b/tests/Feature/Memory/MemoryEventsTest.php
@@ -13,6 +13,7 @@ use BuiltByBerry\LaravelSwarm\Memory\DatabaseMemoryStore;
 use BuiltByBerry\LaravelSwarm\Memory\MemoryEntry;
 use Illuminate\Contracts\Cache\Factory;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
 
@@ -140,6 +141,11 @@ function makeSwarmMemoriesTable(): void
         $table->id();
         $table->string('scope');
         $table->string('scope_id');
+        // run_id mirrors the production schema added by
+        // 2026_05_21_000003_add_run_id_to_swarm_memories_table. No FK here —
+        // these synthetic tests don't exercise the cascade; that's covered by
+        // MemoryRunIdCascadeTest against the real migration stack.
+        $table->string('run_id')->nullable();
         $table->string('key');
         $table->json('value')->nullable();
         $table->json('metadata')->nullable();
@@ -147,6 +153,32 @@ function makeSwarmMemoriesTable(): void
         $table->timestamp('updated_at')->useCurrent();
         $table->unique(['scope', 'scope_id', 'key']);
     });
+}
+
+function seedSwarmRunHistory(string $runId): void
+{
+    // Seed a parent swarm_run_histories row so Run-scoped memory puts pass the
+    // run_id FK added by 2026_05_21_000003. Only required when the real
+    // (migrated) memories table is in play.
+    if (DB::table('swarm_run_histories')->where('run_id', $runId)->exists()) {
+        return;
+    }
+
+    DB::table('swarm_run_histories')->insert([
+        'run_id' => $runId,
+        'swarm_class' => 'ExampleSwarm',
+        'topology' => 'sequential',
+        'status' => 'running',
+        'context' => json_encode([]),
+        'metadata' => json_encode([]),
+        'steps' => json_encode([]),
+        'output' => null,
+        'usage' => json_encode([]),
+        'error' => null,
+        'artifacts' => json_encode([]),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
 }
 
 test('database store dispatches MemoryWritten on put with metadata payload', function () {
@@ -176,6 +208,7 @@ test('database store dispatches MemoryWritten on put with metadata payload', fun
 test('database store dispatches MemoryRead on get whether the row exists or not', function () {
     config()->set('swarm.persistence.driver', 'database');
     makeSwarmMemoriesTable();
+    seedSwarmRunHistory('r1');
 
     Event::fake([MemoryRead::class]);
 

--- a/tests/Feature/Memory/MemoryRunIdCascadeTest.php
+++ b/tests/Feature/Memory/MemoryRunIdCascadeTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Contracts\MemoryStore;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Memory\MemoryEntry;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Verifies the run_id FK cascade on swarm_memories added by
+ * 2026_05_21_000003_add_run_id_to_swarm_memories_table.
+ *
+ * Run-scoped memory rows carry a denormalized run_id that FKs into
+ * swarm_run_histories with ON DELETE CASCADE. Deleting a history row must
+ * synchronously remove its Run-scoped memories (the GDPR/CCPA "delete me and
+ * my data" path) without waiting on the retention purge. Non-Run-scoped rows
+ * leave run_id NULL and survive the parent delete.
+ *
+ * SQLite with foreign_key_constraints=true (configured in TestCase) enforces
+ * PRAGMA foreign_keys=ON so all FK assertions work against the in-memory DB.
+ */
+beforeEach(function () {
+    Artisan::call('migrate:fresh', ['--database' => 'testing']);
+    config()->set('swarm.persistence.driver', 'database');
+});
+
+function insertMemoryParentHistoryRow(string $runId): void
+{
+    $now = Carbon::now('UTC');
+
+    DB::table('swarm_run_histories')->insert([
+        'run_id' => $runId,
+        'swarm_class' => 'ExampleSwarm',
+        'topology' => 'sequential',
+        'status' => 'running',
+        'context' => json_encode([]),
+        'metadata' => json_encode([]),
+        'steps' => json_encode([]),
+        'output' => null,
+        'usage' => json_encode([]),
+        'error' => null,
+        'artifacts' => json_encode([]),
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+}
+
+test('deleting a swarm_run_histories row cascades to its Run-scoped memory rows', function () {
+    $runId = 'cascade-mem-run';
+    insertMemoryParentHistoryRow($runId);
+
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $store->put(new MemoryEntry(MemoryScope::Run, $runId, 'last_output', 'agent said hello'));
+
+    expect(DB::table('swarm_memories')->where('scope', 'run')->where('scope_id', $runId)->exists())->toBeTrue();
+
+    DB::table('swarm_run_histories')->where('run_id', $runId)->delete();
+
+    expect(DB::table('swarm_memories')->where('scope', 'run')->where('scope_id', $runId)->exists())->toBeFalse();
+});
+
+test('non-Run-scoped rows survive parent history delete when scope_id happens to match a run_id', function () {
+    // Same string is used as a Run scope_id (FK-bound) and a Conversation
+    // scope_id (FK-free). Only the Run row should cascade-delete; the
+    // Conversation row's scope_id collision is incidental and irrelevant.
+    $runId = 'shared-id-cascade';
+    insertMemoryParentHistoryRow($runId);
+
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $store->put(new MemoryEntry(MemoryScope::Run, $runId, 'k', 'run-value'));
+    $store->put(new MemoryEntry(MemoryScope::Conversation, $runId, 'k', 'convo-value'));
+
+    expect(DB::table('swarm_memories')->count())->toBe(2);
+
+    DB::table('swarm_run_histories')->where('run_id', $runId)->delete();
+
+    // Run-scoped row is gone via FK cascade.
+    expect(DB::table('swarm_memories')->where('scope', 'run')->exists())->toBeFalse();
+
+    // Conversation-scoped row survives — its run_id is null, no cascade applies.
+    $survivor = DB::table('swarm_memories')->where('scope', 'conversation')->first();
+    expect($survivor)->not->toBeNull()
+        ->and($survivor->run_id)->toBeNull()
+        ->and($survivor->scope_id)->toBe($runId);
+});
+
+test('Agent- and Swarm-scoped rows are unaffected by history deletes', function () {
+    $runId = 'history-going-away';
+    insertMemoryParentHistoryRow($runId);
+
+    /** @var MemoryStore $store */
+    $store = $this->app->make(MemoryStore::class);
+
+    $store->put(new MemoryEntry(MemoryScope::Run, $runId, 'k', 'run-value'));
+    $store->put(new MemoryEntry(MemoryScope::Agent, 'App\\Agents\\Foo', 'k', 'agent-value'));
+    $store->put(new MemoryEntry(MemoryScope::Swarm, 'App\\Swarms\\Bar', 'k', 'swarm-value'));
+
+    DB::table('swarm_run_histories')->where('run_id', $runId)->delete();
+
+    expect(DB::table('swarm_memories')->where('scope', 'run')->exists())->toBeFalse()
+        ->and(DB::table('swarm_memories')->where('scope', 'agent')->exists())->toBeTrue()
+        ->and(DB::table('swarm_memories')->where('scope', 'swarm')->exists())->toBeTrue();
+});

--- a/tests/Feature/Memory/MemorySnapshotsSchemaTest.php
+++ b/tests/Feature/Memory/MemorySnapshotsSchemaTest.php
@@ -59,10 +59,11 @@ test('the swarm_memory_snapshots table exists with the expected columns', functi
 });
 
 test('migration rolls back cleanly', function () {
-    // The snapshots migration sits one below the memories migration added by
-    // #109, so rolling back the top two steps removes both. We only assert the
-    // snapshots table here; the memories migration owns its own rollback test.
-    Artisan::call('migrate:rollback', ['--database' => 'testing', '--step' => 2]);
+    // Stack from the top: (1) memories.run_id FK column (review follow-up),
+    // (2) memories table itself, (3) memory_snapshots table. Rolling back the
+    // top three steps removes all three. We only assert the snapshots table
+    // here; the memories migration owns its own rollback test.
+    Artisan::call('migrate:rollback', ['--database' => 'testing', '--step' => 3]);
 
     expect(Schema::hasTable('swarm_memory_snapshots'))->toBeFalse();
 });

--- a/tests/Feature/RunIdForeignKeysTest.php
+++ b/tests/Feature/RunIdForeignKeysTest.php
@@ -27,7 +27,8 @@ test('run_id FK migration adds all expected foreign key constraints', function (
     expect(Schema::hasTable('swarm_contexts'))->toBeTrue()
         ->and(Schema::hasTable('swarm_artifacts'))->toBeTrue()
         ->and(Schema::hasTable('swarm_run_steps'))->toBeTrue()
-        ->and(Schema::hasTable('swarm_stream_events'))->toBeTrue();
+        ->and(Schema::hasTable('swarm_stream_events'))->toBeTrue()
+        ->and(Schema::hasTable('swarm_memories'))->toBeTrue();
 
     // Durable family
     expect(Schema::hasTable('swarm_durable_branches'))->toBeTrue()
@@ -44,11 +45,13 @@ test('run_id FK migration adds all expected foreign key constraints', function (
 });
 
 test('FK migration rolls back cleanly', function () {
-    // Step 6 rolls back: memories (v0.9), memory-snapshots (v0.9), audit-outbox,
-    // durable-outbox-indexes, durable-outbox-table, and the FK migration itself.
-    // The FK migration is the sixth-most-recent now that v0.9 added both memory
-    // tables on top of the v0.5 audit + durable outbox stack.
-    Artisan::call('migrate:rollback', ['--database' => 'testing', '--step' => 6]);
+    // Step 7 rolls back, top of stack first: memories.run_id FK column
+    // (v0.9 review follow-up), memories (v0.9), memory-snapshots (v0.9),
+    // audit-outbox, durable-outbox-indexes, durable-outbox-table, and the FK
+    // migration itself. The FK migration is the seventh-most-recent now that
+    // v0.9 added the memory tables (and run_id FK column) on top of the v0.5
+    // audit + durable outbox stack.
+    Artisan::call('migrate:rollback', ['--database' => 'testing', '--step' => 7]);
 
     // Tables still exist; FK constraints are just removed. Insert into a child
     // table without a parent row — should succeed now that FKs are dropped.


### PR DESCRIPTION
## Summary

- Adds a dedicated, nullable `run_id` column to `swarm_memories` with a foreign key cascade to `swarm_run_histories.run_id`. Run-scoped memory rows now die synchronously with their parent history row — no waiting on the v0.10 retention purge.
- `DatabaseMemoryStore::put()` populates `run_id` only when `scope === MemoryScope::Run`; Conversation/Agent/Swarm scopes leave it NULL. `hydrate()` ignores the column — it is a denormalization, not part of `MemoryEntry` identity.
- New `MemoryRunIdCascadeTest` covers cascade-on-delete plus scope isolation (a Conversation row whose `scope_id` happens to match a `run_id` survives; only the Run-scoped row cascades). Four existing schema tests have their rollback step counts bumped.

## Design decision: dedicated `run_id` column, not an FK on `scope_id`

The original v0.9.0 schema deliberately omitted any FK on `swarm_memories` because `scope_id` is polymorphic across four scopes: for `MemoryScope::Run` it holds a `swarm_run_histories.run_id`, but for `Conversation` it holds an opaque conversation id, for `Agent` a fully-qualified agent class string, and for `Swarm` a fully-qualified swarm class string. Only the Run-scoped subset is a referential candidate; the rest are not rows in any swarm table. Conditional foreign keys are not portable across MySQL/Postgres/SQLite, and splitting the table by scope to enable a per-scope FK fragments the propagation read path (the hottest query).

The trade-off accepted was that Run-scoped entries were not cascade-deleted when their parent `swarm_run_histories` row was purged — the v0.10 `swarm:memory:purge` retention command reaps them via `created_at`. The v0.9.0 multi-expert review flagged this as inadequate for regulated workloads where "delete me and my data" must be synchronous.

This PR resolves that by adding a **dedicated, nullable `run_id` column** that *only* Run-scoped rows populate, with `scope_id` remaining the authoritative identity carrier for every scope. The FK lives on the denormalized column, gives DB-level cascade guarantees for Run-scope, and leaves the polymorphic invariant untouched. Mirrors the cascade pattern established by `2026_05_04_000001_add_run_id_foreign_keys_to_swarm_tables.php` for the history family (contexts, artifacts, run_steps, stream_events).

## Test plan

- [x] `composer test` — 1028 passed (4096 assertions)
- [x] `composer lint` — pint passed
- [x] `composer analyse` — phpstan OK
- [x] New `MemoryRunIdCascadeTest` asserts FK cascade on Run-scoped rows and survival of Conversation/Agent/Swarm scopes through a parent history delete
- [x] New `DatabaseMemoryStoreTest` assertions verify Run-scoped puts populate `run_id` and non-Run puts leave it NULL
- [x] Rollback step counts bumped in `MemoriesSchemaTest`, `MemorySnapshotsSchemaTest`, and `RunIdForeignKeysTest`; `swarm_memories` added to the history-family assertion in `RunIdForeignKeysTest`