### PR TITLE
docs(memory): introduce the Swarm Memory model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,13 @@ Memory Foundation — first-class scoped, snapshot-replayable memory subsystem w
 
 ### Added
 
-_To be filled in during release wrap-up._
+_Feature entries to be filled in during release wrap-up._
+
+- **`docs/memory.md` — Swarm Memory keystone reference (#116).**
 
 ### Changed
 
-_To be filled in during release wrap-up._
-
-### Documentation
-
-- **`docs/memory.md` — Swarm Memory keystone reference (#116).** New page covering the full memory subsystem: four-scope hierarchy (Run / Conversation / Agent / Swarm), `SwarmMemory` contract read/write API with examples, `MemoryEntry` and `MemoryScope` value object reference, store drivers (`DatabaseMemoryStore` / `CacheMemoryStore` / custom), all five lifecycle events (`MemoryWritten`, `MemoryRead`, `MemoryForgotten`, `MemorySnapshotted`, `MemoryScopeOutOfSnapshot`) with listener examples, snapshot mechanism and `MemorySnapshot` value object, replay semantics (`frozen_view` vs `fresh_execution`) including the `#[MemoryReplay]` per-swarm attribute, the binding-restore constraint on `MemoryReplayCoordinator::during()`, and the RunContext ArrayAccess write-through bridge. Cross-linked from `README.md`, `docs/README.md`, `docs/getting-started.md`, and `docs/advanced-setup.md`.
+_To be filled in during release wrap-up._ New page covering the full memory subsystem: four-scope hierarchy (Run / Conversation / Agent / Swarm), `SwarmMemory` contract read/write API with examples, `MemoryEntry` and `MemoryScope` value object reference, store drivers (`DatabaseMemoryStore` / `CacheMemoryStore` / custom), all five lifecycle events (`MemoryWritten`, `MemoryRead`, `MemoryForgotten`, `MemorySnapshotted`, `MemoryScopeOutOfSnapshot`) with listener examples, snapshot mechanism and `MemorySnapshot` value object, replay semantics (`frozen_view` vs `fresh_execution`) including the `#[MemoryReplay]` per-swarm attribute, the binding-restore constraint on `MemoryReplayCoordinator::during()`, and the RunContext ArrayAccess write-through bridge. Cross-linked from `README.md`, `docs/README.md`, `docs/getting-started.md`, and `docs/advanced-setup.md`.
 
 ## v0.8.0 - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ _To be filled in during release wrap-up._
 
 _To be filled in during release wrap-up._
 
+### Documentation
+
+- **`docs/memory.md` — Swarm Memory keystone reference (#116).** New page covering the full memory subsystem: four-scope hierarchy (Run / Conversation / Agent / Swarm), `SwarmMemory` contract read/write API with examples, `MemoryEntry` and `MemoryScope` value object reference, store drivers (`DatabaseMemoryStore` / `CacheMemoryStore` / custom), all five lifecycle events (`MemoryWritten`, `MemoryRead`, `MemoryForgotten`, `MemorySnapshotted`, `MemoryScopeOutOfSnapshot`) with listener examples, snapshot mechanism and `MemorySnapshot` value object, replay semantics (`frozen_view` vs `fresh_execution`) including the `#[MemoryReplay]` per-swarm attribute, the binding-restore constraint on `MemoryReplayCoordinator::during()`, and the RunContext ArrayAccess write-through bridge. Cross-linked from `README.md`, `docs/README.md`, `docs/getting-started.md`, and `docs/advanced-setup.md`.
+
 ## v0.8.0 - 2026-05-21
 
 One-command install. A new `swarm:install` orchestrator plus four targeted sub-installers (`swarm:install:durable`, `swarm:install:audit`, `swarm:install:pulse`, `swarm:install:examples`) cut the read-the-docs-and-hand-wire-five-things ritual down to a single Artisan command, and a curated runnable starter example pack ships so a fresh Laravel app is up and dispatching swarms inside a minute. New concrete `LogChannelSwarmAuditSink` (the zero-config dev/staging sink the audit installer binds), new `BuiltByBerry\LaravelSwarm\Testing\ScriptedAgent` provider-free agent base class (the starter examples extend it; `make:swarm:agent` scaffolds it), and a polished `make:swarm:swarm` + `make:swarm:agent` generator pair with topology-aware stubs that match the starter pack. The legacy `make:swarm` keeps working as a deprecated alias. Getting Started and Advanced Setup docs rewritten around the new install flow. No migration changes. No breaking changes.

--- a/README.md
+++ b/README.md
@@ -333,6 +333,23 @@ Schedule::command('swarm:prune')->daily();         // retention: removes expired
 
 Start with [Durable Execution](docs/durable-execution.md), then use the topic guides for [waits and signals](docs/durable-waits-and-signals.md), [retries and progress](docs/durable-retries-and-progress.md), [child swarms](docs/durable-child-swarms.md), and [webhooks](docs/durable-webhooks.md).
 
+## Memory (v0.9.0+)
+
+Swarm Memory is a first-class, scoped, snapshot-replayable memory subsystem. It gives agents and application code a place to read and write structured values that persist across steps, survive queue boundaries, and can be replayed deterministically from a frozen snapshot on a crash-resume.
+
+```php
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmMemory;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+
+$memory = app(SwarmMemory::class);
+$memory->put(MemoryScope::Run, $runId, 'draft_approved', true);
+$approved = $memory->get(MemoryScope::Run, $runId, 'draft_approved');
+```
+
+`RunContext` writes through to `MemoryScope::Run` automatically via its `ArrayAccess` interface — `$context['key'] = $value` mirrors to memory without any code change.
+
+See [Swarm Memory](docs/memory.md) for the full reference: scope hierarchy, store drivers, lifecycle events, snapshot inspection, replay semantics (`frozen_view` vs `fresh_execution`), and the `#[MemoryReplay]` attribute. Vector-backed recall ships as the [laravel-swarm-memory-vector](https://github.com/builtbyberry/laravel-swarm-memory-vector) companion package.
+
 ## Topologies
 
 Laravel Swarm supports four topologies.

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,12 @@ The recommended reading path for new users.
 
 ---
 
+## Memory
+
+- [Swarm Memory](memory.md) — scoped, snapshot-replayable memory subsystem; read/write, lifecycle events, replay semantics, and the RunContext bridge (v0.9.0+)
+
+---
+
 ## Reliability & Safety
 
 - [Guardrails](guardrails.md) — input, step, and output validation; child inheritance

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -354,6 +354,8 @@ underlying tables are unavailable by design.
   operational hygiene.
 - [Durable Execution](./durable-execution.md) — checkpointing, the relay,
   recovery, and operator controls.
+- [Swarm Memory](./memory.md) — scoped, snapshot-replayable memory; run,
+  conversation, agent, and swarm scopes with replay semantics. (v0.9.0+)
 - [Audit Evidence Contract](./audit-evidence-contract.md) — the full
   audit contract surface and regulated-deployment extension points.
 - [Pulse](./pulse.md) — recorders, cards, and aggregate observability.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -273,6 +273,28 @@ Controls the audit evidence sink. Bind `SwarmAuditSink` in your service containe
 
 ---
 
+## Memory
+
+Controls the memory subsystem introduced in v0.9.0. Memory stores scoped values (Run, Conversation, Agent, and Swarm scopes) and captures per-step snapshots for deterministic crash-resume replay. See [Swarm Memory](memory.md) for the full subsystem reference.
+
+| Key | Type | Default | Env Var | Description |
+|-----|------|---------|---------|-------------|
+| `swarm.memory.replay_mode` | string | `frozen_view` | `SWARM_MEMORY_REPLAY_MODE` | Controls what memory a durable agent sees when a step is retried after a crash. `frozen_view` — the agent re-executes against the `MemoryScope::Run` entries frozen in the snapshot taken at the original invocation; live writes during the retry are buffered and never reach the backing store. `fresh_execution` — the agent re-executes against live memory with no snapshot guard; use only when idempotency is guaranteed externally. Override per swarm class with the `#[MemoryReplay]` attribute. |
+
+```ini
+# .env — override the global default
+SWARM_MEMORY_REPLAY_MODE=frozen_view
+```
+
+```php
+// config/swarm.php
+'memory' => [
+    'replay_mode' => env('SWARM_MEMORY_REPLAY_MODE', 'frozen_view'),
+],
+```
+
+---
+
 ## Tables
 
 Table name overrides for all database-backed stores. If you change these, publish and update the package migrations as well.

--- a/docs/events.md
+++ b/docs/events.md
@@ -496,6 +496,28 @@ Event::listen(SwarmChildFailed::class, function (SwarmChildFailed $event): void 
 
 ---
 
+## Memory Events
+
+Swarm Memory dispatches five events through Laravel's event system when memory operations occur. All five are dispatched at the **store layer** — they fire from `DatabaseMemoryStore` and `CacheMemoryStore` directly, so custom `MemoryStore` drivers must dispatch them from their own `put()`, `get()`, and `forget()` implementations to keep the listener contract uniform.
+
+| Event | Full class | When | Key properties |
+| --- | --- | --- | --- |
+| `MemoryWritten` | `BuiltByBerry\LaravelSwarm\Events\Memory\MemoryWritten` | After a successful `put()` | `scope`, `scopeId`, `key`, `metadata` |
+| `MemoryRead` | `BuiltByBerry\LaravelSwarm\Events\Memory\MemoryRead` | After every `get()`, hit or miss | `scope`, `scopeId`, `key` |
+| `MemoryForgotten` | `BuiltByBerry\LaravelSwarm\Events\Memory\MemoryForgotten` | After every `forget()` | `scope`, `scopeId`, `key`, `existed` |
+| `MemorySnapshotted` | `BuiltByBerry\LaravelSwarm\Events\Memory\MemorySnapshotted` | After a per-step snapshot is captured | `runId`, `stepIndex`, `snapshotId` |
+| `MemoryScopeOutOfSnapshot` | `BuiltByBerry\LaravelSwarm\Events\Memory\MemoryScopeOutOfSnapshot` | During replay when a read targets a non-Run scope | `runId`, `stepIndex`, `scope`, `scopeId`, `key`, `operation` |
+
+`MemoryRead` intentionally does not expose the entry value. Listeners that need the value should re-read through the store under their own access controls — this keeps the event surface compatible with capture-policy redaction in v0.10.
+
+`MemoryForgotten` includes an `existed` boolean so listeners can distinguish a real deletion from a no-op probe (a `forget()` call on a key that was never set).
+
+`MemoryScopeOutOfSnapshot` fires during `frozen_view` replay when a read targets a Conversation, Agent, or Swarm scoped entry (only Run scope is snapshotted in v0.9.0). Without a listener the read falls through to the live store; no persistent record is created by default. Wire a listener for compliance postures that require a record of every cross-scope read during replay.
+
+For full listener examples and the compliance hard-fail pattern, see [Swarm Memory](memory.md#lifecycle-events).
+
+---
+
 ## Common Patterns
 
 ### Dashboard Run Tracking

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -249,6 +249,8 @@ From here:
   installer step, for environments where the installer cannot run.
 - [Durable Execution](./durable-execution.md) — checkpointed, recoverable,
   long-running workflows.
+- [Swarm Memory](./memory.md) — scoped, snapshot-replayable memory; run,
+  conversation, agent, and swarm scopes with replay semantics. (v0.9.0+)
 - [Audit Evidence Contract](./audit-evidence-contract.md) — regulated
   evidence export with `SwarmAuditSink`.
 - [Pulse](./pulse.md) — Pulse cards for run counts, step latencies, and

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -201,7 +201,7 @@ Event::listen(MemoryScopeOutOfSnapshot::class, function (MemoryScopeOutOfSnapsho
 });
 ```
 
-Without this listener the event fires silently and the read falls through to the live store — pragmatic enough not to break agents that read shared knowledge, but the drift is recorded. Stricter compliance postures should wire this listener.
+Without this listener the event fires silently and the read falls through to the live store — pragmatic enough not to break agents that read shared knowledge, but no persistent record is created. Stricter compliance postures should wire this listener from day one; there is no passive record to fall back on.
 
 **Monitoring — track forget with deletion audit:**
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,0 +1,381 @@
+# Swarm Memory
+
+Swarm Memory is the first-class, scoped, snapshot-replayable memory subsystem shipped in v0.9.0. It gives agents and application code a place to read and write structured values that persist across steps, survive queue boundaries, and can be replayed deterministically from a frozen snapshot on a crash-resume.
+
+The primary surface is the `SwarmMemory` contract, resolved from the container or via `app(SwarmMemory::class)`. The `RunContext` object — the envelope every swarm run carries — writes through to memory automatically, so you can start using memory without any wiring change.
+
+---
+
+## Scope hierarchy
+
+Every memory entry lives in exactly one scope. The scope determines the lifetime and visibility of the entry, and pairs with a `scopeId` (the concrete run ID, conversation ID, agent class, or swarm class) to form the full address.
+
+```
+Swarm scope  ──── shared across all agents in a swarm class
+  │
+  └── Conversation scope  ──── shared across runs in the same conversation thread
+        │
+        └── Run scope  ──── bounded to a single swarm run
+              │
+              └── Agent scope  ──── per-agent-class persistent state
+```
+
+| Scope | `MemoryScope` case | `scopeId` | Lifetime |
+| --- | --- | --- | --- |
+| **Run** | `MemoryScope::Run` | The `runId` string | Cleared with the run |
+| **Conversation** | `MemoryScope::Conversation` | A conversation thread ID | Shared across runs |
+| **Agent** | `MemoryScope::Agent` | The agent class (FQCN) | Per-agent persistent state |
+| **Swarm** | `MemoryScope::Swarm` | The swarm class (FQCN) | Shared across all agents in a swarm |
+
+**v0.9.0 note:** The snapshot mechanism (see [Snapshot mechanism](#snapshot-mechanism) below) captures only `MemoryScope::Run` entries for each agent invocation. Reads against the other three scopes during replay fall through to the live store and fire a `MemoryScopeOutOfSnapshot` event.
+
+---
+
+## Reading and writing
+
+Resolve `SwarmMemory` from the container and call the value-shaped methods:
+
+```php
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmMemory;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+
+$memory = app(SwarmMemory::class);
+
+// Write a value — inserts or updates by (scope, scopeId, key)
+$entry = $memory->put(
+    MemoryScope::Run,
+    $runId,
+    'draft_approved',
+    true,
+);
+
+// Read a value — returns the raw value or null when absent
+$approved = $memory->get(MemoryScope::Run, $runId, 'draft_approved');
+
+// Read the full entry when you need metadata or timestamps
+$entry = $memory->entry(MemoryScope::Run, $runId, 'draft_approved');
+$entry?->createdAt;   // CarbonImmutable
+$entry?->updatedAt;   // CarbonImmutable
+$entry?->metadata;    // array<string, mixed>
+
+// Delete a single entry — returns true when a row was removed
+$existed = $memory->forget(MemoryScope::Run, $runId, 'draft_approved');
+
+// Retrieve every entry under a (scope, scopeId)
+$entries = $memory->all(MemoryScope::Run, $runId);
+// => array<int, MemoryEntry>
+```
+
+All four methods are covered by the `SwarmMemory` contract. Custom drivers and test doubles can implement the contract without touching any other class.
+
+### Scope-bounded query example
+
+Reading all Run-scoped entries for a completed run:
+
+```php
+$entries = app(SwarmMemory::class)->all(MemoryScope::Run, $response->context->runId);
+
+foreach ($entries as $entry) {
+    echo "{$entry->key}: " . json_encode($entry->value) . "\n";
+}
+```
+
+Reading a per-agent persistent value (knowledge that should survive across runs):
+
+```php
+$tone = app(SwarmMemory::class)->get(
+    MemoryScope::Agent,
+    WriterAgent::class,
+    'preferred_tone',
+);
+```
+
+---
+
+## Value objects
+
+### `MemoryEntry`
+
+`MemoryEntry` is the immutable value object returned by `put()`, `entry()`, and `all()`. It carries the full address plus the persisted value and metadata.
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `scope` | `MemoryScope` | The addressing scope |
+| `scopeId` | `string` | The concrete ID within the scope |
+| `key` | `string` | The entry name |
+| `value` | `mixed` | Plain data: string, int, float, bool, null, or nested arrays of those types |
+| `metadata` | `array<string, mixed>` | Implementation annotations (capture policy outcome, source, etc.) |
+| `createdAt` | `?CarbonImmutable` | Populated by the store on first write |
+| `updatedAt` | `?CarbonImmutable` | Populated by the store on every write |
+
+`value` must be plain data. The store normalizes it before persistence; non-serializable values (objects, closures, resources) are rejected.
+
+### `MemoryScope`
+
+```php
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+
+MemoryScope::Run          // 'run'
+MemoryScope::Conversation // 'conversation'
+MemoryScope::Agent        // 'agent'
+MemoryScope::Swarm        // 'swarm'
+```
+
+---
+
+## Store drivers
+
+The `MemoryStore` contract is the low-level storage driver. `SwarmMemory` delegates persistence to a bound `MemoryStore` implementation.
+
+**`DatabaseMemoryStore`** (default) — persists entries to the `swarm_memories` table introduced in v0.9.0. Survives process restarts, queue boundaries, and durable checkpoints. The recommended driver for any application that uses `queue()` or `dispatchDurable()`.
+
+**`CacheMemoryStore`** — persists entries to the Laravel cache. Suitable for synchronous `prompt()` runs in environments without a database; entries are subject to the cache TTL and are not durable.
+
+### Swapping drivers
+
+Bind a different implementation in a service provider:
+
+```php
+use BuiltByBerry\LaravelSwarm\Contracts\MemoryStore;
+use App\Memory\RedisMemoryStore;
+
+$this->app->bind(MemoryStore::class, RedisMemoryStore::class);
+```
+
+Custom drivers must implement `MemoryStore` and dispatch the [memory lifecycle events](#lifecycle-events) from their `put()`, `get()`, and `forget()` methods. The bundled drivers dispatch events unconditionally — see the dispatch-layer note in `DefaultSwarmMemory` for the rationale.
+
+### Installing the memory tables
+
+Run `php artisan swarm:install:memory` (v0.9.0+) to publish and run the `swarm_memories` and `swarm_memory_snapshots` migrations. The command follows the same sentinel-marker pattern as the other sub-installers and is safe to re-run.
+
+---
+
+## Lifecycle events
+
+Swarm Memory dispatches five events through Laravel's event system. Register listeners in `EventServiceProvider` or in a service provider closure.
+
+| Event | When | Key properties |
+| --- | --- | --- |
+| `MemoryWritten` | After a successful `put()` | `scope`, `scopeId`, `key`, `metadata` |
+| `MemoryRead` | After every `get()`, hit or miss | `scope`, `scopeId`, `key` |
+| `MemoryForgotten` | After every `forget()` | `scope`, `scopeId`, `key`, `existed` |
+| `MemorySnapshotted` | After a per-step snapshot is captured | `runId`, `stepIndex`, `snapshotId` |
+| `MemoryScopeOutOfSnapshot` | During replay when a read targets a non-Run scope | `runId`, `stepIndex`, `scope`, `scopeId`, `key`, `operation` |
+
+Events are dispatched at the **store layer**, not from the `SwarmMemory` facade. Custom `MemoryStore` drivers must dispatch them from their own `put()`, `get()`, and `forget()` implementations to keep the listener contract uniform.
+
+`MemoryRead` does not expose the entry value. Listeners that need the value should re-read through the store under their own access controls — this keeps the event surface compatible with capture-policy redaction in v0.10.
+
+### Listener examples
+
+**Audit trail — log every Run-scoped write:**
+
+```php
+use BuiltByBerry\LaravelSwarm\Events\Memory\MemoryWritten;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+
+Event::listen(MemoryWritten::class, function (MemoryWritten $event): void {
+    if ($event->scope !== MemoryScope::Run) {
+        return;
+    }
+
+    logger()->info('Memory written', [
+        'scope'    => $event->scope->value,
+        'scope_id' => $event->scopeId,
+        'key'      => $event->key,
+    ]);
+});
+```
+
+**Compliance — hard-fail on out-of-snapshot cross-scope reads during replay:**
+
+```php
+use BuiltByBerry\LaravelSwarm\Events\Memory\MemoryScopeOutOfSnapshot;
+use BuiltByBerry\LaravelSwarm\Exceptions\SwarmException;
+
+Event::listen(MemoryScopeOutOfSnapshot::class, function (MemoryScopeOutOfSnapshot $event): void {
+    throw new SwarmException(
+        "Replay determinism violation: {$event->operation} on {$event->scope->value} scope "
+        . "at step {$event->stepIndex} of run {$event->runId}."
+    );
+});
+```
+
+Without this listener the event fires silently and the read falls through to the live store — pragmatic enough not to break agents that read shared knowledge, but the drift is recorded. Stricter compliance postures should wire this listener.
+
+**Monitoring — track forget with deletion audit:**
+
+```php
+use BuiltByBerry\LaravelSwarm\Events\Memory\MemoryForgotten;
+
+Event::listen(MemoryForgotten::class, function (MemoryForgotten $event): void {
+    if (! $event->existed) {
+        return; // no-op probe — ignore for audit purposes
+    }
+
+    logger()->warning('Memory entry deleted', [
+        'scope'    => $event->scope->value,
+        'scope_id' => $event->scopeId,
+        'key'      => $event->key,
+    ]);
+});
+```
+
+---
+
+## Snapshot mechanism
+
+Before every agent invocation, each runner (sequential, parallel, hierarchical, and durable branch) freezes the agent-visible memory view by calling `SnapshotsMemory::snapshot()`. The result — a `MemorySnapshot` — is persisted to the `swarm_memory_snapshots` table keyed by `(run_id, step_index)`.
+
+The snapshot captures:
+
+- **`entries`** — every `MemoryScope::Run` entry visible at the moment of invocation, byte-identical to what the agent saw.
+- **`toolCalls`** — input/output pairs for every tool the agent called during the invocation. Appended in real time by the runner after each tool call completes.
+
+### `MemorySnapshot` value object
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `runId` | `string` | The run the snapshot was taken for |
+| `stepIndex` | `int` | Zero-based step index |
+| `entries` | `array` | Plain-data entry rows as recorded |
+| `toolCalls` | `array` | Tool input/output pairs recorded during the invocation |
+| `frozen` | `bool` | `true` on snapshots loaded from persistence; `false` on in-flight writes |
+
+**Inspecting a snapshot** (requires raw database access or the v0.10.0 CLI):
+
+```php
+use BuiltByBerry\LaravelSwarm\Contracts\SnapshotsMemory;
+
+$snapshot = app(SnapshotsMemory::class)->find($runId, $stepIndex);
+
+if ($snapshot !== null) {
+    foreach ($snapshot->entries as $row) {
+        echo "{$row['key']}: " . json_encode($row['value']) . "\n";
+    }
+
+    foreach ($snapshot->toolCalls as $call) {
+        echo "Tool: {$call['name']}, Result: " . json_encode($call['result']) . "\n";
+    }
+}
+```
+
+### v0.9.0 scope coverage
+
+The snapshot captures only `MemoryScope::Run` entries. Conversation, Agent, and Swarm scope entries are **not** snapshotted — reads against those scopes during replay fall through to the live store, and a `MemoryScopeOutOfSnapshot` event fires for each one. This is a pragmatic trade-off: most agents operate on Run-scoped data, and snapshotting the wider scope graph would require coordinating across runs and agent lifecycles that may be long-lived.
+
+---
+
+## Replay semantics
+
+When a durable run crashes mid-step and is retried, the runner needs to decide what memory the agent sees on the second attempt. Two modes are available, controlled by `swarm.memory.replay_mode`.
+
+### `frozen_view` (default)
+
+The agent re-executes against the `MemoryScope::Run` entries frozen in the snapshot captured at the original invocation. Live writes to Run scope during the retry are buffered and never reach the backing store, preserving the canonical audit record. This is the recommended mode for reproducible, audit-friendly runs.
+
+### `fresh_execution`
+
+The agent re-executes against live memory with no snapshot guard. Use only when idempotency is guaranteed externally and you deliberately want the retry to see any writes that arrived between the original invocation and the retry.
+
+### Configuration
+
+```php
+// config/swarm.php
+'memory' => [
+    'replay_mode' => env('SWARM_MEMORY_REPLAY_MODE', 'frozen_view'),
+],
+```
+
+```ini
+# .env
+SWARM_MEMORY_REPLAY_MODE=frozen_view
+```
+
+### Per-swarm override with `#[MemoryReplay]`
+
+Override the global setting for a single swarm class using the `#[MemoryReplay]` attribute:
+
+```php
+use BuiltByBerry\LaravelSwarm\Attributes\MemoryReplay;
+use BuiltByBerry\LaravelSwarm\Enums\ReplayMode;
+
+#[MemoryReplay(mode: ReplayMode::FreshExecution)]
+class MyIdempotentSwarm extends Swarm
+{
+    // …
+}
+```
+
+`ReplayMode` cases:
+
+| Case | Value | Behavior |
+| --- | --- | --- |
+| `ReplayMode::FrozenView` | `frozen_view` | Deterministic replay from frozen snapshot (default) |
+| `ReplayMode::FreshExecution` | `fresh_execution` | Live memory, no snapshot guard |
+
+When the attribute is absent the global `swarm.memory.replay_mode` config applies.
+
+### Binding-restore constraint
+
+`MemoryReplayCoordinator::during()` implements the frozen-view swap by resolving the original `SwarmMemory` binding via `app()->make(SwarmMemory::class)`, installing a `ReplaySwarmMemory` decorator via `app()->instance(SwarmMemory::class, $replay)` for the duration of the callback, then restoring the original binding via `app()->instance(SwarmMemory::class, $original)` in a `finally` block.
+
+**Known constraint:** the restore step uses `instance()`, which always registers a singleton. If your application binds `SwarmMemory` as a factory (a non-singleton closure or a transient binding), the restore step silently converts it to singleton behavior for subsequent resolutions. The default binding is a singleton (`DefaultSwarmMemory`), so this does not affect standard setups. If you have customized the `SwarmMemory` binding to be non-singleton, document this trade-off in your service provider and verify the behavior under replay.
+
+---
+
+## RunContext bridge
+
+`RunContext` — the envelope every swarm run carries — writes through to `SwarmMemory` automatically. You do not need to resolve `SwarmMemory` directly to record per-run state; anything written to `RunContext` via `mergeData()` is mirrored into `MemoryScope::Run` for the same run.
+
+### ArrayAccess on RunContext
+
+`RunContext` implements `ArrayAccess` as of v0.9.0. Use it as a direct memory accessor from any code that already holds a context handle:
+
+```php
+// Write — mirrors into SwarmMemory::Run scope
+$context['approval_status'] = 'pending';
+
+// Read — reads from SwarmMemory::Run scope (falls back to $data array if SwarmMemory is not bound)
+$status = $context['approval_status']; // 'pending'
+
+// Check
+if (isset($context['draft_id'])) {
+    // …
+}
+
+// Delete
+unset($context['draft_id']);
+```
+
+Offset reads are backed by `SwarmMemory::get(MemoryScope::Run, $runId, $key)`. Offset writes call `SwarmMemory::put()` and also update the local `$data` array so prompt interpolation and inter-step relays remain array-fast (Eloquent attribute-caching pattern — the memory store is the write-through target, not the hot-path read source).
+
+### `mergeData()` write-through
+
+The existing `mergeData()` method also mirrors to memory:
+
+```php
+$context->mergeData(['summary' => $agentOutput, 'word_count' => $wordCount]);
+// Both keys are also written to MemoryScope::Run via SwarmMemory::put()
+```
+
+Callers that pass a structured task array to `prompt()` — `BlogPostSwarm::make()->prompt(['topic' => 'AI', 'tone' => 'technical'])` — have always stored that array in `$data`. As of v0.9.0 those same keys are also persisted to memory without any code change.
+
+### Null-bind tolerance
+
+If no `SwarmMemory` is bound in the container (POPO test setups, lightweight unit tests), the write-through path is a no-op. The `$data` array is still updated locally, so all existing test code continues to work without wiring memory.
+
+### How this relates to the memory subsystem
+
+The write-through does not replace direct `SwarmMemory` reads and writes — it complements them. Use `$context['key']` when you already hold a `RunContext` and want to read or write a Run-scoped value as part of the run lifecycle. Use `app(SwarmMemory::class)->get(MemoryScope::Agent, AgentClass::class, 'key')` when you want to read from a different scope or when you are outside the run lifecycle (for example, in a listener or background task).
+
+---
+
+## See Also
+
+- [RunContext](run-context.md) — the envelope that carries input, identity, and carry-forward data through a run; includes ArrayAccess reference
+- [Lifecycle Events](events.md) — every swarm lifecycle event, including memory events
+- [Durable Execution](durable-execution.md) — checkpointing, crash-resume, and replay
+- [Configuration](configuration.md) — `swarm.memory.replay_mode` and all memory config keys
+- [Public Surface](public-surface.md) — `SwarmMemory`, `MemoryEntry`, `MemoryScope`, `MemorySnapshot`, `ReplayMode`, `#[MemoryReplay]` in the public surface matrix
+- [laravel-swarm-memory-vector](https://github.com/builtbyberry/laravel-swarm-memory-vector) — vector-backed recall companion package (v0.1.0+, requires laravel-swarm v0.9.0+)

--- a/docs/public-surface.md
+++ b/docs/public-surface.md
@@ -28,7 +28,7 @@ adding a new public API.
 | `RunContext` | Explicit run input, run ID, data, metadata, artifacts, labels, and details. | [Structured Input](structured-input.md), [Persistence And History](persistence-and-history.md) |
 | `SwarmHistory` | Query persisted history and replay stored stream events. | [Persistence And History](persistence-and-history.md), [Run Inspector](../examples/run-inspector/README.md) |
 | `AuditDrainResult` | Result of an `AuditOutbox::drain()` invocation — `replayed`, `dead_lettered`, `failed`, `claimed`, `reclaimed`. (v0.5.0+) | [Audit Evidence Contract](audit-evidence-contract.md#audit-outbox) |
-| `ReplayMode` | Enum used by `#[MemoryReplay]` and `swarm.memory.replay_mode`. Cases: `FrozenView` (deterministic replay from frozen snapshot — the default) and `FreshExecution` (live memory, no snapshot guard). (v0.9.0+) | Memory (v0.9.0) |
+| `ReplayMode` | Enum used by `#[MemoryReplay]` and `swarm.memory.replay_mode`. Cases: `FrozenView` (deterministic replay from frozen snapshot — the default) and `FreshExecution` (live memory, no snapshot guard). (v0.9.0+) | [Swarm Memory](memory.md#replay-semantics) |
 
 ## Attributes
 
@@ -44,7 +44,7 @@ adding a new public API.
 | `#[DurableWait]` | Declare durable waits entered after checkpoints. | [Durable Waits And Signals](durable-waits-and-signals.md) |
 | `#[DurableLabels]` | Attach initial durable labels for inspection. | [Durable Waits And Signals](durable-waits-and-signals.md#labels-and-details), [Durable Execution](durable-execution.md#durable-operator-surfaces) |
 | `#[DurableDetails]` | Attach durable details for inspection. | [Durable Waits And Signals](durable-waits-and-signals.md#labels-and-details), [Durable Execution](durable-execution.md#durable-operator-surfaces) |
-| `#[MemoryReplay]` | Override the global `swarm.memory.replay_mode` config for a single swarm class. Accepts `ReplayMode::FrozenView` (default — agents re-execute against the memory snapshot frozen at the original invocation, preserving the canonical audit record) or `ReplayMode::FreshExecution` (agents re-execute against live memory; use only when idempotency is guaranteed externally). When absent, the global config default (`frozen_view`) applies. (v0.9.0+) | Memory (v0.9.0) |
+| `#[MemoryReplay]` | Override the global `swarm.memory.replay_mode` config for a single swarm class. Accepts `ReplayMode::FrozenView` (default — agents re-execute against the memory snapshot frozen at the original invocation, preserving the canonical audit record) or `ReplayMode::FreshExecution` (agents re-execute against live memory; use only when idempotency is guaranteed externally). When absent, the global config default (`frozen_view`) applies. (v0.9.0+) | [Swarm Memory](memory.md#replay-semantics) |
 
 ## Testing Surface
 
@@ -140,3 +140,13 @@ adding a new public API.
 | `LogChannelSwarmAuditSink` | Concrete `SwarmAuditSink` implementation that writes every audit record as a structured log entry (`swarm.audit.<category>`) to the configured Laravel log channel (defaults to `audit`, falls back to the default channel when `audit` is not configured). Dev/staging-friendly zero-config sink; production deployments should ship a bounded backend. Bound by `swarm:install:audit --sink=readable`. Does not implement `ReadableSwarmAuditSink` (log channels are not queryable); `swarm:trace` degrades gracefully when this sink is bound. (v0.8.0+) | [Audit Evidence Contract](audit-evidence-contract.md#quick-setup) |
 | `HaltsSwarmExecution` | Marker interface for sink failure exceptions that must halt the run. | [Audit Evidence Contract](audit-evidence-contract.md#sink-failure-handler) |
 | `AuditSinkHaltedException` | Raised when a sink failure handler halts execution. | [Audit Evidence Contract](audit-evidence-contract.md#sink-failure-handler) |
+
+## Memory (v0.9.0)
+
+| Surface | Purpose | Primary documentation |
+| --- | --- | --- |
+| `SwarmMemory` | Primary contract for reading and writing scoped memory entries. Methods: `put(scope, scopeId, key, value, metadata)`, `get(scope, scopeId, key)`, `entry(scope, scopeId, key)`, `forget(scope, scopeId, key)`, `all(scope, scopeId)`. Resolved from the container via `app(SwarmMemory::class)`. Custom drivers and test doubles implement this contract. (v0.9.0+) | [Swarm Memory](memory.md#reading-and-writing) |
+| `MemoryEntry` | Immutable value object returned by `put()`, `entry()`, and `all()`. Properties: `scope` (`MemoryScope`), `scopeId` (string), `key` (string), `value` (mixed — plain data only), `metadata` (array), `createdAt` (`?CarbonImmutable`), `updatedAt` (`?CarbonImmutable`). (v0.9.0+) | [Swarm Memory](memory.md#memoryentry) |
+| `MemoryScope` | Enum addressing the four memory scopes. Cases: `Run` (bounded to a single run), `Conversation` (shared across runs in a thread), `Agent` (per-agent-class persistent state), `Swarm` (shared across all agents in a swarm class). (v0.9.0+) | [Swarm Memory](memory.md#scope-hierarchy) |
+| `MemorySnapshot` | Immutable value object representing the frozen memory view captured before each agent invocation. Properties: `runId`, `stepIndex`, `entries` (Run-scope rows as recorded), `toolCalls` (input/output pairs for the invocation), `frozen` (true on snapshots loaded from persistence). (v0.9.0+) | [Swarm Memory](memory.md#snapshot-mechanism) |
+| `SnapshotsMemory` | Contract for the snapshot recorder. Methods: `snapshot(runId, stepIndex)` — capture and persist a snapshot; `appendToolCall(runId, stepIndex, call)` — append a tool call record; `resetToolCalls(runId, stepIndex)` — clear in-flight tool calls; `find(runId, stepIndex)` — retrieve a persisted snapshot or null. Used by all four runners and by `MemoryReplayCoordinator`. (v0.9.0+) | [Swarm Memory](memory.md#snapshot-mechanism) |


### PR DESCRIPTION
## Summary

- Adds `docs/memory.md` — the keystone reference page for the v0.9.0 memory subsystem covering all four scopes, the `SwarmMemory` contract API, store drivers, five lifecycle events with listener examples, snapshot mechanism, replay semantics (`frozen_view` / `fresh_execution`), the `#[MemoryReplay]` attribute, the binding-restore constraint (OG1 from PR #145 review), and the RunContext ArrayAccess write-through bridge
- Cross-links added to `README.md`, `docs/README.md`, `docs/getting-started.md`, and `docs/advanced-setup.md`
- CHANGELOG Documentation entry added under v0.9.0

## Linked issue

Closes #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)