### PR TITLE
feat(memory): durable sequential + hierarchical replay reads from frozen snapshot

### DIFF
--- a/config/swarm.php
+++ b/config/swarm.php
@@ -222,6 +222,23 @@ return [
         'stream_parallel_branches' => env('SWARM_STATIC_HIERARCHICAL_STREAM_PARALLEL_BRANCHES', 'concurrent'),
     ],
 
+    'memory' => [
+        /*
+         * Controls how a durable swarm re-executes after a crash-resume.
+         *
+         * 'frozen_view'     — agents re-execute against the memory snapshot frozen
+         *                     at the original invocation. Live writes are buffered
+         *                     and never reach the backing store, preserving the
+         *                     canonical audit record. Recommended for reproducible runs.
+         *
+         * 'fresh_execution' — agents re-execute against live memory with no snapshot
+         *                     guard. Use only when idempotency is guaranteed externally.
+         *
+         * Override per swarm with the #[MemoryReplay(mode: ReplayMode::...)] attribute.
+         */
+        'replay_mode' => env('SWARM_MEMORY_REPLAY_MODE', 'frozen_view'),
+    ],
+
     'streaming' => [
         'replay' => [
             'enabled' => env('SWARM_STREAM_REPLAY_ENABLED', false),

--- a/src/Attributes/MemoryReplay.php
+++ b/src/Attributes/MemoryReplay.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Attributes;
+
+use Attribute;
+use BuiltByBerry\LaravelSwarm\Enums\ReplayMode;
+
+/**
+ * Controls how a swarm re-executes after a durable crash-resume.
+ *
+ * Apply to a Swarm class to override the global `swarm.memory.replay_mode` config.
+ *
+ * ```php
+ * #[MemoryReplay(mode: ReplayMode::FreshExecution)]
+ * class MySwarm extends Swarm { ... }
+ * ```
+ *
+ * The default — and the mode used when this attribute is absent — is
+ * {@see ReplayMode::FrozenView}: agents re-execute against the snapshot frozen
+ * at the original invocation, so the determinism guarantee is preserved across
+ * workers and crash-resume boundaries.
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+final class MemoryReplay
+{
+    public function __construct(
+        public readonly ReplayMode $mode = ReplayMode::FrozenView,
+    ) {}
+}

--- a/src/Enums/ReplayMode.php
+++ b/src/Enums/ReplayMode.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Enums;
+
+enum ReplayMode: string
+{
+    /**
+     * The agent re-executes against a frozen snapshot of Run-scope memory taken
+     * at the original invocation. Live memory writes are buffered and never reach
+     * the backing store, preserving the canonical audit record.
+     *
+     * This is the default and the recommended mode for reproducible durable runs.
+     */
+    case FrozenView = 'frozen_view';
+
+    /**
+     * The agent re-executes against live memory with no snapshot guard.
+     * Use only when idempotency is guaranteed by external means or the swarm
+     * explicitly opts out of deterministic replay.
+     */
+    case FreshExecution = 'fresh_execution';
+}

--- a/src/Memory/MemoryReplayCoordinator.php
+++ b/src/Memory/MemoryReplayCoordinator.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Memory;
+
+use BuiltByBerry\LaravelSwarm\Attributes\MemoryReplay;
+use BuiltByBerry\LaravelSwarm\Contracts\SnapshotsMemory;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmMemory;
+use BuiltByBerry\LaravelSwarm\Enums\ReplayMode;
+use Closure;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Foundation\Application;
+use ReflectionClass;
+
+/**
+ * Wraps a durable agent invocation with the snapshot-backed memory lifecycle.
+ *
+ * For each call to {@see during()}, the coordinator:
+ *
+ *   1. Reads the `#[MemoryReplay]` attribute on the swarm class (falls back to
+ *      `swarm.memory.replay_mode` config). If the resolved mode is
+ *      {@see ReplayMode::FreshExecution} the callback is invoked immediately
+ *      with no binding swap.
+ *   2. Calls {@see SnapshotsMemory::find()} to detect a prior crashed attempt.
+ *      If none is found this is a fresh execution — the callback is invoked with
+ *      `null` and the runner's normal `snapshot()` call proceeds as usual.
+ *   3. On replay: swaps the container's `SwarmMemory` binding to a
+ *      {@see ReplaySwarmMemory} decorator backed by the existing frozen snapshot.
+ *      The callback is invoked with the existing snapshot so callers that manage
+ *      their own snapshot lifecycle (e.g. `DurableBranchAdvancer`) can skip the
+ *      redundant `find()` and decide between `resetToolCalls()` vs `snapshot()`.
+ *   4. Restores the original `SwarmMemory` binding in a `finally` block
+ *      regardless of whether the callback throws.
+ *
+ * Because `DatabaseMemorySnapshotRecorder::snapshot()` reads from
+ * `SwarmMemory::all(Run, $runId)`, swapping the binding before any runner
+ * method that internally calls `snapshot()` causes that UPSERT to re-write the
+ * row with the frozen entries instead of live memory — the net result is
+ * identical snapshot contents with an empty `tool_calls` column ready for
+ * rebuilding by the new attempt.
+ *
+ * @internal
+ */
+final class MemoryReplayCoordinator
+{
+    public function __construct(
+        protected SnapshotsMemory $snapshots,
+        protected Application $application,
+        protected Dispatcher $events,
+    ) {}
+
+    /**
+     * Execute `$callback` inside a snapshot-backed memory context for the given
+     * run step, restoring the original binding in `finally`.
+     *
+     * The callback receives `?MemorySnapshot`: `null` means fresh execution
+     * (no prior crashed attempt found), non-null means replay (the binding has
+     * been swapped and the snapshot is available for tool-call lifecycle).
+     *
+     * @template T
+     *
+     * @param  class-string  $swarmClass
+     * @param  Closure(?MemorySnapshot): T  $callback
+     * @return T
+     */
+    public function during(string $swarmClass, string $runId, int $stepIndex, Closure $callback): mixed
+    {
+        if (! $this->replayEnabled($swarmClass)) {
+            return $callback(null);
+        }
+
+        $existing = $this->snapshots->find($runId, $stepIndex);
+
+        if ($existing === null) {
+            return $callback(null);
+        }
+
+        /** @var SwarmMemory $original */
+        $original = $this->application->make(SwarmMemory::class);
+
+        $this->application->instance(
+            SwarmMemory::class,
+            new ReplaySwarmMemory(
+                live: $original,
+                snapshot: $existing,
+                events: $this->events,
+            ),
+        );
+
+        try {
+            return $callback($existing);
+        } finally {
+            $this->application->instance(SwarmMemory::class, $original);
+        }
+    }
+
+    /**
+     * Resolve the effective replay mode for `$swarmClass`.
+     *
+     * The `#[MemoryReplay]` attribute wins over the global config when present.
+     *
+     * @param  class-string  $swarmClass
+     */
+    protected function replayEnabled(string $swarmClass): bool
+    {
+        $ref = new ReflectionClass($swarmClass);
+        $attrs = $ref->getAttributes(MemoryReplay::class);
+
+        $mode = $attrs !== []
+            ? $attrs[0]->newInstance()->mode
+            : ReplayMode::from(config('swarm.memory.replay_mode', ReplayMode::FrozenView->value));
+
+        return $mode === ReplayMode::FrozenView;
+    }
+}

--- a/src/Runners/Durable/DurableBranchAdvancer.php
+++ b/src/Runners/Durable/DurableBranchAdvancer.php
@@ -11,15 +11,14 @@ use BuiltByBerry\LaravelSwarm\Contracts\DurableOutbox;
 use BuiltByBerry\LaravelSwarm\Contracts\DurableRunStore;
 use BuiltByBerry\LaravelSwarm\Contracts\SnapshotsMemory;
 use BuiltByBerry\LaravelSwarm\Contracts\Swarm;
-use BuiltByBerry\LaravelSwarm\Contracts\SwarmMemory;
 use BuiltByBerry\LaravelSwarm\Enums\DurableParallelFailurePolicy;
 use BuiltByBerry\LaravelSwarm\Enums\ExecutionMode;
 use BuiltByBerry\LaravelSwarm\Enums\Topology;
 use BuiltByBerry\LaravelSwarm\Exceptions\LostDurableLeaseException;
 use BuiltByBerry\LaravelSwarm\Exceptions\LostSwarmLeaseException;
 use BuiltByBerry\LaravelSwarm\Exceptions\SwarmException;
+use BuiltByBerry\LaravelSwarm\Memory\MemoryReplayCoordinator;
 use BuiltByBerry\LaravelSwarm\Memory\MemorySnapshot;
-use BuiltByBerry\LaravelSwarm\Memory\ReplaySwarmMemory;
 use BuiltByBerry\LaravelSwarm\Memory\SnapshotToolCallNormalizer;
 use BuiltByBerry\LaravelSwarm\Persistence\DatabaseRunHistoryStore;
 use BuiltByBerry\LaravelSwarm\Responses\SwarmStep;
@@ -61,6 +60,7 @@ class DurableBranchAdvancer
         protected DurableRunTerminalHandler $terminal,
         protected LoggerInterface $logger,
         protected SnapshotsMemory $snapshots,
+        protected MemoryReplayCoordinator $coordinator,
     ) {}
 
     public function advanceBranch(string $runId, string $branchId): void
@@ -96,176 +96,152 @@ class DurableBranchAdvancer
             throw new SwarmException("Unable to resolve durable swarm [{$run['swarm_class']}] from the container.");
         }
 
-        // Detect mid-flight retry: a snapshot row for this step exists, but
-        // the branch never completed (the advancer returns early on completed
-        // branches at the top of this method, so any find() hit here is a
-        // crashed prior attempt). The retry preserves the frozen memory view
-        // for determinism but rebuilds tool calls from scratch — the previous
-        // attempt's partial capture is no longer authoritative.
-        $existingSnapshot = $this->snapshots->find($runId, (int) $branch['step_index']);
-        $isReplay = $existingSnapshot !== null;
+        // The coordinator handles snapshot detection, SwarmMemory binding swap,
+        // and restore in a single boundary — the callback runs under the frozen
+        // memory view on a crash-resume retry, or under live memory on a first
+        // attempt. The callback returns `true` when boundary dispatch should
+        // follow and `false` on all early-return paths.
+        /** @var bool $shouldDispatch */
+        $shouldDispatch = $this->coordinator->during(
+            $run['swarm_class'],
+            $runId,
+            (int) $branch['step_index'],
+            function (?MemorySnapshot $existing) use ($run, $branch, $runId, $branchId, $token, $context, $swarm, $stepLeaseSeconds): bool {
+                $agent = $this->application->make($branch['agent_class']);
 
-        // Swap the SwarmMemory binding to a snapshot-backed view BEFORE the
-        // agent resolves so constructor-injected dependencies see the frozen
-        // memory. The original binding is captured for read-through on
-        // non-Run scopes (the snapshot only freezes Run scope) and restored
-        // in the finally block below.
-        $originalMemory = null;
-
-        if ($isReplay) {
-            /** @var SwarmMemory $originalMemory */
-            $originalMemory = $this->application->make(SwarmMemory::class);
-            $this->application->instance(
-                SwarmMemory::class,
-                new ReplaySwarmMemory(
-                    live: $originalMemory,
-                    snapshot: $existingSnapshot,
-                    events: $this->events,
-                ),
-            );
-        }
-
-        $agent = $this->application->make($branch['agent_class']);
-
-        if (! $agent instanceof Agent) {
-            if ($originalMemory !== null) {
-                $this->application->instance(SwarmMemory::class, $originalMemory);
-            }
-
-            throw new SwarmException("Durable branch agent [{$branch['agent_class']}] must resolve to a Laravel AI agent.");
-        }
-
-        $this->durableRuns->markBranchRunning($runId, $branchId, $token);
-
-        $timeoutSeconds = max((int) ceil((Carbon::parse($run['timeout_at'], 'UTC')->diffInSeconds(now('UTC'), false)) * -1), 1);
-        $state = new SwarmExecutionState(
-            swarm: $swarm,
-            topology: Topology::from($run['topology']),
-            executionMode: ExecutionMode::Durable,
-            deadlineMonotonic: hrtime(true) + ($timeoutSeconds * 1_000_000_000),
-            maxAgentExecutions: (int) $run['total_steps'],
-            ttlSeconds: $this->runs->ttlSeconds(),
-            leaseSeconds: null,
-            executionToken: null,
-            verifyOwnership: fn (): null => $this->durableRuns->assertBranchOwned($runId, $branchId, $token),
-            context: $context,
-            contextStore: $this->contextStore,
-            artifactRepository: $this->artifactRepository,
-            historyStore: $this->historyStore,
-            events: $this->events,
-            queueHierarchicalParallelCoordination: null,
-        );
-
-        $startedAt = MonotonicTime::now();
-        $step = null;
-
-        try {
-            $this->stepsRecorder->started($state, (int) $branch['step_index'], $branch['agent_class'], $branch['input']);
-
-            // On the fresh-execution path we freeze a new snapshot from live
-            // memory. On the retry path the snapshot already exists; we keep
-            // its frozen entries (the determinism guarantee) but clear the
-            // partial tool-call record so this attempt can rebuild it. Both
-            // paths converge on an unfrozen MemorySnapshot we can append to.
-            /** @var MemorySnapshot $snapshot */
-            $snapshot = $isReplay
-                ? $this->snapshots->resetToolCalls($existingSnapshot)
-                : $this->snapshots->snapshot($runId, (int) $branch['step_index']);
-
-            $response = $agent->prompt($branch['input']);
-            $output = (string) $response;
-            $usage = $response->usage->toArray();
-            $durationMs = MonotonicTime::elapsedMilliseconds($startedAt);
-
-            foreach (SnapshotToolCallNormalizer::fromResponse($response) as $toolCall) {
-                $snapshot = $this->snapshots->appendToolCall($snapshot, $toolCall);
-            }
-            $this->guardrails->validateStep(
-                $swarm,
-                GuardrailStepContext::fromState(
-                    $state,
-                    (int) $branch['step_index'],
-                    $branch['agent_class'],
-                    $branch['input'],
-                    $output,
-                    is_array($branch['metadata'] ?? null) ? $branch['metadata'] : [],
-                ),
-                $state->context,
-            );
-            $step = $this->stepsRecorder->completed(
-                state: $state,
-                index: (int) $branch['step_index'],
-                agentClass: $branch['agent_class'],
-                input: $branch['input'],
-                output: $output,
-                usage: $usage,
-                durationMs: $durationMs,
-                metadata: is_array($branch['metadata'] ?? null) ? $branch['metadata'] : [],
-                updateContext: false,
-                storeContext: false,
-                storeArtifacts: false,
-            );
-
-            $this->connection->transaction(function () use ($runId, $branch, $branchId, $token, $output, $usage, $durationMs, $step): void {
-                if (is_string($branch['node_id'] ?? null)) {
-                    $this->durableRuns->storeHierarchicalNodeOutput($runId, $branch['node_id'], $output, $this->runs->ttlSeconds());
+                if (! $agent instanceof Agent) {
+                    throw new SwarmException("Durable branch agent [{$branch['agent_class']}] must resolve to a Laravel AI agent.");
                 }
 
-                $this->persistBranchStepArtifacts($runId, $step);
-                $this->durableRuns->markBranchCompleted($runId, $branchId, $token, $output, $usage, $durationMs);
-            });
-        } catch (LostDurableLeaseException|LostSwarmLeaseException) {
-            return;
-        } catch (Throwable $exception) {
-            $retry = $this->retryHandler->scheduleBranchRetryIfAllowed($run, $branch, $swarm, $context, $token, $exception);
-            if ($retry['scheduled']) {
-                return;
-            }
+                $this->durableRuns->markBranchRunning($runId, $branchId, $token);
 
-            // Branch is terminally failing — log before marking failed so the
-            // exception is visible in application logs even though this code
-            // path never rethrows (silent failure was the v0.3 / v0.4.0
-            // behavior; see issue #1).
-            $this->logger->error('Durable swarm branch failed — retries exhausted or non-retryable.', [
-                'run_id' => $runId,
-                'branch_id' => $branchId,
-                'agent_class' => (string) $branch['agent_class'],
-                'retry_attempt' => (int) ($branch['retry_attempt'] ?? 0),
-                'exception' => $exception::class,
-                'message' => $exception->getMessage(),
-            ]);
-
-            try {
-                $this->durableRuns->markBranchFailed($runId, $branchId, $token, [
-                    'message' => $this->capture->failureMessage($exception),
-                    'class' => $exception::class,
-                ]);
-            } catch (LostDurableLeaseException|LostSwarmLeaseException) {
-                return;
-            }
-
-            if ($this->branches->parallelFailurePolicy($context) === DurableParallelFailurePolicy::FailRun) {
-                $this->hierarchical->failWaitingParentFromBranches(
-                    $run,
-                    $context,
-                    $stepLeaseSeconds,
-                    function (array $freshRun, string $freshToken, RunContext $context, int $stepLeaseSeconds, ?string $parentNodeId): void {
-                        $this->terminal->failCurrentRunFromBranchFailures($freshRun, $freshToken, $context, $stepLeaseSeconds, $parentNodeId);
-                    },
+                $timeoutSeconds = max((int) ceil((Carbon::parse($run['timeout_at'], 'UTC')->diffInSeconds(now('UTC'), false)) * -1), 1);
+                $state = new SwarmExecutionState(
+                    swarm: $swarm,
+                    topology: Topology::from($run['topology']),
+                    executionMode: ExecutionMode::Durable,
+                    deadlineMonotonic: hrtime(true) + ($timeoutSeconds * 1_000_000_000),
+                    maxAgentExecutions: (int) $run['total_steps'],
+                    ttlSeconds: $this->runs->ttlSeconds(),
+                    leaseSeconds: null,
+                    executionToken: null,
+                    verifyOwnership: fn (): null => $this->durableRuns->assertBranchOwned($runId, $branchId, $token),
+                    context: $context,
+                    contextStore: $this->contextStore,
+                    artifactRepository: $this->artifactRepository,
+                    historyStore: $this->historyStore,
+                    events: $this->events,
+                    queueHierarchicalParallelCoordination: null,
                 );
-            }
-        } finally {
-            // Restore the live SwarmMemory binding even if we returned from a
-            // catch block above. The replay decorator only ever covers one
-            // agent invocation; leaving it bound after the advancer exits
-            // would poison subsequent resolutions on this worker.
-            if ($originalMemory !== null) {
-                $this->application->instance(SwarmMemory::class, $originalMemory);
-            }
-        }
 
-        $run = $this->runs->requireRun($runId);
-        $this->hierarchical->dispatchWaitingBoundary($run, false);
+                $startedAt = MonotonicTime::now();
+                $step = null;
+
+                try {
+                    $this->stepsRecorder->started($state, (int) $branch['step_index'], $branch['agent_class'], $branch['input']);
+
+                    // On the fresh-execution path we freeze a new snapshot from live
+                    // memory. On the replay path the snapshot already exists; we keep
+                    // its frozen entries (the determinism guarantee) but clear the
+                    // partial tool-call record so this attempt can rebuild it. Both
+                    // paths converge on an unfrozen MemorySnapshot we can append to.
+                    /** @var MemorySnapshot $snapshot */
+                    $snapshot = $existing !== null
+                        ? $this->snapshots->resetToolCalls($existing)
+                        : $this->snapshots->snapshot($runId, (int) $branch['step_index']);
+
+                    $response = $agent->prompt($branch['input']);
+                    $output = (string) $response;
+                    $usage = $response->usage->toArray();
+                    $durationMs = MonotonicTime::elapsedMilliseconds($startedAt);
+
+                    foreach (SnapshotToolCallNormalizer::fromResponse($response) as $toolCall) {
+                        $snapshot = $this->snapshots->appendToolCall($snapshot, $toolCall);
+                    }
+                    $this->guardrails->validateStep(
+                        $swarm,
+                        GuardrailStepContext::fromState(
+                            $state,
+                            (int) $branch['step_index'],
+                            $branch['agent_class'],
+                            $branch['input'],
+                            $output,
+                            is_array($branch['metadata'] ?? null) ? $branch['metadata'] : [],
+                        ),
+                        $state->context,
+                    );
+                    $step = $this->stepsRecorder->completed(
+                        state: $state,
+                        index: (int) $branch['step_index'],
+                        agentClass: $branch['agent_class'],
+                        input: $branch['input'],
+                        output: $output,
+                        usage: $usage,
+                        durationMs: $durationMs,
+                        metadata: is_array($branch['metadata'] ?? null) ? $branch['metadata'] : [],
+                        updateContext: false,
+                        storeContext: false,
+                        storeArtifacts: false,
+                    );
+
+                    $this->connection->transaction(function () use ($runId, $branch, $branchId, $token, $output, $usage, $durationMs, $step): void {
+                        if (is_string($branch['node_id'] ?? null)) {
+                            $this->durableRuns->storeHierarchicalNodeOutput($runId, $branch['node_id'], $output, $this->runs->ttlSeconds());
+                        }
+
+                        $this->persistBranchStepArtifacts($runId, $step);
+                        $this->durableRuns->markBranchCompleted($runId, $branchId, $token, $output, $usage, $durationMs);
+                    });
+                } catch (LostDurableLeaseException|LostSwarmLeaseException) {
+                    return false;
+                } catch (Throwable $exception) {
+                    $retry = $this->retryHandler->scheduleBranchRetryIfAllowed($run, $branch, $swarm, $context, $token, $exception);
+                    if ($retry['scheduled']) {
+                        return false;
+                    }
+
+                    // Branch is terminally failing — log before marking failed so the
+                    // exception is visible in application logs even though this code
+                    // path never rethrows (silent failure was the v0.3 / v0.4.0
+                    // behavior; see issue #1).
+                    $this->logger->error('Durable swarm branch failed — retries exhausted or non-retryable.', [
+                        'run_id' => $runId,
+                        'branch_id' => $branchId,
+                        'agent_class' => (string) $branch['agent_class'],
+                        'retry_attempt' => (int) ($branch['retry_attempt'] ?? 0),
+                        'exception' => $exception::class,
+                        'message' => $exception->getMessage(),
+                    ]);
+
+                    try {
+                        $this->durableRuns->markBranchFailed($runId, $branchId, $token, [
+                            'message' => $this->capture->failureMessage($exception),
+                            'class' => $exception::class,
+                        ]);
+                    } catch (LostDurableLeaseException|LostSwarmLeaseException) {
+                        return false;
+                    }
+
+                    if ($this->branches->parallelFailurePolicy($context) === DurableParallelFailurePolicy::FailRun) {
+                        $this->hierarchical->failWaitingParentFromBranches(
+                            $run,
+                            $context,
+                            $stepLeaseSeconds,
+                            function (array $freshRun, string $freshToken, RunContext $context, int $stepLeaseSeconds, ?string $parentNodeId): void {
+                                $this->terminal->failCurrentRunFromBranchFailures($freshRun, $freshToken, $context, $stepLeaseSeconds, $parentNodeId);
+                            },
+                        );
+                    }
+                }
+
+                return true;
+            },
+        );
+
+        if ($shouldDispatch) {
+            $run = $this->runs->requireRun($runId);
+            $this->hierarchical->dispatchWaitingBoundary($run, false);
+        }
     }
 
     protected function persistBranchStepArtifacts(string $runId, ?SwarmStep $step): void

--- a/src/Runners/Durable/DurableHierarchicalCoordinator.php
+++ b/src/Runners/Durable/DurableHierarchicalCoordinator.php
@@ -11,6 +11,8 @@ use BuiltByBerry\LaravelSwarm\Contracts\Swarm;
 use BuiltByBerry\LaravelSwarm\Enums\CoordinationProfile;
 use BuiltByBerry\LaravelSwarm\Enums\DurableParallelFailurePolicy;
 use BuiltByBerry\LaravelSwarm\Exceptions\SwarmException;
+use BuiltByBerry\LaravelSwarm\Memory\MemoryReplayCoordinator;
+use BuiltByBerry\LaravelSwarm\Memory\MemorySnapshot;
 use BuiltByBerry\LaravelSwarm\Persistence\DatabaseRunHistoryStore;
 use BuiltByBerry\LaravelSwarm\Runners\DurableHierarchicalStepResult;
 use BuiltByBerry\LaravelSwarm\Runners\HierarchicalRunner;
@@ -37,6 +39,7 @@ class DurableHierarchicalCoordinator
         protected DurableBranchCoordinator $branches,
         protected HierarchicalRunner $hierarchical,
         protected DurableOutbox $outbox,
+        protected MemoryReplayCoordinator $coordinator,
     ) {}
 
     /**
@@ -50,7 +53,13 @@ class DurableHierarchicalCoordinator
             return null;
         }
 
-        return $this->hierarchical->runDurableStep($state, $expectedStepIndex, $run);
+        /** @var DurableHierarchicalStepResult */
+        return $this->coordinator->during(
+            $state->swarm::class,
+            $state->context->runId,
+            $expectedStepIndex,
+            fn (?MemorySnapshot $existing) => $this->hierarchical->runDurableStep($state, $expectedStepIndex, $run),
+        );
     }
 
     /**

--- a/src/Runners/Durable/DurableManagerCollaboratorFactory.php
+++ b/src/Runners/Durable/DurableManagerCollaboratorFactory.php
@@ -8,6 +8,7 @@ use BuiltByBerry\LaravelSwarm\Contracts\ArtifactRepository;
 use BuiltByBerry\LaravelSwarm\Contracts\ContextStore;
 use BuiltByBerry\LaravelSwarm\Contracts\DurableOutbox;
 use BuiltByBerry\LaravelSwarm\Contracts\DurableRunStore;
+use BuiltByBerry\LaravelSwarm\Memory\MemoryReplayCoordinator;
 use BuiltByBerry\LaravelSwarm\Persistence\DatabaseRunHistoryStore;
 use BuiltByBerry\LaravelSwarm\Runners\DurableRunRecorder;
 use BuiltByBerry\LaravelSwarm\Runners\HierarchicalRunner;
@@ -173,6 +174,7 @@ class DurableManagerCollaboratorFactory
             'jobs' => $jobs,
             'children' => $children,
         ]);
+        $memoryReplayCoordinator = $this->application->make(MemoryReplayCoordinator::class);
         $hierarchical = $this->application->makeWith(DurableHierarchicalCoordinator::class, [
             'durableRuns' => $durableRuns,
             'historyStore' => $historyStore,
@@ -184,6 +186,7 @@ class DurableManagerCollaboratorFactory
             'branches' => $branches,
             'hierarchical' => $hierarchicalRunner,
             'outbox' => $outbox,
+            'coordinator' => $memoryReplayCoordinator,
         ]);
         $terminal = $this->application->makeWith(DurableRunTerminalHandler::class, [
             'durableRuns' => $durableRuns,
@@ -220,6 +223,7 @@ class DurableManagerCollaboratorFactory
         ]);
         $sequentialAdvancer = $this->application->makeWith(DurableSequentialStepAdvancer::class, [
             'sequential' => $sequential,
+            'coordinator' => $memoryReplayCoordinator,
         ]);
         $checkpointCoordinator = $this->application->makeWith(DurableStepCheckpointCoordinator::class, [
             'durableRuns' => $durableRuns,
@@ -254,6 +258,7 @@ class DurableManagerCollaboratorFactory
             'retryHandler' => $retryHandler,
             'outbox' => $outbox,
             'terminal' => $terminal,
+            'coordinator' => $memoryReplayCoordinator,
         ]);
 
         return new DurableManagerCollaborators(

--- a/src/Runners/Durable/DurableSequentialStepAdvancer.php
+++ b/src/Runners/Durable/DurableSequentialStepAdvancer.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Runners\Durable;
 
+use BuiltByBerry\LaravelSwarm\Memory\MemoryReplayCoordinator;
+use BuiltByBerry\LaravelSwarm\Memory\MemorySnapshot;
 use BuiltByBerry\LaravelSwarm\Responses\SwarmStep;
 use BuiltByBerry\LaravelSwarm\Runners\SequentialRunner;
 use BuiltByBerry\LaravelSwarm\Support\SwarmExecutionState;
@@ -15,10 +17,17 @@ class DurableSequentialStepAdvancer
 {
     public function __construct(
         protected SequentialRunner $sequential,
+        protected MemoryReplayCoordinator $coordinator,
     ) {}
 
     public function advance(SwarmExecutionState $state, int $expectedStepIndex): SwarmStep
     {
-        return $this->sequential->runSingleStep($state, $expectedStepIndex);
+        /** @var SwarmStep */
+        return $this->coordinator->during(
+            $state->swarm::class,
+            $state->context->runId,
+            $expectedStepIndex,
+            fn (?MemorySnapshot $existing) => $this->sequential->runSingleStep($state, $expectedStepIndex),
+        );
     }
 }

--- a/tests/Unit/Memory/MemoryReplayCoordinatorTest.php
+++ b/tests/Unit/Memory/MemoryReplayCoordinatorTest.php
@@ -1,0 +1,272 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Attributes\MemoryReplay;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmMemory;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Enums\ReplayMode;
+use BuiltByBerry\LaravelSwarm\Memory\DefaultSwarmMemory;
+use BuiltByBerry\LaravelSwarm\Memory\MemoryReplayCoordinator;
+use BuiltByBerry\LaravelSwarm\Memory\MemorySnapshot;
+use BuiltByBerry\LaravelSwarm\Memory\ReplaySwarmMemory;
+use BuiltByBerry\LaravelSwarm\Tests\Support\InMemoryMemoryStore;
+use BuiltByBerry\LaravelSwarm\Tests\Support\RecordingSnapshotsMemory;
+use Illuminate\Events\Dispatcher;
+
+/**
+ * Unit tests for {@see MemoryReplayCoordinator}.
+ *
+ * Verifies the three guarantees the coordinator provides:
+ *
+ * 1. Fresh execution (no existing snapshot) — callback is invoked with `null`,
+ *    no container binding swap occurs.
+ * 2. Replay (existing snapshot found) — container SwarmMemory is swapped to a
+ *    ReplaySwarmMemory for the callback duration, then restored in finally.
+ * 3. FreshExecution mode (via attribute or config) — callback is invoked with
+ *    `null` regardless of whether a snapshot exists.
+ */
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCoordinator(RecordingSnapshotsMemory $snapshots): MemoryReplayCoordinator
+{
+    return new MemoryReplayCoordinator(
+        snapshots: $snapshots,
+        application: app(),
+        events: app(Dispatcher::class),
+    );
+}
+
+/**
+ * @param  array<int, array{scope: string, scope_id: string, key: string, value: mixed, metadata: array<string, mixed>}>  $entries
+ */
+function preloadSnapshot(RecordingSnapshotsMemory $snapshots, string $runId, int $stepIndex, array $entries = []): MemorySnapshot
+{
+    // fromPersisted() requires created_at/updated_at in each entry row.
+    $normalized = array_map(
+        fn (array $e): array => $e + ['created_at' => null, 'updated_at' => null],
+        $entries,
+    );
+
+    $snapshot = MemorySnapshot::fromPersisted(
+        ['run_id' => $runId, 'step_index' => $stepIndex, 'entries' => $normalized],
+        [],
+    );
+    $snapshots->preload($snapshot);
+
+    return $snapshot;
+}
+
+beforeEach(function () {
+    // Bind a live SwarmMemory into the container so the coordinator can capture
+    // and restore it.
+    $this->app->singleton(SwarmMemory::class, fn () => new DefaultSwarmMemory(new InMemoryMemoryStore));
+    $this->liveMemory = $this->app->make(SwarmMemory::class);
+});
+
+// ---------------------------------------------------------------------------
+// Fresh execution (no existing snapshot)
+// ---------------------------------------------------------------------------
+
+test('callback is called with null when no existing snapshot is found', function () {
+    $snapshots = new RecordingSnapshotsMemory;
+    $coordinator = makeCoordinator($snapshots);
+
+    $received = 'not-set';
+    $coordinator->during('stdClass', 'run-1', 0, function (?MemorySnapshot $s) use (&$received) {
+        $received = $s;
+    });
+
+    expect($received)->toBeNull();
+});
+
+test('SwarmMemory binding is unchanged on fresh execution', function () {
+    $snapshots = new RecordingSnapshotsMemory;
+    $coordinator = makeCoordinator($snapshots);
+
+    $seenInCallback = null;
+    $coordinator->during('stdClass', 'run-1', 0, function () use (&$seenInCallback) {
+        $seenInCallback = app(SwarmMemory::class);
+    });
+
+    expect($seenInCallback)->toBeInstanceOf(DefaultSwarmMemory::class);
+});
+
+test('coordinator returns the callback return value on fresh execution', function () {
+    $snapshots = new RecordingSnapshotsMemory;
+    $coordinator = makeCoordinator($snapshots);
+
+    $result = $coordinator->during('stdClass', 'run-1', 0, fn () => 'fresh-result');
+
+    expect($result)->toBe('fresh-result');
+});
+
+// ---------------------------------------------------------------------------
+// Replay — binding swap
+// ---------------------------------------------------------------------------
+
+test('callback is called with existing snapshot when a prior attempt is found', function () {
+    $snapshots = new RecordingSnapshotsMemory;
+    $frozen = preloadSnapshot($snapshots, 'run-1', 3);
+    $coordinator = makeCoordinator($snapshots);
+
+    $received = 'not-set';
+    $coordinator->during('stdClass', 'run-1', 3, function (?MemorySnapshot $s) use (&$received) {
+        $received = $s;
+    });
+
+    expect($received)->toBe($frozen);
+});
+
+test('SwarmMemory binding is swapped to ReplaySwarmMemory during the callback on replay', function () {
+    $snapshots = new RecordingSnapshotsMemory;
+    preloadSnapshot($snapshots, 'run-1', 0, [
+        ['scope' => 'run', 'scope_id' => 'run-1', 'key' => 'frozen_key', 'value' => 'frozen_value', 'metadata' => []],
+    ]);
+    $coordinator = makeCoordinator($snapshots);
+
+    $seenInCallback = null;
+    $coordinator->during('stdClass', 'run-1', 0, function () use (&$seenInCallback) {
+        $seenInCallback = app(SwarmMemory::class);
+    });
+
+    expect($seenInCallback)->toBeInstanceOf(ReplaySwarmMemory::class);
+});
+
+test('ReplaySwarmMemory during callback serves frozen values, not live store', function () {
+    $store = new InMemoryMemoryStore;
+    $live = new DefaultSwarmMemory($store);
+    $this->app->instance(SwarmMemory::class, $live);
+
+    // Drift live store past the snapshot.
+    $live->put(MemoryScope::Run, 'run-1', 'key', 'live-drifted');
+
+    $snapshots = new RecordingSnapshotsMemory;
+    preloadSnapshot($snapshots, 'run-1', 0, [
+        ['scope' => 'run', 'scope_id' => 'run-1', 'key' => 'key', 'value' => 'frozen-value', 'metadata' => []],
+    ]);
+    $coordinator = makeCoordinator($snapshots);
+
+    $seenValue = null;
+    $coordinator->during('stdClass', 'run-1', 0, function () use (&$seenValue) {
+        $seenValue = app(SwarmMemory::class)->get(MemoryScope::Run, 'run-1', 'key');
+    });
+
+    expect($seenValue)->toBe('frozen-value');
+});
+
+test('original SwarmMemory binding is restored after the callback completes', function () {
+    $snapshots = new RecordingSnapshotsMemory;
+    preloadSnapshot($snapshots, 'run-1', 0);
+    $coordinator = makeCoordinator($snapshots);
+
+    $coordinator->during('stdClass', 'run-1', 0, fn () => null);
+
+    expect(app(SwarmMemory::class))->toBeInstanceOf(DefaultSwarmMemory::class);
+});
+
+test('original SwarmMemory binding is restored even when the callback throws', function () {
+    $snapshots = new RecordingSnapshotsMemory;
+    preloadSnapshot($snapshots, 'run-1', 0);
+    $coordinator = makeCoordinator($snapshots);
+
+    try {
+        $coordinator->during('stdClass', 'run-1', 0, fn () => throw new RuntimeException('boom'));
+    } catch (RuntimeException) {
+        // expected
+    }
+
+    expect(app(SwarmMemory::class))->toBeInstanceOf(DefaultSwarmMemory::class);
+});
+
+test('coordinator returns the callback return value on replay', function () {
+    $snapshots = new RecordingSnapshotsMemory;
+    preloadSnapshot($snapshots, 'run-1', 0);
+    $coordinator = makeCoordinator($snapshots);
+
+    $result = $coordinator->during('stdClass', 'run-1', 0, fn () => 'replay-result');
+
+    expect($result)->toBe('replay-result');
+});
+
+// ---------------------------------------------------------------------------
+// FreshExecution mode — via config
+// ---------------------------------------------------------------------------
+
+test('config fresh_execution bypasses the snapshot check and invokes callback with null', function () {
+    config(['swarm.memory.replay_mode' => ReplayMode::FreshExecution->value]);
+
+    $snapshots = new RecordingSnapshotsMemory;
+    preloadSnapshot($snapshots, 'run-1', 0); // a snapshot exists — should be ignored
+
+    $coordinator = makeCoordinator($snapshots);
+
+    $received = 'not-set';
+    $coordinator->during('stdClass', 'run-1', 0, function (?MemorySnapshot $s) use (&$received) {
+        $received = $s;
+    });
+
+    expect($received)->toBeNull();
+});
+
+test('config fresh_execution leaves the SwarmMemory binding untouched', function () {
+    config(['swarm.memory.replay_mode' => ReplayMode::FreshExecution->value]);
+
+    $snapshots = new RecordingSnapshotsMemory;
+    preloadSnapshot($snapshots, 'run-1', 0);
+
+    $coordinator = makeCoordinator($snapshots);
+
+    $seenInCallback = null;
+    $coordinator->during('stdClass', 'run-1', 0, function () use (&$seenInCallback) {
+        $seenInCallback = app(SwarmMemory::class);
+    });
+
+    expect($seenInCallback)->toBeInstanceOf(DefaultSwarmMemory::class);
+});
+
+// ---------------------------------------------------------------------------
+// FreshExecution mode — via #[MemoryReplay] attribute (wins over config)
+// ---------------------------------------------------------------------------
+
+test('MemoryReplay attribute with FreshExecution wins over frozen_view config', function () {
+    config(['swarm.memory.replay_mode' => ReplayMode::FrozenView->value]); // config says frozen
+
+    $snapshots = new RecordingSnapshotsMemory;
+    preloadSnapshot($snapshots, 'run-1', 0);
+
+    $coordinator = makeCoordinator($snapshots);
+
+    // Anonymous class with the attribute.
+    $swarmClass = new #[MemoryReplay(mode: ReplayMode::FreshExecution)] class {};
+
+    $seenInCallback = null;
+    $coordinator->during($swarmClass::class, 'run-1', 0, function () use (&$seenInCallback) {
+        $seenInCallback = app(SwarmMemory::class);
+    });
+
+    // Attribute wins — no binding swap despite frozen_view config.
+    expect($seenInCallback)->toBeInstanceOf(DefaultSwarmMemory::class);
+});
+
+test('MemoryReplay attribute with FrozenView wins over fresh_execution config', function () {
+    config(['swarm.memory.replay_mode' => ReplayMode::FreshExecution->value]); // config says fresh
+
+    $snapshots = new RecordingSnapshotsMemory;
+    preloadSnapshot($snapshots, 'run-1', 0);
+
+    $coordinator = makeCoordinator($snapshots);
+
+    $swarmClass = new #[MemoryReplay(mode: ReplayMode::FrozenView)] class {};
+
+    $seenInCallback = null;
+    $coordinator->during($swarmClass::class, 'run-1', 0, function () use (&$seenInCallback) {
+        $seenInCallback = app(SwarmMemory::class);
+    });
+
+    // Attribute wins — binding IS swapped despite fresh_execution config.
+    expect($seenInCallback)->toBeInstanceOf(ReplaySwarmMemory::class);
+});


### PR DESCRIPTION
## Summary

- Introduces `MemoryReplayCoordinator` — a narrow service that wraps a durable agent invocation with the snapshot-backed memory lifecycle, swapping `SwarmMemory` to a `ReplaySwarmMemory` on crash-resume and restoring it in `finally` regardless of the outcome
- Extends the frozen-snapshot replay guarantee (first landed for parallel branches in #143) to **sequential** (`DurableSequentialStepAdvancer`) and **hierarchical** (`DurableHierarchicalCoordinator::runStep()`) durable topologies — all three paths now share one coordinator rather than duplicating inline find/swap/restore
- Refactors `DurableBranchAdvancer` to use the same coordinator, eliminating the previous inline logic and closing a subtle exception-safety gap (binding restoration was previously unguarded for exceptions thrown before the `try` block)
- Ships `ReplayMode` enum + `#[MemoryReplay]` attribute for per-swarm override of the `swarm.memory.replay_mode` config key (`frozen_view` | `fresh_execution`)

## Commits

| Commit | Description |
|--------|-------------|
| `c2fb94c` | Introduce `MemoryReplayCoordinator` with `ReplayMode`, `MemoryReplay` attribute, config key, 13 unit tests |
| `4376b90` | Wire sequential + hierarchical durable paths through coordinator; refactor `DurableBranchAdvancer` |

## Test plan

- [x] 13 new unit tests in `tests/Unit/Memory/MemoryReplayCoordinatorTest.php` covering fresh-execution, replay binding swap, binding restoration (normal + exception paths), and attribute/config mode selection
- [x] Full test suite: **1095 passed, 0 failures**
- [x] PHPStan level 7: no errors across all changed files
- [x] Laravel Pint: no style violations

Closes #142