### PR TITLE
fix(prune): seed counts shape so phpstan proves summary offsets

### DIFF
--- a/src/Commands/SwarmPruneCommand.php
+++ b/src/Commands/SwarmPruneCommand.php
@@ -63,7 +63,10 @@ class SwarmPruneCommand extends Command
             'audit_outbox' => (string) $config->get('swarm.tables.audit_outbox', 'swarm_audit_outbox'),
         ];
 
-        $counts = [];
+        // Seed every table key to zero so the count shape is fully known: the
+        // loop below assigns each key, but pre-filling lets static analysis
+        // prove the summary accesses below are present.
+        $counts = array_fill_keys(array_keys($tables), 0);
         $schema = $connection->getSchemaBuilder();
 
         if (! $schema->hasTable($tables['history'])) {


### PR DESCRIPTION
## What

`composer analyse` on the **stable-latest** CI leg started failing with 19 `offsetAccess.notFound` errors in `SwarmPruneCommand.php` after larastan floated to 3.10 / phpstan 2.2. The analyzer now infers `$counts` as an all-optional array shape (`array{history?: int, ...}`) because its keys are assigned inside the table loop, so the summary lines that read `$counts['durable_waits']` etc. are flagged as possibly-missing offsets.

## Fix

Pre-seed `$counts` with `array_fill_keys(array_keys($tables), 0)` before the loop. Every key is now provably present. **Behaviour is identical** — the loop already assigned all of them; this only changes the inferred type and defaults un-run keys to 0 (which the loop overwrites anyway).

## Scope / why separate

Pre-existing latent issue surfaced by dependency drift, **not** introduced by any v0.10.0 feature work. Carved out as its own chore so it cleanly unblocks the stable-latest analyse leg for the whole release branch (#153/#154/#155 inherit the same green).

## Verification

Reproduced locally on PHP 8.5.5 with refreshed stable deps (larastan 3.10.0, phpstan 2.2.1): 19 errors → after fix `[OK] No errors`. Pint clean. Prune/audit test suite: 24 passed.