### PR TITLE
chore(memory): narrow recorder QueryException catch + add tests

### DIFF
--- a/src/Memory/DatabaseMemorySnapshotRecorder.php
+++ b/src/Memory/DatabaseMemorySnapshotRecorder.php
@@ -12,7 +12,8 @@ use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Builder;
-use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\Schema;
+use Psr\Log\LoggerInterface;
 
 /**
  * Default {@see SnapshotsMemory} implementation backed by the
@@ -36,24 +37,38 @@ final class DatabaseMemorySnapshotRecorder implements SnapshotsMemory
 {
     use InteractsWithJsonColumns;
 
+    /**
+     * Cached result of the one-time `swarm_memories` table precheck. `null`
+     * means "not yet probed"; the first {@see snapshot()} call resolves it
+     * via {@see Schema::hasTable()} and reuses the answer for the lifetime
+     * of the instance so we don't pay a `SHOW TABLES` round-trip on every
+     * agent invocation.
+     */
+    protected ?bool $memoryTableExists = null;
+
     public function __construct(
         protected Connection $connection,
         protected ConfigRepository $config,
         protected SwarmMemory $memory,
+        protected LoggerInterface $logger,
     ) {}
 
     public function snapshot(string $runId, int $stepIndex): MemorySnapshot
     {
-        // The companion `swarm_memories` table (issue #109) may not be
-        // migrated yet — for example during the 0.9.0 staged rollout where
-        // the entries-schema and snapshots-schema migrations land in
-        // separate PRs. Treat a missing memory table as "no Run-scoped
-        // entries" rather than failing every agent invocation; the snapshot
-        // row itself still persists so replay sees the empty view.
-        try {
-            $entries = $this->memory->all(MemoryScope::Run, $runId);
-        } catch (QueryException) {
+        // The companion `swarm_memories` table (issue #109) is required for
+        // the Run-scoped read below. We probe its existence exactly once per
+        // recorder instance via `Schema::hasTable()` and cache the result on
+        // `$memoryTableExists`. When the precheck fails we log and persist
+        // an empty entries list so the snapshot row itself still lands for
+        // replay. When the precheck succeeds we delegate straight to the
+        // memory facade and let any genuine `QueryException` (connection
+        // drop, permission revocation, schema corruption, deadlock, …)
+        // propagate — silently swallowing those would corrupt the audit
+        // trail without surfacing the failure to the operator.
+        if (! $this->ensureMemoryTableExists()) {
             $entries = [];
+        } else {
+            $entries = $this->memory->all(MemoryScope::Run, $runId);
         }
 
         $snapshot = MemorySnapshot::fromEntries($runId, $stepIndex, $entries, []);
@@ -124,5 +139,33 @@ final class DatabaseMemorySnapshotRecorder implements SnapshotsMemory
         return $this->connection->table(
             (string) $this->config->get('swarm.tables.memory_snapshots', 'swarm_memory_snapshots'),
         );
+    }
+
+    /**
+     * Probe the `swarm_memories` table once per recorder instance.
+     *
+     * Returns `true` when the table is present and the recorder can safely
+     * read Run-scoped entries from the memory facade. Returns `false` when
+     * the table is absent, in which case the snapshot persists with an
+     * empty entries list and an info-level log line is emitted so operators
+     * can spot misconfigured environments.
+     */
+    protected function ensureMemoryTableExists(): bool
+    {
+        if ($this->memoryTableExists !== null) {
+            return $this->memoryTableExists;
+        }
+
+        $table = (string) $this->config->get('swarm.tables.memories', 'swarm_memories');
+        $exists = Schema::connection($this->connection->getName())->hasTable($table);
+
+        if (! $exists) {
+            $this->logger->info(
+                'laravel-swarm: memory table missing; snapshot will persist with empty entries',
+                ['table' => $table, 'connection' => $this->connection->getName()],
+            );
+        }
+
+        return $this->memoryTableExists = $exists;
     }
 }

--- a/tests/Feature/Memory/MemorySnapshotTest.php
+++ b/tests/Feature/Memory/MemorySnapshotTest.php
@@ -11,9 +11,14 @@ use BuiltByBerry\LaravelSwarm\Memory\DefaultSwarmMemory;
 use BuiltByBerry\LaravelSwarm\Memory\MemoryEntry;
 use BuiltByBerry\LaravelSwarm\Memory\MemorySnapshot;
 use BuiltByBerry\LaravelSwarm\Tests\Support\InMemoryMemoryStore;
+use BuiltByBerry\LaravelSwarm\Tests\Support\ThrowingMemoryStore;
 use Illuminate\Database\Connection;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Psr\Log\LoggerInterface;
 
 beforeEach(function () {
     DB::table('swarm_run_histories')->insert([
@@ -41,6 +46,7 @@ beforeEach(function () {
             connection: $this->app->make(Connection::class),
             config: $this->app->make('config'),
             memory: $this->app->make(SwarmMemory::class),
+            logger: $this->app->make(LoggerInterface::class),
         );
     });
 });
@@ -212,4 +218,57 @@ test('snapshot payload stays within a reasonable byte budget for typical workloa
     $row = DB::table('swarm_memory_snapshots')->where('run_id', 'run-snap')->where('step_index', 0)->first();
     /** @var object $row */
     expect(strlen((string) $row->payload))->toBeLessThan(32 * 1024);
+});
+
+// ---------------------------------------------------------------------------
+// Hardened error handling — review F1 + F5
+// ---------------------------------------------------------------------------
+//
+// The recorder used to wrap the Run-scoped memory read in a bare
+// `catch (QueryException)` so the staged 0.9.0 rollout could land the
+// snapshots migration ahead of the entries migration without the recorder
+// failing every agent invocation. Both migrations now ship together, so the
+// catch is reshaped into a `Schema::hasTable()` precheck — missing table
+// degrades gracefully with a log line, but any *real* `QueryException`
+// (connection drop, permission revocation, deadlock, schema corruption)
+// must propagate so operators see the failure instead of getting a
+// silently-empty audit trail.
+
+test('snapshot returns empty entries and logs when swarm_memories table is missing', function () {
+    Schema::drop('swarm_memories');
+
+    Log::spy();
+
+    /** @var SnapshotsMemory $recorder */
+    $recorder = $this->app->make(SnapshotsMemory::class);
+    $snapshot = $recorder->snapshot('run-snap', 0);
+
+    expect($snapshot->entries)->toBe([]);
+
+    $row = DB::table('swarm_memory_snapshots')->where('run_id', 'run-snap')->where('step_index', 0)->first();
+    expect($row)->not->toBeNull();
+    /** @var object $row */
+    expect(json_decode((string) $row->payload, true)['entries'])->toBe([]);
+
+    Log::shouldHaveReceived('info')
+        ->withArgs(fn (string $message, array $context = []) => str_contains($message, 'memory table missing')
+            && ($context['table'] ?? null) === 'swarm_memories')
+        ->once();
+});
+
+test('snapshot propagates real QueryException from the memory store instead of swallowing it', function () {
+    // Re-bind the recorder against a memory store that throws QueryException
+    // from `all()`. We have to rebuild the recorder so it picks up the new
+    // store via DefaultSwarmMemory.
+    $this->app->instance(MemoryStore::class, new ThrowingMemoryStore);
+    $this->app->forgetInstance(SwarmMemory::class);
+    $this->app->forgetInstance(SnapshotsMemory::class);
+
+    /** @var SnapshotsMemory $recorder */
+    $recorder = $this->app->make(SnapshotsMemory::class);
+
+    expect(fn () => $recorder->snapshot('run-snap', 0))->toThrow(QueryException::class);
+
+    // The snapshot row must not have landed — propagation is the contract.
+    expect(DB::table('swarm_memory_snapshots')->where('run_id', 'run-snap')->count())->toBe(0);
 });

--- a/tests/Support/ThrowingMemoryStore.php
+++ b/tests/Support/ThrowingMemoryStore.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Tests\Support;
+
+use BuiltByBerry\LaravelSwarm\Contracts\MemoryStore;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Memory\MemoryEntry;
+use Illuminate\Database\QueryException;
+
+/**
+ * Test double that throws {@see QueryException} from {@see all()} so the
+ * snapshot recorder hardening tests can assert that real DB errors propagate
+ * up rather than being silently swallowed as empty entries (review F1+F5).
+ *
+ * The constructor accepts an optional pre-built `QueryException` so callers
+ * can control the wrapped driver error / SQL state when that matters; the
+ * default uses a plain "connection refused"-shaped message.
+ */
+final class ThrowingMemoryStore implements MemoryStore
+{
+    public function __construct(
+        private readonly QueryException $exception = new QueryException(
+            'testing',
+            'select * from "swarm_memories" where "scope" = ? and "scope_id" = ?',
+            ['run', 'run-snap'],
+            new \RuntimeException('SQLSTATE[HY000] [2002] Connection refused'),
+        ),
+    ) {}
+
+    public function put(MemoryEntry $entry): MemoryEntry
+    {
+        throw $this->exception;
+    }
+
+    public function get(MemoryScope $scope, string $scopeId, string $key): ?MemoryEntry
+    {
+        throw $this->exception;
+    }
+
+    public function forget(MemoryScope $scope, string $scopeId, string $key): bool
+    {
+        throw $this->exception;
+    }
+
+    public function all(MemoryScope $scope, string $scopeId): array
+    {
+        throw $this->exception;
+    }
+}


### PR DESCRIPTION
## Summary

- Replace the bare `catch (QueryException)` in `DatabaseMemorySnapshotRecorder::snapshot()` with a once-per-instance `Schema::hasTable('swarm_memories')` precheck; missing table degrades to empty entries with a logged warning, but any real `QueryException` (connection drop, permission revocation, deadlock, schema corruption) now propagates so operators see the failure instead of getting a silently-empty audit trail.
- Inject `Psr\Log\LoggerInterface` into the recorder constructor for the precheck log line; the container resolves it automatically through the service provider.
- Add two feature tests in `tests/Feature/Memory/MemorySnapshotTest.php`: the missing-table path (entries === [], log line emitted, snapshot row still persists) and the propagation path (`QueryException` thrown by a new `ThrowingMemoryStore` test double bubbles up, no snapshot row written).

## Review findings addressed

- **F1** — recorder's load-bearing `catch (QueryException)` was scoped only to the staged-rollout window; both companion migrations now ship together so the broad catch is too wide.
- **F5** — silently swallowing any DB error during the memory read corrupts the audit trail without surfacing the failure to operators.

## Dependency

This PR builds on `feat/0.9.0-memory-snapshot` (PR #137 — the snapshot recorder itself). The merge commit on this branch brings that work in as the base; once PR #137 lands on `release/v0.9.0`, the merge commit becomes a no-op and only the hardening commit remains in the diff.

## Test plan

- [x] `composer test` — 1037 passed (4137 assertions), +2 new tests in `MemorySnapshotTest`
- [x] `composer lint` — pint clean
- [x] `composer analyse` — phpstan clean
- [x] New `ThrowingMemoryStore` follows the test-double pattern from `tests/Support/InMemoryMemoryStore.php`