### PR TITLE
test(memory): crash-resume replay determinism coverage (#118)

### DIFF
--- a/tests/Feature/Memory/ReplayDeterminismTest.php
+++ b/tests/Feature/Memory/ReplayDeterminismTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Contracts\ArtifactRepository;
+use BuiltByBerry\LaravelSwarm\Contracts\ContextStore;
+use BuiltByBerry\LaravelSwarm\Contracts\DurableRunStore;
+use BuiltByBerry\LaravelSwarm\Contracts\RunHistoryStore;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmMemory;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use BuiltByBerry\LaravelSwarm\Jobs\AdvanceDurableBranch;
+use BuiltByBerry\LaravelSwarm\Jobs\AdvanceDurableSwarm;
+use BuiltByBerry\LaravelSwarm\Runners\DurableSwarmManager;
+use BuiltByBerry\LaravelSwarm\Runners\SwarmRunner;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\FakeHierarchicalCoordinator;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\FakeResearcher;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\MemorySpyFlakyAgent;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\FreshExecutionReplaySwarm;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\ReplayDeterminismHierarchicalSwarm;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\ReplayDeterminismParallelSwarm;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\ReplayDeterminismSequentialSwarm;
+use BuiltByBerry\LaravelSwarm\Tests\Support\HierarchicalTestPlan;
+use Illuminate\Support\Facades\Artisan;
+
+/**
+ * Proves that the replay coordinator serves a frozen memory snapshot to a
+ * retried agent rather than the live (mutated) memory at retry time.
+ *
+ * Each test follows the same pattern:
+ *
+ *   1. Dispatch the durable swarm.
+ *   2. Write 'initial-value' to the probe key in Run-scoped memory.
+ *   3. Advance the step → MemorySpyFlakyAgent crashes on its first attempt,
+ *      but records what it read from SwarmMemory.
+ *   4. Overwrite the probe key with 'mutated-value'.
+ *   5. Travel 61 s past the retry backoff and call swarm:recover.
+ *   6. Advance the step again → MemorySpyFlakyAgent succeeds on its second
+ *      attempt and records what it read.
+ *   7. Assert that on the second attempt the agent still saw 'initial-value'
+ *      (the frozen snapshot), not 'mutated-value'.
+ *
+ * A final test verifies the FreshExecution opt-out: with replay mode overridden
+ * to FreshExecution the agent sees the live 'mutated-value' on retry.
+ */
+beforeEach(function () {
+    config()->set('swarm.persistence.driver', 'database');
+    config()->set('queue.connections.durable-test', ['driver' => 'null']);
+    config()->set('swarm.durable.queue.connection', 'durable-test');
+    config()->set('swarm.durable.queue.name', 'swarm-durable');
+
+    app()->forgetInstance(ContextStore::class);
+    app()->forgetInstance(ArtifactRepository::class);
+    app()->forgetInstance(RunHistoryStore::class);
+    app()->forgetInstance(DurableRunStore::class);
+    app()->forgetInstance(SwarmRunner::class);
+    app()->forgetInstance(DurableSwarmManager::class);
+
+    Artisan::call('migrate:fresh', ['--database' => 'testing']);
+
+    MemorySpyFlakyAgent::reset();
+});
+
+test('sequential replay coordinator serves frozen snapshot to retried agent', function () {
+    $response = ReplayDeterminismSequentialSwarm::make()->dispatchDurable('replay-determinism-task');
+    $manager = app(DurableSwarmManager::class);
+
+    // Write the initial probe value and wire the spy to this run.
+    app(SwarmMemory::class)->put(MemoryScope::Run, $response->runId, 'probe-key', 'initial-value');
+    MemorySpyFlakyAgent::reset($response->runId);
+
+    // First advance: agent crashes and records what memory it read.
+    (new AdvanceDurableSwarm($response->runId, 0))->handle($manager);
+
+    expect(MemorySpyFlakyAgent::$seenValues[1])->toBe('initial-value')
+        ->and($manager->find($response->runId)['status'])->toBe('pending');
+
+    // Mutate memory after the crash — the retry must NOT see this value.
+    app(SwarmMemory::class)->put(MemoryScope::Run, $response->runId, 'probe-key', 'mutated-value');
+
+    // Let the backoff expire and recover.
+    $this->travel(61)->seconds();
+    Artisan::call('swarm:recover');
+
+    // Second advance: agent succeeds and records what the replay coordinator gave it.
+    (new AdvanceDurableSwarm($response->runId, 0))->handle($manager);
+
+    expect(MemorySpyFlakyAgent::$attempts)->toBe(2)
+        ->and(MemorySpyFlakyAgent::$seenValues[2])->toBe('initial-value')
+        ->and($manager->find($response->runId)['status'])->toBe('completed');
+});
+
+test('parallel replay coordinator serves frozen snapshot to retried branch agent', function () {
+    FakeResearcher::fake(['stable-branch-output']);
+
+    $response = ReplayDeterminismParallelSwarm::make()->dispatchDurable('replay-determinism-parallel-task');
+    $manager = app(DurableSwarmManager::class);
+
+    // Write the initial probe value and wire the spy to this run.
+    app(SwarmMemory::class)->put(MemoryScope::Run, $response->runId, 'probe-key', 'initial-value');
+    MemorySpyFlakyAgent::reset($response->runId);
+
+    // Dispatch parallel branches (step 0 of a parallel swarm fans out).
+    (new AdvanceDurableSwarm($response->runId, 0))->handle($manager);
+
+    // Branch 0 (FakeResearcher) completes cleanly.
+    (new AdvanceDurableBranch($response->runId, 'parallel:0'))->handle($manager);
+
+    // Branch 1 (MemorySpyFlakyAgent) crashes on its first attempt.
+    (new AdvanceDurableBranch($response->runId, 'parallel:1'))->handle($manager);
+
+    expect(MemorySpyFlakyAgent::$seenValues[1])->toBe('initial-value');
+
+    // Mutate memory after the crash.
+    app(SwarmMemory::class)->put(MemoryScope::Run, $response->runId, 'probe-key', 'mutated-value');
+
+    $this->travel(61)->seconds();
+    Artisan::call('swarm:recover');
+
+    // Retry branch 1: agent must see the frozen snapshot value.
+    (new AdvanceDurableBranch($response->runId, 'parallel:1'))->handle($manager);
+
+    expect(MemorySpyFlakyAgent::$attempts)->toBe(2)
+        ->and(MemorySpyFlakyAgent::$seenValues[2])->toBe('initial-value');
+
+    // Complete the synthesis step so the run closes cleanly.
+    (new AdvanceDurableSwarm($response->runId, 2))->handle($manager);
+
+    expect($manager->find($response->runId)['status'])->toBe('completed');
+});
+
+test('hierarchical replay coordinator serves frozen snapshot to retried worker agent', function () {
+    FakeHierarchicalCoordinator::fake([
+        HierarchicalTestPlan::make('spy_node', [
+            'spy_node' => [
+                'type' => 'worker',
+                'agent' => MemorySpyFlakyAgent::class,
+                'prompt' => 'spy-worker-task',
+            ],
+        ]),
+    ]);
+
+    $response = ReplayDeterminismHierarchicalSwarm::make()->dispatchDurable('replay-determinism-hierarchical-task');
+    $manager = app(DurableSwarmManager::class);
+
+    // Write the initial probe value before anything executes.
+    app(SwarmMemory::class)->put(MemoryScope::Run, $response->runId, 'probe-key', 'initial-value');
+    MemorySpyFlakyAgent::reset($response->runId);
+
+    // Step 0: coordinator runs, plans worker route.
+    (new AdvanceDurableSwarm($response->runId, 0))->handle($manager);
+
+    // Step 1: worker (MemorySpyFlakyAgent) crashes on first attempt.
+    (new AdvanceDurableSwarm($response->runId, 1))->handle($manager);
+
+    expect(MemorySpyFlakyAgent::$seenValues[1])->toBe('initial-value');
+
+    // Mutate memory after the crash.
+    app(SwarmMemory::class)->put(MemoryScope::Run, $response->runId, 'probe-key', 'mutated-value');
+
+    $this->travel(61)->seconds();
+    Artisan::call('swarm:recover');
+
+    // Step 1 retry: worker must see the frozen snapshot value.
+    (new AdvanceDurableSwarm($response->runId, 1))->handle($manager);
+
+    expect(MemorySpyFlakyAgent::$attempts)->toBe(2)
+        ->and(MemorySpyFlakyAgent::$seenValues[2])->toBe('initial-value')
+        ->and($manager->find($response->runId)['status'])->toBe('completed');
+});
+
+test('FreshExecution replay mode bypasses frozen snapshot and sees live memory on retry', function () {
+    $response = FreshExecutionReplaySwarm::make()->dispatchDurable('fresh-execution-replay-task');
+    $manager = app(DurableSwarmManager::class);
+
+    app(SwarmMemory::class)->put(MemoryScope::Run, $response->runId, 'probe-key', 'initial-value');
+    MemorySpyFlakyAgent::reset($response->runId);
+
+    // First advance: agent crashes.
+    (new AdvanceDurableSwarm($response->runId, 0))->handle($manager);
+
+    expect(MemorySpyFlakyAgent::$seenValues[1])->toBe('initial-value');
+
+    // Mutate memory after the crash.
+    app(SwarmMemory::class)->put(MemoryScope::Run, $response->runId, 'probe-key', 'mutated-value');
+
+    $this->travel(61)->seconds();
+    Artisan::call('swarm:recover');
+
+    // Retry: FreshExecution mode does NOT freeze memory, so the agent sees the
+    // live mutated value rather than the snapshot.
+    (new AdvanceDurableSwarm($response->runId, 0))->handle($manager);
+
+    expect(MemorySpyFlakyAgent::$attempts)->toBe(2)
+        ->and(MemorySpyFlakyAgent::$seenValues[2])->toBe('mutated-value')
+        ->and($manager->find($response->runId)['status'])->toBe('completed');
+});

--- a/tests/Fixtures/Agents/MemorySpyFlakyAgent.php
+++ b/tests/Fixtures/Agents/MemorySpyFlakyAgent.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents;
+
+use BuiltByBerry\LaravelSwarm\Contracts\Agent;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmMemory;
+use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
+use Illuminate\Broadcasting\Channel;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Responses\AgentResponse;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\QueuedAgentResponse;
+use Laravel\Ai\Responses\StreamableAgentResponse;
+use RuntimeException;
+use Stringable;
+
+/**
+ * A test fixture that spies on what SwarmMemory returns during each invocation.
+ *
+ * On its first attempt it throws so the durable runner schedules a retry.
+ * After the retry, callers can inspect `self::$seenValues` to verify that the
+ * replay coordinator served the frozen snapshot value rather than any value
+ * written to memory after the first crash.
+ *
+ * @phpstan-import-type LaravelAiAgentAttachments from \BuiltByBerry\LaravelSwarm\Support\PhpStanTypeAliases
+ * @phpstan-import-type LaravelAiAgentProvider from \BuiltByBerry\LaravelSwarm\Support\PhpStanTypeAliases
+ * @phpstan-import-type SwarmBroadcastChannels from \BuiltByBerry\LaravelSwarm\Support\PhpStanTypeAliases
+ */
+class MemorySpyFlakyAgent implements Agent
+{
+    public static int $attempts = 0;
+
+    /** @var array<int, mixed> keyed by attempt number (1 = first attempt, 2 = first retry, …) */
+    public static array $seenValues = [];
+
+    public static ?string $runId = null;
+
+    public static function reset(?string $runId = null): void
+    {
+        self::$attempts = 0;
+        self::$seenValues = [];
+        self::$runId = $runId;
+    }
+
+    public function instructions(): Stringable|string
+    {
+        return 'You are a memory spy for replay-determinism tests.';
+    }
+
+    /**
+     * @param  LaravelAiAgentAttachments  $attachments
+     * @param  LaravelAiAgentProvider  $provider
+     */
+    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    {
+        self::$attempts++;
+
+        /** @var SwarmMemory $memory */
+        $memory = app(SwarmMemory::class);
+
+        self::$seenValues[self::$attempts] = $memory->get(
+            MemoryScope::Run,
+            self::$runId ?? '',
+            'probe-key',
+        );
+
+        if (self::$attempts === 1) {
+            throw new RuntimeException('memory-spy-crash-first-attempt');
+        }
+
+        return new AgentResponse('memory-spy', 'spy-success', new Usage, new Meta);
+    }
+
+    /**
+     * @param  LaravelAiAgentAttachments  $attachments
+     * @param  LaravelAiAgentProvider  $provider
+     */
+    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    {
+        throw new RuntimeException('Streaming is not supported in this test fixture.');
+    }
+
+    /**
+     * @param  LaravelAiAgentAttachments  $attachments
+     * @param  LaravelAiAgentProvider  $provider
+     */
+    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    {
+        throw new RuntimeException('Queueing is not supported in this test fixture.');
+    }
+
+    /**
+     * @param  SwarmBroadcastChannels  $channels
+     * @param  LaravelAiAgentAttachments  $attachments
+     * @param  LaravelAiAgentProvider  $provider
+     */
+    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    {
+        throw new RuntimeException('Broadcasting is not supported in this test fixture.');
+    }
+
+    /**
+     * @param  SwarmBroadcastChannels  $channels
+     * @param  LaravelAiAgentAttachments  $attachments
+     * @param  LaravelAiAgentProvider  $provider
+     */
+    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    {
+        throw new RuntimeException('Broadcasting is not supported in this test fixture.');
+    }
+
+    /**
+     * @param  SwarmBroadcastChannels  $channels
+     * @param  LaravelAiAgentAttachments  $attachments
+     * @param  LaravelAiAgentProvider  $provider
+     */
+    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    {
+        throw new RuntimeException('Broadcast queueing is not supported in this test fixture.');
+    }
+}

--- a/tests/Fixtures/Swarms/FreshExecutionReplaySwarm.php
+++ b/tests/Fixtures/Swarms/FreshExecutionReplaySwarm.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms;
+
+use BuiltByBerry\LaravelSwarm\Attributes\DurableRetry;
+use BuiltByBerry\LaravelSwarm\Attributes\MemoryReplay;
+use BuiltByBerry\LaravelSwarm\Attributes\Topology;
+use BuiltByBerry\LaravelSwarm\Concerns\Runnable;
+use BuiltByBerry\LaravelSwarm\Contracts\Swarm;
+use BuiltByBerry\LaravelSwarm\Enums\ReplayMode;
+use BuiltByBerry\LaravelSwarm\Enums\Topology as TopologyEnum;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\MemorySpyFlakyAgent;
+
+#[Topology(TopologyEnum::Sequential)]
+#[DurableRetry(maxAttempts: 2, backoffSeconds: [60])]
+#[MemoryReplay(mode: ReplayMode::FreshExecution)]
+class FreshExecutionReplaySwarm implements Swarm
+{
+    use Runnable;
+
+    public function agents(): array
+    {
+        return [
+            new MemorySpyFlakyAgent,
+        ];
+    }
+}

--- a/tests/Fixtures/Swarms/ReplayDeterminismHierarchicalSwarm.php
+++ b/tests/Fixtures/Swarms/ReplayDeterminismHierarchicalSwarm.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms;
+
+use BuiltByBerry\LaravelSwarm\Attributes\DurableRetry;
+use BuiltByBerry\LaravelSwarm\Attributes\Topology;
+use BuiltByBerry\LaravelSwarm\Concerns\Runnable;
+use BuiltByBerry\LaravelSwarm\Contracts\Swarm;
+use BuiltByBerry\LaravelSwarm\Enums\Topology as TopologyEnum;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\FakeHierarchicalCoordinator;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\MemorySpyFlakyAgent;
+
+#[Topology(TopologyEnum::Hierarchical)]
+#[DurableRetry(maxAttempts: 2, backoffSeconds: [60])]
+class ReplayDeterminismHierarchicalSwarm implements Swarm
+{
+    use Runnable;
+
+    public function agents(): array
+    {
+        return [
+            new FakeHierarchicalCoordinator,
+            new MemorySpyFlakyAgent,
+        ];
+    }
+}

--- a/tests/Fixtures/Swarms/ReplayDeterminismParallelSwarm.php
+++ b/tests/Fixtures/Swarms/ReplayDeterminismParallelSwarm.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms;
+
+use BuiltByBerry\LaravelSwarm\Attributes\DurableRetry;
+use BuiltByBerry\LaravelSwarm\Attributes\Topology;
+use BuiltByBerry\LaravelSwarm\Concerns\Runnable;
+use BuiltByBerry\LaravelSwarm\Contracts\Swarm;
+use BuiltByBerry\LaravelSwarm\Enums\Topology as TopologyEnum;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\FakeResearcher;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\MemorySpyFlakyAgent;
+
+#[Topology(TopologyEnum::Parallel)]
+#[DurableRetry(maxAttempts: 2, backoffSeconds: [60])]
+class ReplayDeterminismParallelSwarm implements Swarm
+{
+    use Runnable;
+
+    public function agents(): array
+    {
+        return [
+            new FakeResearcher,
+            new MemorySpyFlakyAgent,
+        ];
+    }
+}

--- a/tests/Fixtures/Swarms/ReplayDeterminismSequentialSwarm.php
+++ b/tests/Fixtures/Swarms/ReplayDeterminismSequentialSwarm.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms;
+
+use BuiltByBerry\LaravelSwarm\Attributes\DurableRetry;
+use BuiltByBerry\LaravelSwarm\Attributes\Topology;
+use BuiltByBerry\LaravelSwarm\Concerns\Runnable;
+use BuiltByBerry\LaravelSwarm\Contracts\Swarm;
+use BuiltByBerry\LaravelSwarm\Enums\Topology as TopologyEnum;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\MemorySpyFlakyAgent;
+
+#[Topology(TopologyEnum::Sequential)]
+#[DurableRetry(maxAttempts: 2, backoffSeconds: [60])]
+class ReplayDeterminismSequentialSwarm implements Swarm
+{
+    use Runnable;
+
+    public function agents(): array
+    {
+        return [
+            new MemorySpyFlakyAgent,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `MemorySpyFlakyAgent` — a fixture that reads `SwarmMemory::Run`-scoped memory on each invocation, records the value it saw, and crashes on its first attempt so the durable runner schedules a retry
- Adds four swarm fixtures: `ReplayDeterminismSequentialSwarm`, `ReplayDeterminismParallelSwarm`, `ReplayDeterminismHierarchicalSwarm`, and `FreshExecutionReplaySwarm`
- Adds `tests/Feature/Memory/ReplayDeterminismTest.php` with four tests proving that `MemoryReplayCoordinator::during()` serves a frozen snapshot value — not the live mutated value — across all three durable topologies; a fourth test confirms the `FreshExecution` opt-out bypasses the freeze and sees live memory

## Linked issue

Closes #118