### PR TITLE
feat(memory): durable parallel branch replay reads from frozen snapshot

### DIFF
--- a/src/Contracts/SnapshotsMemory.php
+++ b/src/Contracts/SnapshotsMemory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Contracts;
 
+use BuiltByBerry\LaravelSwarm\Exceptions\SnapshotFrozenException;
 use BuiltByBerry\LaravelSwarm\Memory\MemorySnapshot;
 
 /**
@@ -48,13 +49,47 @@ interface SnapshotsMemory
      * Returns the updated snapshot with the new tool call included. Callers
      * should treat the original snapshot as stale after this call.
      *
+     * Implementations MUST throw
+     * {@see SnapshotFrozenException}
+     * when `$snapshot->frozen` is true. The frozen flag marks a snapshot as
+     * the canonical record of a completed step (loaded via {@see find()});
+     * silently allowing a write through that guard would corrupt the audit
+     * trail. Callers that legitimately need to rewrite tool calls (the
+     * durable mid-flight retry path) must call {@see resetToolCalls()} first
+     * so the reset is itself recorded as a deliberate action.
+     *
      * @param  array{name: string, arguments: array<string, mixed>, result: mixed, id?: string|null, result_id?: string|null}  $toolCall
      */
     public function appendToolCall(MemorySnapshot $snapshot, array $toolCall): MemorySnapshot;
 
     /**
+     * Clear the persisted `tool_calls` column for `(run_id, step_index)` and
+     * return an unfrozen snapshot the caller can append to.
+     *
+     * Exists for the durable mid-flight retry path: when a worker crashed
+     * after the snapshot was frozen but before the step completed, the row
+     * holds a partial tool-call record. The retry preserves the frozen
+     * memory view (determinism guarantee) but rebuilds tool calls from
+     * scratch — that rebuild starts here.
+     *
+     * Implementations MUST persist the empty `tool_calls` column eagerly so
+     * the reset is durable even if the retry worker also crashes before
+     * appending any new tool calls. The returned {@see MemorySnapshot} has
+     * `$frozen === false` so subsequent {@see appendToolCall()} calls
+     * succeed without tripping the canonical-record guard.
+     *
+     * Public on the contract — not private to the recorder — so v0.10
+     * operator tooling (CLI dump/inspect/purge) and future debugger
+     * surfaces can use it as a first-class reset primitive.
+     */
+    public function resetToolCalls(MemorySnapshot $snapshot): MemorySnapshot;
+
+    /**
      * Look up a previously persisted snapshot by its natural key. Returns
      * null when no snapshot was recorded for that step.
+     *
+     * The returned snapshot is `frozen` — implementations construct it via
+     * {@see MemorySnapshot::fromPersisted()} which defaults the flag to true.
      */
     public function find(string $runId, int $stepIndex): ?MemorySnapshot;
 }

--- a/src/Events/Memory/MemoryScopeOutOfSnapshot.php
+++ b/src/Events/Memory/MemoryScopeOutOfSnapshot.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Events\Memory;
+
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Memory\ReplaySwarmMemory;
+
+/**
+ * Fired when a replay-mode read targets a scope that the frozen snapshot does
+ * not cover (anything other than the snapshotted Run scope).
+ *
+ * The v0.9.0 snapshot captures only `MemoryScope::Run` entries — Conversation,
+ * Agent, and Swarm scope are read-through to the live store during replay.
+ * Those values may have drifted since the original invocation, which is a
+ * controlled determinism leak: pragmatic enough not to break working agents
+ * that read shared knowledge, but the audit trail needs to know it happened
+ * so compliance can decide whether that drift is acceptable for their workload.
+ *
+ * Dispatched by {@see ReplaySwarmMemory} on every cross-scope read or write
+ * attempt during replay. Listeners can flip it into a hard failure for
+ * stricter compliance postures by registering a subscriber that throws.
+ *
+ * No value payload is exposed — same redaction-safety stance as
+ * {@see MemoryRead}.
+ */
+final class MemoryScopeOutOfSnapshot
+{
+    public function __construct(
+        public readonly string $runId,
+        public readonly int $stepIndex,
+        public readonly MemoryScope $scope,
+        public readonly string $scopeId,
+        public readonly string $key,
+        public readonly string $operation,
+    ) {}
+}

--- a/src/Exceptions/ReplayDriftException.php
+++ b/src/Exceptions/ReplayDriftException.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Exceptions;
+
+/**
+ * Raised when durable replay of a completed step produces tool calls that
+ * diverge from the canonical snapshot record.
+ *
+ * Replay is the compliance-grade audit guarantee: the same step, replayed
+ * later, must produce the same observable behaviour. If it doesn't —
+ * different tools called, different arguments, different result ordering —
+ * the run is no longer audit-defensible and the operator needs to know
+ * immediately. Silent drift is the worst failure mode for regulated
+ * workloads, so this exception is hard-failure by design (matches the
+ * stance taken for the canonical-record guard in
+ * {@see SnapshotFrozenException}).
+ *
+ * The structured diff payload is preserved on the exception so listeners can
+ * forward it to audit sinks before the run aborts.
+ */
+class ReplayDriftException extends SwarmException
+{
+    /**
+     * @param  array<int, array<string, mixed>>  $recorded
+     * @param  array<int, array<string, mixed>>  $observed
+     */
+    public function __construct(
+        public readonly string $runId,
+        public readonly int $stepIndex,
+        public readonly array $recorded,
+        public readonly array $observed,
+        string $message = '',
+    ) {
+        parent::__construct(
+            $message !== '' ? $message : sprintf(
+                'Durable replay produced tool calls that diverge from the canonical '
+                .'snapshot for run [%s] step [%d]. Recorded %d call(s), observed %d.',
+                $runId,
+                $stepIndex,
+                count($recorded),
+                count($observed),
+            ),
+        );
+    }
+}

--- a/src/Exceptions/SnapshotFrozenException.php
+++ b/src/Exceptions/SnapshotFrozenException.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Exceptions;
+
+use BuiltByBerry\LaravelSwarm\Contracts\SnapshotsMemory;
+use BuiltByBerry\LaravelSwarm\Memory\MemorySnapshot;
+
+/**
+ * Raised when a caller attempts to mutate a {@see MemorySnapshot} that has
+ * been loaded as the canonical record of a completed step.
+ *
+ * Thrown from {@see SnapshotsMemory::appendToolCall()} when the supplied
+ * snapshot has `$frozen === true`. The canonical record is the audit-defensible
+ * source of truth for replay; silently allowing a write would corrupt that
+ * guarantee and is exactly the failure mode the v0.9.0 memory subsystem is
+ * designed to prevent.
+ *
+ * Callers that legitimately need to rewrite tool calls on a snapshot — the
+ * durable mid-flight retry path is the only one today — must first obtain an
+ * unfrozen copy via {@see SnapshotsMemory::resetToolCalls()}, which records
+ * the reset as a deliberate action rather than swallowing it.
+ */
+class SnapshotFrozenException extends SwarmException
+{
+    public static function forStep(string $runId, int $stepIndex): self
+    {
+        return new self(sprintf(
+            'Cannot mutate a frozen memory snapshot for run [%s] step [%d]. '
+            .'The snapshot is the canonical record of a completed step; '
+            .'call SnapshotsMemory::resetToolCalls() first if you need to '
+            .'rebuild tool calls on a mid-flight retry.',
+            $runId,
+            $stepIndex,
+        ));
+    }
+}

--- a/src/Memory/DatabaseMemorySnapshotRecorder.php
+++ b/src/Memory/DatabaseMemorySnapshotRecorder.php
@@ -7,6 +7,7 @@ namespace BuiltByBerry\LaravelSwarm\Memory;
 use BuiltByBerry\LaravelSwarm\Contracts\SnapshotsMemory;
 use BuiltByBerry\LaravelSwarm\Contracts\SwarmMemory;
 use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Exceptions\SnapshotFrozenException;
 use BuiltByBerry\LaravelSwarm\Persistence\Concerns\InteractsWithJsonColumns;
 use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
@@ -80,6 +81,10 @@ final class DatabaseMemorySnapshotRecorder implements SnapshotsMemory
 
     public function appendToolCall(MemorySnapshot $snapshot, array $toolCall): MemorySnapshot
     {
+        if ($snapshot->frozen) {
+            throw SnapshotFrozenException::forStep($snapshot->runId, $snapshot->stepIndex);
+        }
+
         $updated = $snapshot->withToolCall($toolCall);
 
         $this->table()
@@ -91,6 +96,22 @@ final class DatabaseMemorySnapshotRecorder implements SnapshotsMemory
             ]);
 
         return $updated;
+    }
+
+    public function resetToolCalls(MemorySnapshot $snapshot): MemorySnapshot
+    {
+        // The reset persists eagerly so an interrupted retry can't leak the
+        // previous attempt's partial tool-call record back into the canonical
+        // row on its next try.
+        $this->table()
+            ->where('run_id', $snapshot->runId)
+            ->where('step_index', $snapshot->stepIndex)
+            ->update([
+                'tool_calls' => $this->encodeJson([]),
+                'updated_at' => CarbonImmutable::now('UTC'),
+            ]);
+
+        return $snapshot->withClearedToolCalls();
     }
 
     public function find(string $runId, int $stepIndex): ?MemorySnapshot

--- a/src/Memory/MemorySnapshot.php
+++ b/src/Memory/MemorySnapshot.php
@@ -32,12 +32,26 @@ final readonly class MemorySnapshot
     /**
      * @param  array<int, array{scope: string, scope_id: string, key: string, value: mixed, metadata: array<string, mixed>, created_at: string|null, updated_at: string|null}>  $entries
      * @param  array<int, array{name: string, arguments: array<string, mixed>, result: mixed, id?: string|null, result_id?: string|null}>  $toolCalls
+     *
+     * `$frozen` records the canonical-replay invariant: true means the snapshot
+     * was loaded from persistence as the canonical record of a completed step
+     * and any attempt to mutate it (via
+     * {@see SnapshotsMemory::appendToolCall()}) must raise loudly. False means
+     * the snapshot is either freshly frozen for an in-flight invocation or
+     * being rebuilt during a mid-flight retry — both legitimate write paths.
+     *
+     * Constructors that produce fresh-snapshot instances (`fromEntries()`,
+     * implementations of {@see SnapshotsMemory::snapshot()}) leave `$frozen`
+     * false. The read-side hydrator (`fromPersisted()`) and any other
+     * read-only producer must opt in to `$frozen = true` so the contract
+     * layer can defend the canonical record from drift-time mutation.
      */
     public function __construct(
         public string $runId,
         public int $stepIndex,
         public array $entries,
         public array $toolCalls = [],
+        public bool $frozen = false,
     ) {}
 
     /**
@@ -80,6 +94,31 @@ final readonly class MemorySnapshot
             stepIndex: $this->stepIndex,
             entries: $this->entries,
             toolCalls: [...$this->toolCalls, $toolCall],
+            frozen: $this->frozen,
+        );
+    }
+
+    /**
+     * Return a copy of this snapshot with `toolCalls` reset to an empty list.
+     *
+     * Used by the mid-flight retry path in the durable runner: the original
+     * worker crashed after the snapshot was frozen but before the step
+     * completed, leaving a partial `tool_calls` record. The retry preserves
+     * the frozen memory view (determinism guarantee) but rebuilds tool calls
+     * from scratch.
+     *
+     * The returned snapshot is unfrozen so subsequent
+     * {@see SnapshotsMemory::appendToolCall()} calls succeed. Carries no
+     * other state change.
+     */
+    public function withClearedToolCalls(): self
+    {
+        return new self(
+            runId: $this->runId,
+            stepIndex: $this->stepIndex,
+            entries: $this->entries,
+            toolCalls: [],
+            frozen: false,
         );
     }
 
@@ -95,6 +134,7 @@ final readonly class MemorySnapshot
             stepIndex: $this->stepIndex,
             entries: $this->entries,
             toolCalls: array_values($toolCalls),
+            frozen: $this->frozen,
         );
     }
 
@@ -117,10 +157,15 @@ final readonly class MemorySnapshot
      * columns. The shape mirrors what {@see toPayloadArray()} and
      * {@see toolCalls} emit on persist.
      *
+     * `$frozen` defaults to true because the typical caller is the read-side
+     * `find()` path that loads a canonical record. Mid-flight retry callers
+     * explicitly pass `frozen: false` so they can rebuild tool calls without
+     * tripping the canonical-record guard.
+     *
      * @param  array<string, mixed>  $payload
      * @param  array<int, array<string, mixed>>  $toolCalls
      */
-    public static function fromPersisted(array $payload, array $toolCalls): self
+    public static function fromPersisted(array $payload, array $toolCalls, bool $frozen = true): self
     {
         /** @var array<int, array{scope: string, scope_id: string, key: string, value: mixed, metadata: array<string, mixed>, created_at: string|null, updated_at: string|null}> $entries */
         $entries = is_array($payload['entries'] ?? null) ? $payload['entries'] : [];
@@ -133,6 +178,7 @@ final readonly class MemorySnapshot
             stepIndex: (int) ($payload['step_index'] ?? 0),
             entries: $entries,
             toolCalls: $normalizedToolCalls,
+            frozen: $frozen,
         );
     }
 }

--- a/src/Memory/NullSnapshotsMemory.php
+++ b/src/Memory/NullSnapshotsMemory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BuiltByBerry\LaravelSwarm\Memory;
 
 use BuiltByBerry\LaravelSwarm\Contracts\SnapshotsMemory;
+use BuiltByBerry\LaravelSwarm\Exceptions\SnapshotFrozenException;
 
 /**
  * No-op {@see SnapshotsMemory} implementation used when persistence runs in
@@ -27,7 +28,16 @@ final class NullSnapshotsMemory implements SnapshotsMemory
 
     public function appendToolCall(MemorySnapshot $snapshot, array $toolCall): MemorySnapshot
     {
+        if ($snapshot->frozen) {
+            throw SnapshotFrozenException::forStep($snapshot->runId, $snapshot->stepIndex);
+        }
+
         return $snapshot->withToolCall($toolCall);
+    }
+
+    public function resetToolCalls(MemorySnapshot $snapshot): MemorySnapshot
+    {
+        return $snapshot->withClearedToolCalls();
     }
 
     public function find(string $runId, int $stepIndex): ?MemorySnapshot

--- a/src/Memory/ReplaySwarmMemory.php
+++ b/src/Memory/ReplaySwarmMemory.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Memory;
+
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmMemory;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Events\Memory\MemoryScopeOutOfSnapshot;
+use Carbon\CarbonImmutable;
+use Illuminate\Contracts\Events\Dispatcher;
+
+/**
+ * {@see SwarmMemory} decorator that serves the snapshot-backed memory view
+ * during durable replay.
+ *
+ * Resolves four behaviours by `(scope, scopeId)`:
+ *
+ * - **Run scope of the replayed run** — reads come from the frozen
+ *   {@see MemorySnapshot}; writes and forgets are buffered in-memory and
+ *   never touch the wrapped store. The buffer overlays the snapshot for
+ *   subsequent reads within the same invocation so an agent that writes-then-
+ *   reads-its-own-write sees the buffered value, matching live-store semantics.
+ * - **Any other scope** — reads and writes pass through to the wrapped
+ *   {@see SwarmMemory} live, with a {@see MemoryScopeOutOfSnapshot} event
+ *   dispatched per access so compliance audits can see where determinism
+ *   leaked. The snapshot only freezes Run-scope; treating cross-scope
+ *   accesses as drift would break agents that read shared Conversation /
+ *   Agent / Swarm state during replay.
+ *
+ * Bound onto `SwarmMemory::class` only for the duration of one agent
+ * invocation by the durable runner. Outside replay the regular
+ * {@see DefaultSwarmMemory} resolves.
+ *
+ * @internal
+ */
+final class ReplaySwarmMemory implements SwarmMemory
+{
+    /** @var array<string, MemoryEntry> Keyed by `{scope}:{scopeId}:{key}`. */
+    private array $writeBuffer = [];
+
+    /** @var array<string, true> Keyed by `{scope}:{scopeId}:{key}`. Tracks forgets. */
+    private array $forgetBuffer = [];
+
+    public function __construct(
+        private readonly SwarmMemory $live,
+        private readonly MemorySnapshot $snapshot,
+        private readonly Dispatcher $events,
+    ) {}
+
+    public function get(MemoryScope $scope, string $scopeId, string $key): mixed
+    {
+        return $this->entry($scope, $scopeId, $key)?->value;
+    }
+
+    public function entry(MemoryScope $scope, string $scopeId, string $key): ?MemoryEntry
+    {
+        if (! $this->isReplayedRunScope($scope, $scopeId)) {
+            $this->dispatchOutOfSnapshot($scope, $scopeId, $key, 'entry');
+
+            return $this->live->entry($scope, $scopeId, $key);
+        }
+
+        $bufferKey = $this->bufferKey($scope, $scopeId, $key);
+
+        if (array_key_exists($bufferKey, $this->forgetBuffer)) {
+            return null;
+        }
+
+        if (array_key_exists($bufferKey, $this->writeBuffer)) {
+            return $this->writeBuffer[$bufferKey];
+        }
+
+        foreach ($this->snapshot->entries as $row) {
+            if ($row['scope'] === $scope->value
+                && $row['scope_id'] === $scopeId
+                && $row['key'] === $key) {
+                return $this->hydrate($row);
+            }
+        }
+
+        return null;
+    }
+
+    public function put(
+        MemoryScope $scope,
+        string $scopeId,
+        string $key,
+        mixed $value,
+        array $metadata = [],
+    ): MemoryEntry {
+        if (! $this->isReplayedRunScope($scope, $scopeId)) {
+            $this->dispatchOutOfSnapshot($scope, $scopeId, $key, 'put');
+
+            return $this->live->put($scope, $scopeId, $key, $value, $metadata);
+        }
+
+        $bufferKey = $this->bufferKey($scope, $scopeId, $key);
+        unset($this->forgetBuffer[$bufferKey]);
+
+        $now = CarbonImmutable::now('UTC');
+        $existing = $this->writeBuffer[$bufferKey] ?? $this->snapshotEntry($scope, $scopeId, $key);
+        $createdAt = $existing !== null ? ($existing->createdAt ?? $now) : $now;
+
+        $entry = new MemoryEntry(
+            scope: $scope,
+            scopeId: $scopeId,
+            key: $key,
+            value: $value,
+            metadata: $metadata,
+            createdAt: $createdAt,
+            updatedAt: $now,
+        );
+
+        $this->writeBuffer[$bufferKey] = $entry;
+
+        return $entry;
+    }
+
+    public function forget(MemoryScope $scope, string $scopeId, string $key): bool
+    {
+        if (! $this->isReplayedRunScope($scope, $scopeId)) {
+            $this->dispatchOutOfSnapshot($scope, $scopeId, $key, 'forget');
+
+            return $this->live->forget($scope, $scopeId, $key);
+        }
+
+        $bufferKey = $this->bufferKey($scope, $scopeId, $key);
+        $existedInBuffer = array_key_exists($bufferKey, $this->writeBuffer);
+        $existedInSnapshot = $this->snapshotEntry($scope, $scopeId, $key) !== null;
+
+        unset($this->writeBuffer[$bufferKey]);
+        $this->forgetBuffer[$bufferKey] = true;
+
+        return $existedInBuffer || $existedInSnapshot;
+    }
+
+    public function all(MemoryScope $scope, string $scopeId): array
+    {
+        if (! $this->isReplayedRunScope($scope, $scopeId)) {
+            $this->dispatchOutOfSnapshot($scope, $scopeId, '*', 'all');
+
+            return $this->live->all($scope, $scopeId);
+        }
+
+        $entries = [];
+
+        foreach ($this->snapshot->entries as $row) {
+            if ($row['scope'] !== $scope->value || $row['scope_id'] !== $scopeId) {
+                continue;
+            }
+
+            $bufferKey = $this->bufferKey($scope, $scopeId, $row['key']);
+
+            if (array_key_exists($bufferKey, $this->forgetBuffer)) {
+                continue;
+            }
+
+            if (array_key_exists($bufferKey, $this->writeBuffer)) {
+                continue; // Surfaced from the buffer below to preserve write-after-read semantics.
+            }
+
+            $entries[] = $this->hydrate($row);
+        }
+
+        foreach ($this->writeBuffer as $bufferKey => $entry) {
+            if ($entry->scope !== $scope || $entry->scopeId !== $scopeId) {
+                continue;
+            }
+
+            if (array_key_exists($bufferKey, $this->forgetBuffer)) {
+                continue;
+            }
+
+            $entries[] = $entry;
+        }
+
+        return $entries;
+    }
+
+    private function isReplayedRunScope(MemoryScope $scope, string $scopeId): bool
+    {
+        return $scope === MemoryScope::Run && $scopeId === $this->snapshot->runId;
+    }
+
+    private function bufferKey(MemoryScope $scope, string $scopeId, string $key): string
+    {
+        return $scope->value.':'.$scopeId.':'.$key;
+    }
+
+    private function snapshotEntry(MemoryScope $scope, string $scopeId, string $key): ?MemoryEntry
+    {
+        foreach ($this->snapshot->entries as $row) {
+            if ($row['scope'] === $scope->value
+                && $row['scope_id'] === $scopeId
+                && $row['key'] === $key) {
+                return $this->hydrate($row);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array{scope: string, scope_id: string, key: string, value: mixed, metadata: array<string, mixed>, created_at: string|null, updated_at: string|null}  $row
+     */
+    private function hydrate(array $row): MemoryEntry
+    {
+        return new MemoryEntry(
+            scope: MemoryScope::from($row['scope']),
+            scopeId: $row['scope_id'],
+            key: $row['key'],
+            value: $row['value'],
+            metadata: $row['metadata'],
+            createdAt: $row['created_at'] !== null ? CarbonImmutable::parse($row['created_at']) : null,
+            updatedAt: $row['updated_at'] !== null ? CarbonImmutable::parse($row['updated_at']) : null,
+        );
+    }
+
+    private function dispatchOutOfSnapshot(MemoryScope $scope, string $scopeId, string $key, string $operation): void
+    {
+        $this->events->dispatch(new MemoryScopeOutOfSnapshot(
+            runId: $this->snapshot->runId,
+            stepIndex: $this->snapshot->stepIndex,
+            scope: $scope,
+            scopeId: $scopeId,
+            key: $key,
+            operation: $operation,
+        ));
+    }
+}

--- a/src/Runners/Durable/DurableBranchAdvancer.php
+++ b/src/Runners/Durable/DurableBranchAdvancer.php
@@ -11,12 +11,15 @@ use BuiltByBerry\LaravelSwarm\Contracts\DurableOutbox;
 use BuiltByBerry\LaravelSwarm\Contracts\DurableRunStore;
 use BuiltByBerry\LaravelSwarm\Contracts\SnapshotsMemory;
 use BuiltByBerry\LaravelSwarm\Contracts\Swarm;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmMemory;
 use BuiltByBerry\LaravelSwarm\Enums\DurableParallelFailurePolicy;
 use BuiltByBerry\LaravelSwarm\Enums\ExecutionMode;
 use BuiltByBerry\LaravelSwarm\Enums\Topology;
 use BuiltByBerry\LaravelSwarm\Exceptions\LostDurableLeaseException;
 use BuiltByBerry\LaravelSwarm\Exceptions\LostSwarmLeaseException;
 use BuiltByBerry\LaravelSwarm\Exceptions\SwarmException;
+use BuiltByBerry\LaravelSwarm\Memory\MemorySnapshot;
+use BuiltByBerry\LaravelSwarm\Memory\ReplaySwarmMemory;
 use BuiltByBerry\LaravelSwarm\Memory\SnapshotToolCallNormalizer;
 use BuiltByBerry\LaravelSwarm\Persistence\DatabaseRunHistoryStore;
 use BuiltByBerry\LaravelSwarm\Responses\SwarmStep;
@@ -93,9 +96,42 @@ class DurableBranchAdvancer
             throw new SwarmException("Unable to resolve durable swarm [{$run['swarm_class']}] from the container.");
         }
 
+        // Detect mid-flight retry: a snapshot row for this step exists, but
+        // the branch never completed (the advancer returns early on completed
+        // branches at the top of this method, so any find() hit here is a
+        // crashed prior attempt). The retry preserves the frozen memory view
+        // for determinism but rebuilds tool calls from scratch — the previous
+        // attempt's partial capture is no longer authoritative.
+        $existingSnapshot = $this->snapshots->find($runId, (int) $branch['step_index']);
+        $isReplay = $existingSnapshot !== null;
+
+        // Swap the SwarmMemory binding to a snapshot-backed view BEFORE the
+        // agent resolves so constructor-injected dependencies see the frozen
+        // memory. The original binding is captured for read-through on
+        // non-Run scopes (the snapshot only freezes Run scope) and restored
+        // in the finally block below.
+        $originalMemory = null;
+
+        if ($isReplay) {
+            /** @var SwarmMemory $originalMemory */
+            $originalMemory = $this->application->make(SwarmMemory::class);
+            $this->application->instance(
+                SwarmMemory::class,
+                new ReplaySwarmMemory(
+                    live: $originalMemory,
+                    snapshot: $existingSnapshot,
+                    events: $this->events,
+                ),
+            );
+        }
+
         $agent = $this->application->make($branch['agent_class']);
 
         if (! $agent instanceof Agent) {
+            if ($originalMemory !== null) {
+                $this->application->instance(SwarmMemory::class, $originalMemory);
+            }
+
             throw new SwarmException("Durable branch agent [{$branch['agent_class']}] must resolve to a Laravel AI agent.");
         }
 
@@ -125,7 +161,17 @@ class DurableBranchAdvancer
 
         try {
             $this->stepsRecorder->started($state, (int) $branch['step_index'], $branch['agent_class'], $branch['input']);
-            $snapshot = $this->snapshots->snapshot($runId, (int) $branch['step_index']);
+
+            // On the fresh-execution path we freeze a new snapshot from live
+            // memory. On the retry path the snapshot already exists; we keep
+            // its frozen entries (the determinism guarantee) but clear the
+            // partial tool-call record so this attempt can rebuild it. Both
+            // paths converge on an unfrozen MemorySnapshot we can append to.
+            /** @var MemorySnapshot $snapshot */
+            $snapshot = $isReplay
+                ? $this->snapshots->resetToolCalls($existingSnapshot)
+                : $this->snapshots->snapshot($runId, (int) $branch['step_index']);
+
             $response = $agent->prompt($branch['input']);
             $output = (string) $response;
             $usage = $response->usage->toArray();
@@ -207,6 +253,14 @@ class DurableBranchAdvancer
                         $this->terminal->failCurrentRunFromBranchFailures($freshRun, $freshToken, $context, $stepLeaseSeconds, $parentNodeId);
                     },
                 );
+            }
+        } finally {
+            // Restore the live SwarmMemory binding even if we returned from a
+            // catch block above. The replay decorator only ever covers one
+            // agent invocation; leaving it bound after the advancer exits
+            // would poison subsequent resolutions on this worker.
+            if ($originalMemory !== null) {
+                $this->application->instance(SwarmMemory::class, $originalMemory);
             }
         }
 

--- a/tests/Feature/Memory/MemorySnapshotTest.php
+++ b/tests/Feature/Memory/MemorySnapshotTest.php
@@ -6,6 +6,7 @@ use BuiltByBerry\LaravelSwarm\Contracts\MemoryStore;
 use BuiltByBerry\LaravelSwarm\Contracts\SnapshotsMemory;
 use BuiltByBerry\LaravelSwarm\Contracts\SwarmMemory;
 use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Exceptions\SnapshotFrozenException;
 use BuiltByBerry\LaravelSwarm\Memory\DatabaseMemorySnapshotRecorder;
 use BuiltByBerry\LaravelSwarm\Memory\DefaultSwarmMemory;
 use BuiltByBerry\LaravelSwarm\Memory\MemoryEntry;
@@ -188,6 +189,100 @@ test('snapshot persists with an empty entries list when no memory has been writt
     $row = DB::table('swarm_memory_snapshots')->where('run_id', 'run-snap')->where('step_index', 0)->first();
     /** @var object $row */
     expect(json_decode((string) $row->payload, true)['entries'])->toBe([]);
+});
+
+// ---------------------------------------------------------------------------
+// Replay-determinism contract: frozen flag + appendToolCall guard + reset
+// ---------------------------------------------------------------------------
+//
+// The canonical-record guard (`SnapshotFrozenException`) and the mid-flight
+// retry reset (`resetToolCalls`) are the load-bearing contract additions for
+// #112's replay-snapshot-determinism guarantee. See ReplaySwarmMemoryTest for
+// the decorator-side coverage.
+
+test('find returns a snapshot with frozen=true so the canonical-record guard fires', function () {
+    /** @var SnapshotsMemory $recorder */
+    $recorder = $this->app->make(SnapshotsMemory::class);
+    $recorder->snapshot('run-snap', 0);
+
+    $rehydrated = $recorder->find('run-snap', 0);
+
+    expect($rehydrated)->not->toBeNull();
+    /** @var MemorySnapshot $rehydrated */
+    expect($rehydrated->frozen)->toBeTrue();
+});
+
+test('snapshot returns a fresh snapshot with frozen=false so appends to the in-flight invocation succeed', function () {
+    /** @var SnapshotsMemory $recorder */
+    $recorder = $this->app->make(SnapshotsMemory::class);
+    $snapshot = $recorder->snapshot('run-snap', 0);
+
+    expect($snapshot->frozen)->toBeFalse();
+});
+
+test('appendToolCall throws SnapshotFrozenException when handed a snapshot loaded via find()', function () {
+    /** @var SnapshotsMemory $recorder */
+    $recorder = $this->app->make(SnapshotsMemory::class);
+    $recorder->snapshot('run-snap', 0);
+
+    /** @var MemorySnapshot $frozen */
+    $frozen = $recorder->find('run-snap', 0);
+
+    expect(fn () => $recorder->appendToolCall($frozen, [
+        'name' => 't',
+        'arguments' => [],
+        'result' => 'ok',
+    ]))->toThrow(SnapshotFrozenException::class);
+
+    // The canonical row must be untouched after the guard fires.
+    $row = DB::table('swarm_memory_snapshots')->where('run_id', 'run-snap')->where('step_index', 0)->first();
+    /** @var object $row */
+    expect(json_decode((string) $row->tool_calls, true))->toBe([]);
+});
+
+test('resetToolCalls clears the persisted tool_calls column and returns an unfrozen snapshot', function () {
+    /** @var SnapshotsMemory $recorder */
+    $recorder = $this->app->make(SnapshotsMemory::class);
+    $snapshot = $recorder->snapshot('run-snap', 0);
+    $recorder->appendToolCall($snapshot, ['name' => 'first', 'arguments' => [], 'result' => 'a']);
+    $recorder->appendToolCall($snapshot->withToolCall(['name' => 'first', 'arguments' => [], 'result' => 'a']), [
+        'name' => 'second', 'arguments' => [], 'result' => 'b',
+    ]);
+
+    /** @var MemorySnapshot $frozen */
+    $frozen = $recorder->find('run-snap', 0);
+    expect($frozen->toolCalls)->toHaveCount(2);
+
+    $cleared = $recorder->resetToolCalls($frozen);
+
+    expect($cleared->toolCalls)->toBe([]);
+    expect($cleared->frozen)->toBeFalse();
+
+    $row = DB::table('swarm_memory_snapshots')->where('run_id', 'run-snap')->where('step_index', 0)->first();
+    /** @var object $row */
+    expect(json_decode((string) $row->tool_calls, true))->toBe([]);
+});
+
+test('after resetToolCalls a subsequent appendToolCall on the returned snapshot succeeds and persists', function () {
+    /** @var SnapshotsMemory $recorder */
+    $recorder = $this->app->make(SnapshotsMemory::class);
+    $recorder->snapshot('run-snap', 0);
+
+    /** @var MemorySnapshot $frozen */
+    $frozen = $recorder->find('run-snap', 0);
+    $reset = $recorder->resetToolCalls($frozen);
+
+    $appended = $recorder->appendToolCall($reset, [
+        'name' => 'rebuilt-on-retry', 'arguments' => [], 'result' => 'ok',
+    ]);
+
+    expect($appended->toolCalls)->toHaveCount(1);
+
+    $row = DB::table('swarm_memory_snapshots')->where('run_id', 'run-snap')->where('step_index', 0)->first();
+    /** @var object $row */
+    $toolCalls = json_decode((string) $row->tool_calls, true);
+    expect($toolCalls)->toHaveCount(1);
+    expect($toolCalls[0]['name'])->toBe('rebuilt-on-retry');
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/Support/RecordingSnapshotsMemory.php
+++ b/tests/Support/RecordingSnapshotsMemory.php
@@ -20,6 +20,12 @@ final class RecordingSnapshotsMemory implements SnapshotsMemory
     /** @var array<int, array{run_id: string, step_index: int, tool_call: array<string, mixed>}> */
     public array $toolCallAppends = [];
 
+    /** @var array<int, array{run_id: string, step_index: int}> */
+    public array $toolCallResets = [];
+
+    /** @var array<string, MemorySnapshot> Stub canned `find()` results keyed by `{runId}:{stepIndex}`. */
+    public array $preloaded = [];
+
     public function snapshot(string $runId, int $stepIndex): MemorySnapshot
     {
         $this->snapshotCalls[] = ['run_id' => $runId, 'step_index' => $stepIndex];
@@ -38,8 +44,23 @@ final class RecordingSnapshotsMemory implements SnapshotsMemory
         return $snapshot->withToolCall($toolCall);
     }
 
+    public function resetToolCalls(MemorySnapshot $snapshot): MemorySnapshot
+    {
+        $this->toolCallResets[] = [
+            'run_id' => $snapshot->runId,
+            'step_index' => $snapshot->stepIndex,
+        ];
+
+        return $snapshot->withClearedToolCalls();
+    }
+
     public function find(string $runId, int $stepIndex): ?MemorySnapshot
     {
-        return null;
+        return $this->preloaded[$runId.':'.$stepIndex] ?? null;
+    }
+
+    public function preload(MemorySnapshot $snapshot): void
+    {
+        $this->preloaded[$snapshot->runId.':'.$snapshot->stepIndex] = $snapshot;
     }
 }

--- a/tests/Unit/Memory/ReplaySwarmMemoryTest.php
+++ b/tests/Unit/Memory/ReplaySwarmMemoryTest.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmMemory;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Events\Memory\MemoryScopeOutOfSnapshot;
+use BuiltByBerry\LaravelSwarm\Memory\DefaultSwarmMemory;
+use BuiltByBerry\LaravelSwarm\Memory\MemoryEntry;
+use BuiltByBerry\LaravelSwarm\Memory\MemorySnapshot;
+use BuiltByBerry\LaravelSwarm\Memory\ReplaySwarmMemory;
+use BuiltByBerry\LaravelSwarm\Tests\Support\InMemoryMemoryStore;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Support\Facades\Event;
+
+/**
+ * Unit tests for the {@see ReplaySwarmMemory} decorator.
+ *
+ * Verifies the four-quadrant behaviour:
+ *
+ * 1. Reads against the replayed Run scope come from the frozen snapshot —
+ *    not from whatever the live store currently holds.
+ * 2. Writes against the replayed Run scope are buffered and never reach the
+ *    wrapped store, but are visible to subsequent reads in the same
+ *    invocation (write-after-read locality).
+ * 3. Reads/writes against any other scope read-through to the live store
+ *    and dispatch {@see MemoryScopeOutOfSnapshot} so cross-scope drift is
+ *    visible in the audit trail.
+ * 4. `forget()` on the replayed Run scope clears the buffered value and
+ *    masks the snapshot entry without touching the live store.
+ */
+function makeSnapshot(string $runId, array $entries = []): MemorySnapshot
+{
+    $hydrated = [];
+
+    foreach ($entries as [$scope, $scopeId, $key, $value, $metadata]) {
+        $hydrated[] = new MemoryEntry(
+            scope: $scope,
+            scopeId: $scopeId,
+            key: $key,
+            value: $value,
+            metadata: $metadata,
+        );
+    }
+
+    return MemorySnapshot::fromEntries($runId, 0, $hydrated);
+}
+
+function makeReplay(MemorySnapshot $snapshot, ?SwarmMemory $live = null): ReplaySwarmMemory
+{
+    return new ReplaySwarmMemory(
+        live: $live ?? new DefaultSwarmMemory(new InMemoryMemoryStore),
+        snapshot: $snapshot,
+        events: app(Dispatcher::class),
+    );
+}
+
+beforeEach(function () {
+    // The replay decorator dispatches events through the container; reset the
+    // fake on every test so cross-test assertions don't leak.
+    Event::fake([MemoryScopeOutOfSnapshot::class]);
+});
+
+test('reads against the replayed Run scope return the frozen snapshot value, not the live store', function () {
+    $live = new DefaultSwarmMemory(new InMemoryMemoryStore);
+    $live->put(MemoryScope::Run, 'run-1', 'config', 'drifted-since-original');
+
+    $snapshot = makeSnapshot('run-1', [
+        [MemoryScope::Run, 'run-1', 'config', 'frozen-at-invocation', []],
+    ]);
+
+    $replay = makeReplay($snapshot, $live);
+
+    expect($replay->get(MemoryScope::Run, 'run-1', 'config'))->toBe('frozen-at-invocation');
+});
+
+test('entry on the replayed Run scope returns a MemoryEntry hydrated from the snapshot row', function () {
+    $snapshot = makeSnapshot('run-1', [
+        [MemoryScope::Run, 'run-1', 'k', 'v', ['source' => 'frozen']],
+    ]);
+
+    $entry = makeReplay($snapshot)->entry(MemoryScope::Run, 'run-1', 'k');
+
+    expect($entry)->toBeInstanceOf(MemoryEntry::class);
+    expect($entry?->value)->toBe('v');
+    expect($entry?->metadata)->toBe(['source' => 'frozen']);
+    expect($entry?->scope)->toBe(MemoryScope::Run);
+});
+
+test('reads for keys missing from the snapshot return null without touching the live store', function () {
+    $live = new DefaultSwarmMemory(new InMemoryMemoryStore);
+    $live->put(MemoryScope::Run, 'run-1', 'leaked', 'live-value');
+
+    $snapshot = makeSnapshot('run-1'); // No entries.
+
+    expect(makeReplay($snapshot, $live)->get(MemoryScope::Run, 'run-1', 'leaked'))->toBeNull();
+});
+
+test('writes against the replayed Run scope buffer in memory and never reach the live store', function () {
+    $store = new InMemoryMemoryStore;
+    $live = new DefaultSwarmMemory($store);
+    $snapshot = makeSnapshot('run-1');
+    $replay = makeReplay($snapshot, $live);
+
+    $replay->put(MemoryScope::Run, 'run-1', 'scratchpad', 'buffered');
+
+    expect($store->all(MemoryScope::Run, 'run-1'))->toBeEmpty();
+});
+
+test('a buffered write is visible to subsequent reads in the same invocation', function () {
+    $snapshot = makeSnapshot('run-1', [
+        [MemoryScope::Run, 'run-1', 'snapshot-only', 'original', []],
+    ]);
+    $replay = makeReplay($snapshot);
+
+    $replay->put(MemoryScope::Run, 'run-1', 'scratchpad', 'just-written');
+
+    expect($replay->get(MemoryScope::Run, 'run-1', 'scratchpad'))->toBe('just-written');
+    expect($replay->get(MemoryScope::Run, 'run-1', 'snapshot-only'))->toBe('original');
+});
+
+test('a buffered write that overlays a snapshot key returns the buffer on subsequent reads', function () {
+    $snapshot = makeSnapshot('run-1', [
+        [MemoryScope::Run, 'run-1', 'k', 'snapshot-value', []],
+    ]);
+    $replay = makeReplay($snapshot);
+
+    $replay->put(MemoryScope::Run, 'run-1', 'k', 'overlay-value');
+
+    expect($replay->get(MemoryScope::Run, 'run-1', 'k'))->toBe('overlay-value');
+});
+
+test('forget on a replayed Run-scope key masks the snapshot row and leaves the live store untouched', function () {
+    $store = new InMemoryMemoryStore;
+    $live = new DefaultSwarmMemory($store);
+    $live->put(MemoryScope::Run, 'run-1', 'k', 'live-value');
+
+    $snapshot = makeSnapshot('run-1', [
+        [MemoryScope::Run, 'run-1', 'k', 'frozen-value', []],
+    ]);
+
+    $replay = makeReplay($snapshot, $live);
+
+    expect($replay->forget(MemoryScope::Run, 'run-1', 'k'))->toBeTrue();
+    expect($replay->get(MemoryScope::Run, 'run-1', 'k'))->toBeNull();
+    expect($store->get(MemoryScope::Run, 'run-1', 'k')?->value)->toBe('live-value');
+});
+
+test('forget returns false when neither the snapshot nor the buffer holds the key', function () {
+    $snapshot = makeSnapshot('run-1');
+
+    expect(makeReplay($snapshot)->forget(MemoryScope::Run, 'run-1', 'missing'))->toBeFalse();
+});
+
+test('all on the replayed Run scope merges snapshot entries with buffered writes and excludes forgets', function () {
+    $snapshot = makeSnapshot('run-1', [
+        [MemoryScope::Run, 'run-1', 'a', '1', []],
+        [MemoryScope::Run, 'run-1', 'b', '2', []],
+        [MemoryScope::Run, 'run-1', 'c', '3', []],
+    ]);
+
+    $replay = makeReplay($snapshot);
+    $replay->put(MemoryScope::Run, 'run-1', 'b', 'overlay-b'); // overlay
+    $replay->put(MemoryScope::Run, 'run-1', 'd', '4');          // new
+    $replay->forget(MemoryScope::Run, 'run-1', 'c');            // mask
+
+    $values = collect($replay->all(MemoryScope::Run, 'run-1'))
+        ->mapWithKeys(fn (MemoryEntry $entry) => [$entry->key => $entry->value])
+        ->all();
+
+    expect($values)->toBe([
+        'a' => '1',
+        'b' => 'overlay-b',
+        'd' => '4',
+    ]);
+});
+
+test('reads against non-Run scopes read-through to the live store and dispatch MemoryScopeOutOfSnapshot', function () {
+    $live = new DefaultSwarmMemory(new InMemoryMemoryStore);
+    $live->put(MemoryScope::Conversation, 'conv-1', 'tone', 'casual');
+
+    $snapshot = makeSnapshot('run-1');
+
+    expect(makeReplay($snapshot, $live)->get(MemoryScope::Conversation, 'conv-1', 'tone'))->toBe('casual');
+
+    Event::assertDispatched(MemoryScopeOutOfSnapshot::class, fn (MemoryScopeOutOfSnapshot $e): bool => $e->runId === 'run-1'
+        && $e->scope === MemoryScope::Conversation
+        && $e->scopeId === 'conv-1'
+        && $e->key === 'tone'
+        && $e->operation === 'entry');
+});
+
+test('writes against non-Run scopes hit the live store and dispatch MemoryScopeOutOfSnapshot with operation=put', function () {
+    $store = new InMemoryMemoryStore;
+    $live = new DefaultSwarmMemory($store);
+    $snapshot = makeSnapshot('run-1');
+
+    makeReplay($snapshot, $live)->put(MemoryScope::Agent, 'App\\Agents\\Tagger', 'preference', 'tagged');
+
+    expect($store->get(MemoryScope::Agent, 'App\\Agents\\Tagger', 'preference')?->value)->toBe('tagged');
+
+    Event::assertDispatched(MemoryScopeOutOfSnapshot::class, fn (MemoryScopeOutOfSnapshot $e): bool => $e->scope === MemoryScope::Agent
+        && $e->operation === 'put');
+});
+
+test('reads against the Run scope of a DIFFERENT run dispatch the cross-scope event and read live', function () {
+    $live = new DefaultSwarmMemory(new InMemoryMemoryStore);
+    $live->put(MemoryScope::Run, 'run-other', 'k', 'other-run-value');
+
+    $snapshot = makeSnapshot('run-1');
+
+    expect(makeReplay($snapshot, $live)->get(MemoryScope::Run, 'run-other', 'k'))->toBe('other-run-value');
+
+    Event::assertDispatched(MemoryScopeOutOfSnapshot::class, fn (MemoryScopeOutOfSnapshot $e): bool => $e->scopeId === 'run-other');
+});
+
+test('all against a non-Run scope dispatches MemoryScopeOutOfSnapshot with a wildcard key', function () {
+    $live = new DefaultSwarmMemory(new InMemoryMemoryStore);
+    $snapshot = makeSnapshot('run-1');
+
+    makeReplay($snapshot, $live)->all(MemoryScope::Swarm, 'App\\Swarms\\MarkasSwarm');
+
+    Event::assertDispatched(MemoryScopeOutOfSnapshot::class, fn (MemoryScopeOutOfSnapshot $e): bool => $e->scope === MemoryScope::Swarm
+        && $e->key === '*'
+        && $e->operation === 'all');
+});
+
+test('snapshot frozen flag round-trips through fromPersisted to true by default', function () {
+    $snapshot = MemorySnapshot::fromPersisted(
+        ['run_id' => 'r', 'step_index' => 0, 'entries' => []],
+        [],
+    );
+
+    expect($snapshot->frozen)->toBeTrue();
+});
+
+test('snapshot frozen flag round-trips through fromEntries to false by default', function () {
+    expect(MemorySnapshot::fromEntries('r', 0, [])->frozen)->toBeFalse();
+});
+
+test('withClearedToolCalls returns an unfrozen snapshot with empty toolCalls', function () {
+    $snapshot = MemorySnapshot::fromPersisted(
+        ['run_id' => 'r', 'step_index' => 0, 'entries' => []],
+        [['name' => 't', 'arguments' => [], 'result' => 'r']],
+    );
+
+    expect($snapshot->frozen)->toBeTrue();
+    expect($snapshot->toolCalls)->toHaveCount(1);
+
+    $cleared = $snapshot->withClearedToolCalls();
+
+    expect($cleared->toolCalls)->toBe([]);
+    expect($cleared->frozen)->toBeFalse();
+});


### PR DESCRIPTION
## Summary

Lands the **parallel branch** portion of #112 — durable replay reads from the frozen `swarm_memory_snapshots` row instead of re-querying live memory when a worker resumes after a crash. Sequential + hierarchical durable resume paths are split out into follow-up #142 so they can land cleanly after #113 (`runcontext-on-memory`).

- **`ReplaySwarmMemory`** decorator (new) — implements `SwarmMemory`; serves the snapshot-backed view for Run-scope reads of the replayed run, buffers Run-scope writes in memory so the live store stays untouched, and reads non-Run scopes through to live while dispatching `MemoryScopeOutOfSnapshot` so cross-scope drift is visible in the audit trail.
- **`MemorySnapshot::$frozen`** (new) — `false` on fresh snapshots, `true` on hydrations via `fromPersisted()`. The canonical-record guard.
- **`SnapshotsMemory::resetToolCalls()`** (new, **public** on the contract) — clears the persisted `tool_calls` column and returns an unfrozen snapshot. The mid-flight retry primitive; also lays groundwork for v0.10 operator/inspector tooling.
- **`SnapshotsMemory::appendToolCall()`** now throws **`SnapshotFrozenException`** when given a snapshot loaded via `find()` — protects the canonical record from drift-time mutation.
- **`DurableBranchAdvancer::advanceBranch`** — detects mid-flight retry via `snapshots->find()` before agent resolution, swaps the `SwarmMemory` binding to a `ReplaySwarmMemory` for the duration of the invocation, restores it in a `finally` block. Constructor-injected `SwarmMemory` on the agent picks up the decorator because the swap happens before container resolution.
- **`ReplayDriftException`** (new) — defined for the v0.10 canonical-replay/inspector flow that will compare a freshly produced tool-call sequence against the canonical record. No production caller yet.

## What is NOT covered here

Sequential + hierarchical durable resume paths still UPSERT the snapshot row with live memory on retry. Filed as **#142** and blocked **#118** (compliance evidence suite) on it so v0.9.0 ships with full three-topology coverage. See the design discussion in #142 for the proposed `MemoryReplayCoordinator` abstraction (lands cleanly post-#113).

## Test plan

- [x] `composer test` — 1068 passed / 4204 assertions
- [x] `composer analyse` — clean
- [x] `vendor/bin/pint --test` — clean
- [x] New unit tests: 16 for `ReplaySwarmMemory` decorator (four-quadrant behaviour: replayed Run scope reads/writes, cross-scope drift events, write-after-read overlay semantics, `withClearedToolCalls` invariants)
- [x] New feature tests on the recorder: `find()` returns frozen, `appendToolCall(frozen)` throws `SnapshotFrozenException`, `resetToolCalls` clears the persisted column + returns unfrozen, post-reset `appendToolCall` succeeds
- [ ] End-to-end retry scenario across the full `DurableSwarmManager` flow lands in **#118**'s compliance suite, which will now also cover sequential + hierarchical once #142 ships

## Linked issues

Refs #112 — partial (parallel branch path). Sequential + hierarchical split out into #142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)