### PR TITLE
feat(memory): RunContext implements ArrayAccess + writes through to SwarmMemory

### DIFF
--- a/src/Support/RunContext.php
+++ b/src/Support/RunContext.php
@@ -4,14 +4,37 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Support;
 
+use ArrayAccess;
 use BuiltByBerry\LaravelSwarm\Audit\Actor;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmMemory;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
 use BuiltByBerry\LaravelSwarm\Exceptions\SwarmException;
 use BuiltByBerry\LaravelSwarm\Responses\DurableWaitOutcome;
 use BuiltByBerry\LaravelSwarm\Responses\SwarmArtifact;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Auth\Authenticatable;
 use JsonException;
 
-class RunContext
+/**
+ * Per-run state handle that carries the run id, input, and a write-through
+ * cache of Run-scoped {@see SwarmMemory} entries.
+ *
+ * `$data` is the in-memory cache for the Run-scoped memory view. Writes go
+ * through {@see mergeData()} (and the {@see ArrayAccess} surface) to both
+ * the cache and the bound {@see SwarmMemory}, so reads through `$data`
+ * stay array-fast on the hot path (`prompt()` and runner inter-step relays)
+ * while the canonical store is always current. This mirrors Eloquent's
+ * attribute caching: the in-memory representation is authoritative for the
+ * duration of the run; persistence happens on the documented mutation paths.
+ *
+ * `$metadata` and `$artifacts` are framework-operational state — durable
+ * labels, actor binding, signal payloads, wait outcomes, captured artifacts.
+ * Those intentionally do not write through to SwarmMemory: they're not
+ * agent-readable knowledge, just plumbing.
+ *
+ * @implements ArrayAccess<string, mixed>
+ */
+class RunContext implements ArrayAccess
 {
     /**
      * @param  array<string, mixed>  $data
@@ -141,6 +164,8 @@ class RunContext
     public function mergeData(array $values): self
     {
         $this->data = array_merge($this->data, $values);
+
+        $this->writeThroughToMemory($values);
 
         return $this;
     }
@@ -293,6 +318,113 @@ class RunContext
     public function toQueuePayload(): array
     {
         return self::validateSerializedPayload($this->toArray(), 'RunContext queue payload');
+    }
+
+    // ------------------------------------------------------------------
+    // ArrayAccess — direct SwarmMemory Run-scope reads/writes
+    // ------------------------------------------------------------------
+    //
+    // `$context[$key]` is the canonical context-level memory accessor:
+    // every operation goes straight through {@see SwarmMemory} so callers
+    // see the latest value, including writes made outside this RunContext
+    // instance (e.g. from another worker on a durable parallel branch).
+    // The cached `$data` projection is intentionally bypassed here — its
+    // purpose is to keep `prompt()` and runner inter-step relays fast, not
+    // to be the source of truth.
+    //
+    // When SwarmMemory isn't bound (e.g. test setups that never boot the
+    // app), every operation falls back to the cached `$data` array so
+    // POPO-style usage keeps working.
+
+    public function offsetExists(mixed $offset): bool
+    {
+        $memory = $this->resolveMemory();
+
+        if ($memory === null) {
+            return array_key_exists((string) $offset, $this->data);
+        }
+
+        return $memory->entry(MemoryScope::Run, $this->runId, (string) $offset) !== null;
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        $memory = $this->resolveMemory();
+
+        if ($memory === null) {
+            return $this->data[(string) $offset] ?? null;
+        }
+
+        return $memory->get(MemoryScope::Run, $this->runId, (string) $offset);
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        if ($offset === null) {
+            throw new SwarmException('RunContext memory keys are addressed by string — appending without a key is not supported.');
+        }
+
+        $key = (string) $offset;
+        $this->data[$key] = $value;
+
+        $memory = $this->resolveMemory();
+
+        if ($memory !== null) {
+            $memory->put(MemoryScope::Run, $this->runId, $key, $value);
+        }
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        $key = (string) $offset;
+        unset($this->data[$key]);
+
+        $memory = $this->resolveMemory();
+
+        if ($memory !== null) {
+            $memory->forget(MemoryScope::Run, $this->runId, $key);
+        }
+    }
+
+    /**
+     * Mirror {@see mergeData()} writes into the bound {@see SwarmMemory}
+     * Run scope. Best-effort: when no SwarmMemory is bound (typical for
+     * unbooted-app test setups) the cache is the only writer and the
+     * canonical store is whatever the test asserts on directly.
+     *
+     * @param  array<string, mixed>  $values
+     */
+    protected function writeThroughToMemory(array $values): void
+    {
+        $memory = $this->resolveMemory();
+
+        if ($memory === null) {
+            return;
+        }
+
+        foreach ($values as $key => $value) {
+            $memory->put(MemoryScope::Run, $this->runId, (string) $key, $value);
+        }
+    }
+
+    /**
+     * Resolve the bound {@see SwarmMemory} or null when no container/binding
+     * is available. Uses `Container::getInstance()` rather than the global
+     * `app()` helper so RunContext can be constructed in tests that never
+     * boot the framework. Returns null cheaply — callers must guard.
+     */
+    protected function resolveMemory(): ?SwarmMemory
+    {
+        $container = Container::getInstance();
+
+        if (! $container->bound(SwarmMemory::class)) {
+            return null;
+        }
+
+        /** @var SwarmMemory $memory */
+        $memory = $container->make(SwarmMemory::class);
+
+        return $memory;
     }
 
     /**

--- a/tests/Feature/Memory/RunContextMemoryBackingTest.php
+++ b/tests/Feature/Memory/RunContextMemoryBackingTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Contracts\MemoryStore;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmMemory;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Exceptions\SwarmException;
+use BuiltByBerry\LaravelSwarm\Memory\DefaultSwarmMemory;
+use BuiltByBerry\LaravelSwarm\Support\RunContext;
+use BuiltByBerry\LaravelSwarm\Tests\Support\InMemoryMemoryStore;
+use Illuminate\Container\Container;
+
+/**
+ * RunContext is now a write-through facade over the SwarmMemory Run scope.
+ * Two guarantees this suite locks down:
+ *
+ * 1. Writes through `mergeData()` and the new `ArrayAccess` surface land in
+ *    both the cached `$data` array and the bound SwarmMemory store. The
+ *    cache keeps the hot inter-step relay (`prompt()`, Sequential / Parallel
+ *    / Hierarchical runners) array-fast; the store is the canonical view
+ *    that durable resumes, cross-worker reads, and the v0.10 operator
+ *    surface will rely on.
+ * 2. When no SwarmMemory binding is available (e.g. POPO test setups that
+ *    never boot the application), RunContext degrades to in-memory-only
+ *    behaviour — no fatals, no log noise — so existing direct-construction
+ *    fixtures keep working.
+ */
+beforeEach(function () {
+    $this->app->singleton(MemoryStore::class, fn (): MemoryStore => new InMemoryMemoryStore);
+    $this->app->singleton(SwarmMemory::class, DefaultSwarmMemory::class);
+});
+
+// ---------------------------------------------------------------------------
+// mergeData() write-through
+// ---------------------------------------------------------------------------
+
+test('mergeData populates both the cached $data array and the SwarmMemory Run scope', function () {
+    $memory = $this->app->make(SwarmMemory::class);
+    $context = new RunContext(runId: 'run-1', input: 'go');
+
+    $context->mergeData(['last_output' => 'agent-said-hello', 'steps' => 1]);
+
+    expect($context->data)->toBe(['last_output' => 'agent-said-hello', 'steps' => 1]);
+    expect($memory->get(MemoryScope::Run, 'run-1', 'last_output'))->toBe('agent-said-hello');
+    expect($memory->get(MemoryScope::Run, 'run-1', 'steps'))->toBe(1);
+});
+
+test('mergeData write-through preserves the canonical store across multiple merges', function () {
+    $memory = $this->app->make(SwarmMemory::class);
+    $context = new RunContext(runId: 'run-1', input: 'go');
+
+    $context->mergeData(['a' => 1]);
+    $context->mergeData(['b' => 2]);
+    $context->mergeData(['a' => 'updated']); // overwrite
+
+    expect($memory->get(MemoryScope::Run, 'run-1', 'a'))->toBe('updated');
+    expect($memory->get(MemoryScope::Run, 'run-1', 'b'))->toBe(2);
+});
+
+test('mergeData on one RunContext is observable through SwarmMemory by another worker resolving the same run_id', function () {
+    // Simulates the durable-resume scenario: worker A merges data on a
+    // RunContext, then worker B (different process / different RunContext
+    // instance) resolves the same run via SwarmMemory.
+    $contextA = new RunContext(runId: 'run-shared', input: 'go');
+    $contextA->mergeData(['handoff' => 'value-from-worker-a']);
+
+    $memory = $this->app->make(SwarmMemory::class);
+
+    expect($memory->get(MemoryScope::Run, 'run-shared', 'handoff'))->toBe('value-from-worker-a');
+});
+
+// ---------------------------------------------------------------------------
+// ArrayAccess — direct SwarmMemory reads/writes
+// ---------------------------------------------------------------------------
+
+test('$context[$key] reads go straight through SwarmMemory rather than the cache', function () {
+    $memory = $this->app->make(SwarmMemory::class);
+    $context = new RunContext(runId: 'run-1', input: 'go');
+
+    // Pre-populate the canonical store directly (bypassing RunContext entirely
+    // so the cache stays empty — proves the ArrayAccess read is not a cache lookup).
+    $memory->put(MemoryScope::Run, 'run-1', 'set_by_other_worker', 'canonical');
+
+    expect($context['set_by_other_worker'])->toBe('canonical');
+    expect($context->data)->toBe([]); // cache is still empty
+});
+
+test('$context[$key] = $value writes to both SwarmMemory and the cache', function () {
+    $memory = $this->app->make(SwarmMemory::class);
+    $context = new RunContext(runId: 'run-1', input: 'go');
+
+    $context['note'] = 'remember me';
+
+    expect($memory->get(MemoryScope::Run, 'run-1', 'note'))->toBe('remember me');
+    expect($context->data['note'])->toBe('remember me');
+});
+
+test('isset($context[$key]) consults SwarmMemory, not the cache', function () {
+    $memory = $this->app->make(SwarmMemory::class);
+    $memory->put(MemoryScope::Run, 'run-1', 'present', 'yes');
+
+    $context = new RunContext(runId: 'run-1', input: 'go');
+
+    expect(isset($context['present']))->toBeTrue();
+    expect(isset($context['absent']))->toBeFalse();
+});
+
+test('unset($context[$key]) forgets from SwarmMemory and removes from the cache', function () {
+    $memory = $this->app->make(SwarmMemory::class);
+    $context = new RunContext(runId: 'run-1', input: 'go');
+
+    $context['scratchpad'] = 'temp';
+    expect($context->data['scratchpad'])->toBe('temp');
+    expect($memory->get(MemoryScope::Run, 'run-1', 'scratchpad'))->toBe('temp');
+
+    unset($context['scratchpad']);
+
+    expect($context->data)->not->toHaveKey('scratchpad');
+    expect($memory->get(MemoryScope::Run, 'run-1', 'scratchpad'))->toBeNull();
+});
+
+test('appending without a key throws — RunContext memory is keyed access only', function () {
+    $context = new RunContext(runId: 'run-1', input: 'go');
+
+    expect(fn () => $context[] = 'no-key')->toThrow(SwarmException::class);
+});
+
+// ---------------------------------------------------------------------------
+// prompt() — cache-backed for performance; behaviour unchanged
+// ---------------------------------------------------------------------------
+
+test('prompt() reads the last_output from the cache rather than round-tripping through SwarmMemory', function () {
+    $memory = $this->app->make(SwarmMemory::class);
+    $context = new RunContext(runId: 'run-1', input: 'go');
+
+    $context->mergeData(['last_output' => 'first-output']);
+
+    // Drift the canonical store underneath the cache. prompt() must still
+    // return the cached value — the cache is the authoritative read source
+    // for the hot inter-step relay (Eloquent-style attribute caching).
+    $memory->put(MemoryScope::Run, 'run-1', 'last_output', 'mutated-out-of-band');
+
+    expect($context->prompt())->toBe('first-output');
+});
+
+test('prompt() falls back to input when no last_output has been written', function () {
+    $context = new RunContext(runId: 'run-1', input: 'original prompt');
+
+    expect($context->prompt())->toBe('original prompt');
+});
+
+// ---------------------------------------------------------------------------
+// Null-bind tolerance — works without an application container
+// ---------------------------------------------------------------------------
+
+test('mergeData on a RunContext built without a SwarmMemory binding behaves as in-memory only', function () {
+    // Replace the container with a fresh one that has nothing bound. This
+    // mirrors the POPO-style fixture setup some test suites use to construct
+    // RunContext without booting the framework.
+    $previous = Container::getInstance();
+
+    try {
+        Container::setInstance(new Container);
+
+        $context = new RunContext(runId: 'run-1', input: 'go');
+        $context->mergeData(['k' => 'v']);
+
+        expect($context->data['k'])->toBe('v');
+        // No fatal, no log noise, no exception — degrades cleanly.
+    } finally {
+        Container::setInstance($previous);
+    }
+});
+
+test('ArrayAccess on an unbound RunContext falls back to the cached data array', function () {
+    $previous = Container::getInstance();
+
+    try {
+        Container::setInstance(new Container);
+
+        $context = new RunContext(runId: 'run-1', input: 'go', data: ['preset' => 'value']);
+
+        expect($context['preset'])->toBe('value');
+        expect(isset($context['preset']))->toBeTrue();
+        expect(isset($context['missing']))->toBeFalse();
+
+        $context['new'] = 'written';
+        expect($context->data['new'])->toBe('written');
+
+        unset($context['preset']);
+        expect($context->data)->not->toHaveKey('preset');
+    } finally {
+        Container::setInstance($previous);
+    }
+});
+
+// ---------------------------------------------------------------------------
+// Serialization unchanged — fromPayload / toQueuePayload round-trip
+// ---------------------------------------------------------------------------
+
+test('toQueuePayload includes the cached data and round-trips through fromPayload unchanged', function () {
+    $context = new RunContext(runId: 'run-1', input: 'go');
+    $context->mergeData(['k1' => 'v1', 'k2' => ['nested' => true]]);
+
+    $payload = $context->toQueuePayload();
+    $rehydrated = RunContext::fromPayload($payload);
+
+    expect($rehydrated->runId)->toBe('run-1');
+    expect($rehydrated->input)->toBe('go');
+    expect($rehydrated->data)->toBe(['k1' => 'v1', 'k2' => ['nested' => true]]);
+});
+
+test('RunContext::fake([data: ...]) seeds the cache without requiring SwarmMemory write-through', function () {
+    $previous = Container::getInstance();
+
+    try {
+        Container::setInstance(new Container);
+
+        $context = RunContext::fake([
+            'run_id' => 'fake-1',
+            'input' => 'test',
+            'data' => ['preloaded' => 'yes'],
+        ]);
+
+        expect($context->data['preloaded'])->toBe('yes');
+        expect($context['preloaded'])->toBe('yes');
+    } finally {
+        Container::setInstance($previous);
+    }
+});


### PR DESCRIPTION
## Summary

Lands #113 — RunContext is now a write-through facade over the SwarmMemory Run scope. **Ships non-breaking** after the codebase audit showed all internal `$data` mutation already flows through `mergeData()`, so the consolidation was achievable without changing the public API.

- **`mergeData()` write-through.** Every key passed to `mergeData()` is also written to `SwarmMemory::put(Run, $runId, $key, $value)`. The cached `$data` array stays in sync and keeps the hot path (`prompt()`, inter-step relays in Sequential/Parallel/Hierarchical runners) array-fast — Eloquent-style attribute caching, not a Doctrine-style lazy proxy.
- **`ArrayAccess` on RunContext.** `$context['key']` reads/writes go straight through SwarmMemory (cache bypassed) so callers see the canonical view including writes from sibling workers, the future v0.10 operator surface, etc. `$context[] = $value` (append without key) throws — memory is keyed-access only.
- **Null-bind tolerance.** When no `SwarmMemory` is bound in the container (POPO test setups that never boot the framework), every operation falls back to the cached `$data` array — no fatals, no log noise. Existing direct-construction fixtures keep working unchanged.
- **`$metadata` and `$artifacts` stay where they are.** They're framework-operational state (durable labels, actor binding, signal payloads, wait outcomes, captured artifacts) — plumbing the framework reads, not agent-readable knowledge. Out of scope for SwarmMemory write-through.

## Why non-breaking

#113 was originally classified BREAKING on the assumption that consolidating the memory model would require changing RunContext's public surface (shim layer, deprecation logs, etc.). An audit before coding showed:

- Zero direct `$context->data['x'] = ...` writes anywhere in `src/`
- Zero `is_array($context->data)` or `array_keys($context->data)` introspection
- All 12 internal writers go through `mergeData()`
- All reads either go through `prompt()` or are read-only fallbacks like `$data['last_output'] ?? $input`

That meant the unified memory model was achievable by making `mergeData()` the write-through hook and adding `ArrayAccess` for the new addressing API — no shim, no deprecation, no breaking change. `$data`/`$metadata` as state-container properties remain for backward compat; their eventual removal in favor of pure ArrayAccess is deferred to v1.0+.

Side effect: **#117 (`migration-from-runcontext`) closed as obsolete** — no migration guide is needed when nothing breaks. The "what's new in v0.9.0 memory" narrative belongs to #116 (memory-model-doc).

## What I deliberately did NOT do

- **No internal-reader migration.** Walked every `$context->data[...]` read site in `src/` (Sequential, Hierarchical, Static/Stream variants, DurableRunTerminalHandler). All are either same-process post-write reads or terminal output assembly where the cache was just populated by `mergeData()` milliseconds earlier. Moving them to `SwarmMemory::get(...)` would have changed the data source without changing the value — pure theatrical churn. The cache is provably-current for the duration of a run because we control all writers.
- **No deprecation logs.** The original AC asked for them on the "shim path"; the redesign has no shim. Both APIs (mergeData and ArrayAccess) are first-class going forward.
- **No CHANGELOG entry yet.** Following the codebase convention — v0.9.0's CHANGELOG section is populated at release wrap (`/release-wrap`), not per-PR. Earlier merged components (#108–#115, #138–#141, #143) did the same.

## Test plan

- [x] `composer test` — **1082 passed / 4234 assertions** (+14 over post-#143 baseline)
- [x] `composer analyse` — clean
- [x] `vendor/bin/pint --test` — clean
- [x] New test file: `tests/Feature/Memory/RunContextMemoryBackingTest.php` (14 tests, 30 assertions). Covers:
  - `mergeData()` writes to both cache and SwarmMemory
  - Cross-RunContext observability via SwarmMemory (simulates the durable-resume scenario)
  - ArrayAccess reads bypass the cache and hit SwarmMemory directly
  - ArrayAccess writes update both
  - `prompt()` still reads from the cache (parity with current behavior, including under cache-vs-store drift)
  - Null-bind fallback works for unbooted-container test setups
  - `toQueuePayload`/`fromPayload` round-trip unchanged

## Linked issues

Closes #113. Closed-as-obsolete #117 (migration guide no longer needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)