### PR TITLE
test(memory): assert the command.memory.* audit category across the memory operator commands (#162)

### DIFF
--- a/tests/Feature/Memory/SwarmMemoryPurgeCommandTest.php
+++ b/tests/Feature/Memory/SwarmMemoryPurgeCommandTest.php
@@ -2,8 +2,11 @@
 
 declare(strict_types=1);
 
+use BuiltByBerry\LaravelSwarm\Audit\SwarmAuditDispatcher;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
 use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
 use BuiltByBerry\LaravelSwarm\Events\Memory\MemoryPurged;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\RecordingSwarmAuditSink;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
@@ -343,4 +346,120 @@ test('swarm:memory:purge is registered with the package', function (): void {
     $kernel = $this->app->make(Kernel::class);
 
     expect(array_key_exists('swarm:memory:purge', $kernel->all()))->toBeTrue();
+});
+
+// ---------------------------------------------------------------------------
+// Audit category — `command.memory.purge` is the load-bearing compliance
+// artifact for retention enforcement: the positive record of *what was removed
+// (or would be), under what criteria, and when*. The tests above assert the
+// in-process `MemoryPurged` event; these assert the audit-sink category the
+// dispatcher enriches and forwards. The prevent_prune path is the one most at
+// risk of regression — a disabled purge must still leave an audit trail showing
+// the scheduled run happened and was skipped. Mirrors the `command.memory.dump`
+// coverage via the shared RecordingSwarmAuditSink.
+// ---------------------------------------------------------------------------
+
+function purgeBindRecordingAuditSink(): RecordingSwarmAuditSink
+{
+    $sink = new RecordingSwarmAuditSink;
+    app()->instance(SwarmAuditSink::class, $sink);
+    app()->forgetInstance(SwarmAuditDispatcher::class);
+
+    return $sink;
+}
+
+test('emits the command.memory.purge audit category with per-scope counts and criteria on a real prune', function (): void {
+    config()->set('swarm.memory.retention.days', [
+        'run' => 5,
+        'conversation' => null,
+        'agent' => null,
+        'swarm' => null,
+    ]);
+
+    seedMemoryRow(MemoryScope::Run, 'run-old-1', 'k', Carbon::now('UTC')->subDays(10));
+    seedMemoryRow(MemoryScope::Run, 'run-old-2', 'k', Carbon::now('UTC')->subDays(12));
+
+    $sink = purgeBindRecordingAuditSink();
+
+    $exit = Artisan::call('swarm:memory:purge');
+
+    expect($exit)->toBe(0)
+        ->and($sink->hasCategory('command.memory.purge'))->toBeTrue()
+        ->and($sink->recordsForCategory('command.memory.purge'))->toHaveCount(1);
+
+    $record = $sink->recordsForCategory('command.memory.purge')[0];
+
+    expect($record['category'])->toBe('command.memory.purge')
+        ->and($record['status'])->toBe('purged')
+        ->and($record['dry_run'])->toBeFalse()
+        ->and($record['prevent_prune'])->toBeFalse()
+        // Per-scope counts — what was removed.
+        ->and($record['counts']['run'])->toBe(2)
+        // Criteria — the parameters the operator ran with.
+        ->and($record['criteria']['retention_days']['run'])->toBe(5)
+        ->and($record['criteria']['scope_filter'])->toBeNull()
+        ->and($record['criteria']['prune_snapshots'])->toBeTrue()
+        ->and($record['criteria']['cutoffs'])->toHaveKey('run')
+        // Actor identity — the "who" — is carried in reserved metadata.
+        ->and($record['metadata_keys'])->toContain('actor')
+        ->and($record['metadata'])->toHaveKey('actor');
+});
+
+test('emits the command.memory.purge audit category with status=skipped on the prevent_prune path', function (): void {
+    config()->set('swarm.memory.retention.days.run', 1);
+    config()->set('swarm.retention.prevent_prune', true);
+
+    seedMemoryRow(MemoryScope::Run, 'run-old', 'k', Carbon::now('UTC')->subDays(30));
+
+    $sink = purgeBindRecordingAuditSink();
+
+    $exit = Artisan::call('swarm:memory:purge');
+
+    // Destructive delete suppressed, but the audit trail must still record the run.
+    expect($exit)->toBe(0)
+        ->and(DB::table('swarm_memories')->count())->toBe(1)
+        ->and($sink->hasCategory('command.memory.purge'))->toBeTrue();
+
+    $record = $sink->recordsForCategory('command.memory.purge')[0];
+
+    expect($record['status'])->toBe('skipped')
+        ->and($record['prevent_prune'])->toBeTrue()
+        ->and($record['dry_run'])->toBeFalse()
+        // Counts are zeroed because nothing was deleted.
+        ->and($record['counts']['run'])->toBe(0)
+        ->and($record['criteria']['prevent_prune'])->toBeTrue();
+});
+
+test('emits the command.memory.purge audit category with status=dry_run on a --dry-run preview', function (): void {
+    config()->set('swarm.memory.retention.days.run', 7);
+
+    seedMemoryRow(MemoryScope::Run, 'run-old-a', 'k', Carbon::now('UTC')->subDays(10));
+    seedMemoryRow(MemoryScope::Run, 'run-old-b', 'k', Carbon::now('UTC')->subDays(20));
+
+    $sink = purgeBindRecordingAuditSink();
+
+    $exit = Artisan::call('swarm:memory:purge', ['--dry-run' => true]);
+
+    expect($exit)->toBe(0)
+        // Nothing deleted on a dry run, but the access is still recorded.
+        ->and(DB::table('swarm_memories')->count())->toBe(2);
+
+    $record = $sink->recordsForCategory('command.memory.purge')[0];
+
+    expect($record['status'])->toBe('dry_run')
+        ->and($record['dry_run'])->toBeTrue()
+        ->and($record['counts']['run'])->toBe(2);
+});
+
+test('does not emit the command.memory.purge audit category when the persistence driver is not database', function (): void {
+    config()->set('swarm.persistence.driver', 'cache');
+    config()->set('swarm.memory.retention.days.run', 1);
+
+    $sink = purgeBindRecordingAuditSink();
+
+    $exit = Artisan::call('swarm:memory:purge');
+
+    // The command no-ops before any retention work, so there is nothing to audit.
+    expect($exit)->toBe(0)
+        ->and($sink->hasCategory('command.memory.purge'))->toBeFalse();
 });

--- a/tests/Feature/SwarmMemoryInspectCommandTest.php
+++ b/tests/Feature/SwarmMemoryInspectCommandTest.php
@@ -2,8 +2,11 @@
 
 declare(strict_types=1);
 
+use BuiltByBerry\LaravelSwarm\Audit\SwarmAuditDispatcher;
 use BuiltByBerry\LaravelSwarm\Contracts\SnapshotsMemory;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
 use BuiltByBerry\LaravelSwarm\Events\Memory\MemoryInspected;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\RecordingSwarmAuditSink;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
@@ -537,4 +540,104 @@ test('table mode hints at --format=json when a tool-call cell truncates', functi
     $output = Artisan::output();
     expect($output)->toContain('--format=json');
     expect($output)->toContain('truncated');
+});
+
+// ---------------------------------------------------------------------------
+// Audit category — `command.memory.inspect` is the load-bearing compliance
+// artifact: the positive record of *who inspected what, and when*. The event
+// tests above assert the in-process `MemoryInspected` event; these assert the
+// audit-sink category the dispatcher enriches and forwards. A refactor that
+// drops or mis-shapes the category would ship green on the event tests alone —
+// this section guards the category itself. Mirrors the `command.memory.dump`
+// coverage in SwarmMemoryDumpCommandTest via the shared RecordingSwarmAuditSink.
+// ---------------------------------------------------------------------------
+
+function inspectBindRecordingAuditSink(): RecordingSwarmAuditSink
+{
+    $sink = new RecordingSwarmAuditSink;
+    app()->instance(SwarmAuditSink::class, $sink);
+    app()->forgetInstance(SwarmAuditDispatcher::class);
+
+    return $sink;
+}
+
+test('emits the command.memory.inspect audit category once on a successful list read', function (): void {
+    seedMemorySnapshotRow('run-audit', 0, runEntries('run-audit'));
+    seedMemorySnapshotRow('run-audit', 1, runEntries('run-audit'));
+
+    $sink = inspectBindRecordingAuditSink();
+
+    $exit = Artisan::call('swarm:memory:inspect', ['run_id' => 'run-audit', '--format' => 'json']);
+
+    expect($exit)->toBe(0)
+        ->and($sink->hasCategory('command.memory.inspect'))->toBeTrue()
+        ->and($sink->recordsForCategory('command.memory.inspect'))->toHaveCount(1);
+
+    $record = $sink->recordsForCategory('command.memory.inspect')[0];
+
+    // Lookup parameters + snapshot count — the "what was inspected" record.
+    expect($record['category'])->toBe('command.memory.inspect')
+        ->and($record['run_id'])->toBe('run-audit')
+        ->and($record['step_index'])->toBeNull()
+        ->and($record['scope_filter'])->toBeNull()
+        ->and($record['format'])->toBe('json')
+        ->and($record['snapshot_count'])->toBe(2)
+        // Actor identity — the "who" — is carried in reserved metadata.
+        ->and($record['metadata_keys'])->toContain('actor')
+        ->and($record['metadata'])->toHaveKey('actor');
+});
+
+test('the command.memory.inspect audit category carries the step and scope filters', function (): void {
+    seedMemorySnapshotRow('run-audit-fil', 0, mixedScopeEntries('run-audit-fil'));
+
+    $sink = inspectBindRecordingAuditSink();
+
+    $exit = Artisan::call('swarm:memory:inspect', [
+        'run_id' => 'run-audit-fil',
+        '--step' => 0,
+        '--scope' => 'agent',
+        '--format' => 'json',
+    ]);
+
+    expect($exit)->toBe(0);
+
+    $record = $sink->recordsForCategory('command.memory.inspect')[0];
+
+    expect($record['step_index'])->toBe(0)
+        ->and($record['scope_filter'])->toBe('agent')
+        ->and($record['snapshot_count'])->toBe(1);
+});
+
+test('does not emit the command.memory.inspect audit category when the run has no snapshots', function (): void {
+    $sink = inspectBindRecordingAuditSink();
+
+    $exit = Artisan::call('swarm:memory:inspect', ['run_id' => 'never-existed', '--format' => 'json']);
+
+    expect($exit)->toBe(1)
+        ->and($sink->hasCategory('command.memory.inspect'))->toBeFalse();
+});
+
+test('does not emit the command.memory.inspect audit category when a known run lacks the requested step', function (): void {
+    seedMemorySnapshotRow('run-audit-miss', 0, runEntries('run-audit-miss'));
+
+    $sink = inspectBindRecordingAuditSink();
+
+    $exit = Artisan::call('swarm:memory:inspect', ['run_id' => 'run-audit-miss', '--step' => 99, '--format' => 'json']);
+
+    expect($exit)->toBe(1)
+        ->and($sink->hasCategory('command.memory.inspect'))->toBeFalse();
+});
+
+test('does not emit the command.memory.inspect audit category under the cache persistence driver', function (): void {
+    // The cache driver resolves SnapshotsMemory to NullSnapshotsMemory; the
+    // command fails with a configuration hint before reaching the audit emit.
+    config()->set('swarm.persistence.driver', 'cache');
+    app()->forgetInstance(SnapshotsMemory::class);
+
+    $sink = inspectBindRecordingAuditSink();
+
+    $exit = Artisan::call('swarm:memory:inspect', ['run_id' => 'r-cache', '--format' => 'json']);
+
+    expect($exit)->toBe(1)
+        ->and($sink->hasCategory('command.memory.inspect'))->toBeFalse();
 });


### PR DESCRIPTION
## Summary

Backfills audit-category coverage so the `swarm:memory:*` operator commands are uniform. The suite tested the **events** (`MemoryInspected`, `MemoryPurged`) but not the `command.memory.*` **audit categories** — the load-bearing compliance artifact (the positive record of *who inspected / what was purged, and when*). `dump` got this in #161 via `RecordingSwarmAuditSink`; this closes the gap for `inspect` and `purge`.

A refactor that dropped or mis-shaped the audit category would ship green on the event tests alone — exactly the regression that matters most for a compliance-themed release.

- **`inspect`** — `command.memory.inspect` emits once on a successful read carrying the lookup params (`run_id`, `step_index`, `scope_filter`, `format`) + `snapshot_count` + actor metadata; carries step/scope filters when set; does **not** emit on the no-snapshots, missing-step, or cache-driver paths.
- **`purge`** — `command.memory.purge` emits with per-scope `counts` + `criteria` on a real prune (`status=purged`), with `status=skipped` on the `prevent_prune` path, and `status=dry_run` on `--dry-run`; does **not** emit under the non-database driver.

Reuses the existing `RecordingSwarmAuditSink` fixture and the dump test's binding pattern — no production changes.

## Test plan

- `composer test` (both files): 50 passed / 145 assertions — 9 new (5 inspect, 4 purge)
- `vendor/bin/pint --test`: passed
- `composer analyse` (PHPStan): no errors

## Linked issue

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)