### PR TITLE
feat(memory): opt-in Octane/worker reset listener for ActiveRunContext stale frames (#171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Memory-as-tool DX. First-class Recall/Remember tools agents can use mid-prompt, 
 
 ### Added
 
-_To be filled in during release wrap-up._
+- **Octane worker-reset flush for `ActiveRunContext` (#171).** When `laravel/octane` is installed, `SwarmServiceProvider` now wires a listener on Octane's `OperationTerminated` contract that calls `ActiveRunContext::flush()` on every worker reset (request, task, and tick), so a stale run frame left by an abnormally-terminated run — a hard timeout or fatal that bypasses the `enter()`/`exit()` finally — is cleared eagerly instead of relying on the next run to shadow it. Opt-in by presence: the listener is registered only when Octane's contract is loadable, so non-Octane apps see zero behaviour change and the package never hard-depends on Octane. `swarm:install:memory` now surfaces a confirmation note (and the manual `config/octane.php` equivalent) when it detects Octane.
 
 ### Changed
 

--- a/src/Commands/Install/InstallMemoryCommand.php
+++ b/src/Commands/Install/InstallMemoryCommand.php
@@ -238,5 +238,33 @@ class InstallMemoryCommand extends Command
         $this->line('  • Full memory reference: <comment>docs/memory.md</comment>');
         $this->line('  • Per-swarm replay tuning: <comment>#[MemoryReplay(mode: ReplayMode::FreshExecution)]</comment>');
         $this->line('  • Per-swarm worker visibility: <comment>#[PropagationPolicy(MyPolicy::class)]</comment>');
+
+        $this->printOctaneNote();
+    }
+
+    /**
+     * When running under Laravel Octane, Swarm flushes the process-local active
+     * run context on every worker reset automatically (a wired
+     * `OperationTerminated` listener). Surface this only when Octane is present
+     * so the note stays out of the way for everyone else, and document the
+     * manual `flush()` equivalent for operators who want it in `octane.php`.
+     */
+    private function printOctaneNote(): void
+    {
+        if (! interface_exists('Laravel\Octane\Contracts\OperationTerminated')) {
+            return;
+        }
+
+        $this->newLine();
+        $this->components->info('Laravel Octane detected');
+        $this->line(
+            '  Swarm flushes its process-local active run context on every Octane '
+            .'worker reset automatically — no configuration needed.',
+        );
+        $this->line(
+            '  To flush it yourself instead, add to <comment>config/octane.php</comment> under each '
+            .'<comment>*Terminated</comment> listener:',
+        );
+        $this->line('    <comment>\BuiltByBerry\LaravelSwarm\Support\ActiveRunContext::flush(...),</comment>');
     }
 }

--- a/src/Support/ActiveRunContext.php
+++ b/src/Support/ActiveRunContext.php
@@ -7,6 +7,7 @@ namespace BuiltByBerry\LaravelSwarm\Support;
 use BuiltByBerry\LaravelSwarm\Concerns\RemembersRunContext;
 use Illuminate\Support\Facades\Context;
 use Laravel\Ai\Contracts\Conversational;
+use Laravel\Octane\Contracts\OperationTerminated;
 
 /**
  * Process-local handle to the swarm run currently executing an agent.
@@ -41,8 +42,11 @@ use Laravel\Ai\Contracts\Conversational;
  * {@see current()} returns the top, and the next run's {@see enter()} pushes a
  * fresh frame above it, so there is no correctness or cross-run-bleed concern.
  * The only residue is a single retained {@see RunContext} reference until the
- * worker recycles. If you want it cleared eagerly under Octane, reset it from a
- * worker/operationTerminated hook with {@see flush()}.
+ * worker recycles. Under Laravel Octane this residue is cleared eagerly: when
+ * the package detects Octane is installed, {@see SwarmServiceProvider} wires an
+ * {@see OperationTerminated} listener that calls
+ * {@see flush()} on every worker reset (request, task, and tick). Non-Octane
+ * apps rely on the self-healing shadowing described above.
  *
  * @internal
  */

--- a/src/SwarmServiceProvider.php
+++ b/src/SwarmServiceProvider.php
@@ -119,6 +119,7 @@ use BuiltByBerry\LaravelSwarm\Runners\SwarmAttributeResolver;
 use BuiltByBerry\LaravelSwarm\Runners\SwarmGuardrailRunner;
 use BuiltByBerry\LaravelSwarm\Runners\SwarmRunner;
 use BuiltByBerry\LaravelSwarm\Runners\SwarmStepRecorder;
+use BuiltByBerry\LaravelSwarm\Support\ActiveRunContext;
 use BuiltByBerry\LaravelSwarm\Support\SwarmEventRecorder;
 use BuiltByBerry\LaravelSwarm\Support\SwarmHistory;
 use BuiltByBerry\LaravelSwarm\Telemetry\NoOpSwarmTelemetrySink;
@@ -130,6 +131,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Octane\Contracts\OperationTerminated;
 use Laravel\Pulse\Pulse;
 use Livewire\LivewireManager;
 use Psr\Log\LoggerInterface;
@@ -354,6 +356,8 @@ class SwarmServiceProvider extends ServiceProvider
             Event::subscribe(SwarmTelemetryEventListener::class);
         }
 
+        $this->registerOctaneStateReset();
+
         if (class_exists(Pulse::class)) {
             $this->loadViewsFrom(__DIR__.'/../resources/views', 'swarm');
 
@@ -409,6 +413,30 @@ class SwarmServiceProvider extends ServiceProvider
             ]);
         }
 
+    }
+
+    /**
+     * Flush the process-local {@see ActiveRunContext} stack on every Octane
+     * worker reset, so a stale frame left by an abnormally-terminated run
+     * (hard timeout, fatal) never outlives the operation that produced it.
+     *
+     * Opt-in by presence: the listener is wired only when `laravel/octane`'s
+     * {@see OperationTerminated} contract is loadable,
+     * so non-Octane apps see zero behaviour change and we never hard-depend on
+     * the package. The contract is implemented by every terminated event
+     * (request, task, tick), so one binding covers all three reset points.
+     */
+    protected function registerOctaneStateReset(): void
+    {
+        $operationTerminated = 'Laravel\Octane\Contracts\OperationTerminated';
+
+        if (! interface_exists($operationTerminated)) {
+            return;
+        }
+
+        Event::listen($operationTerminated, static function (): void {
+            ActiveRunContext::flush();
+        });
     }
 
     /**

--- a/tests/Feature/OctaneRunContextResetTest.php
+++ b/tests/Feature/OctaneRunContextResetTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+// laravel/octane is not a dependency of this package, so we stand in a stub for
+// its OperationTerminated contract under the real namespace. Defining it at file
+// load time (before the testbench app boots in TestCase::setUp) means
+// SwarmServiceProvider::registerOctaneStateReset() sees Octane as "installed"
+// and wires the worker-reset listener, exactly as it would in a host app that
+// has Octane. Bracketed namespaces are required because the stubs live under the
+// Laravel\Octane namespace while the test body runs in the global namespace.
+
+namespace Laravel\Octane\Contracts {
+    if (! interface_exists(OperationTerminated::class)) {
+        interface OperationTerminated {}
+    }
+}
+
+namespace Laravel\Octane\Events {
+    use Laravel\Octane\Contracts\OperationTerminated;
+
+    if (! class_exists(RequestTerminated::class)) {
+        class RequestTerminated implements OperationTerminated {}
+    }
+}
+
+namespace {
+
+    use BuiltByBerry\LaravelSwarm\Support\ActiveRunContext;
+    use BuiltByBerry\LaravelSwarm\Support\RunContext;
+    use Illuminate\Contracts\Events\Dispatcher;
+    use Laravel\Octane\Events\RequestTerminated;
+
+    afterEach(function () {
+        ActiveRunContext::flush();
+    });
+
+    test('a simulated Octane worker reset flushes stale ActiveRunContext frames', function () {
+        // Leave a frame behind, as an abnormally-terminated run on a long-lived
+        // worker would (the finally that pairs enter()/exit() was bypassed).
+        ActiveRunContext::enter('stale-run', 'StaleSwarm', RunContext::fake(['run_id' => 'stale-run']));
+        expect(ActiveRunContext::current())->not->toBeNull();
+
+        // Octane fires an OperationTerminated event (RequestTerminated here) on
+        // every worker reset; the provider-registered listener should clear the
+        // stack.
+        $this->app->make(Dispatcher::class)->dispatch(new RequestTerminated);
+
+        expect(ActiveRunContext::current())->toBeNull();
+    });
+
+    test('the worker-reset listener is registered for the OperationTerminated contract', function () {
+        expect($this->app->make(Dispatcher::class)->hasListeners('Laravel\Octane\Contracts\OperationTerminated'))
+            ->toBeTrue();
+    });
+}


### PR DESCRIPTION
## Summary

`ActiveRunContext` is a process-local static stack pushed/popped around every agent invocation via `enter()`/`exit()` with a `finally`-based cleanup. On a long-lived worker (Octane, persistent queue worker), a hard timeout or fatal that bypasses the `finally` can leave a stale frame on the stack. This was correctness-safe (the next `enter()` shadows it and it is never read out of an active run), but the "self-healing" guarantee was asserted rather than enforced.

This PR enforces it under Octane:

- **`SwarmServiceProvider::registerOctaneStateReset()`** wires a listener on Octane's `Laravel\Octane\Contracts\OperationTerminated` contract that calls `ActiveRunContext::flush()` on every worker reset. The contract is implemented by all three terminated events (request, task, tick), so one binding covers every reset point.
- **Opt-in by presence.** The listener is registered only when the Octane contract is loadable (`interface_exists`), so non-Octane apps see zero behaviour change and the package never hard-depends on `laravel/octane`. The check uses a string literal, not a `use`-resolved symbol, so nothing in the missing namespace is touched at runtime.
- **`swarm:install:memory`** now prints a confirmation note when it detects Octane, including the manual `config/octane.php` equivalent for operators who prefer to wire it themselves.
- The existing `ActiveRunContext::flush()` method (added in a prior pass) is now actually used; its docblock and the class docblock are updated to describe the auto-wiring.

## Tests

New `tests/Feature/OctaneRunContextResetTest.php` stubs the `OperationTerminated` contract under its real namespace (Octane is not a dependency), then:
- proves a simulated worker-reset event (`RequestTerminated`) flushes a stale frame off the stack, and
- asserts the listener is registered against the contract.

## Verification

- `composer test` — PASS (1291 passed)
- `vendor/bin/pint --test` — PASS
- `composer analyse` — PASS (no errors)
- `composer test:process-concurrency` — PASS (5 passed; 2 pre-existing skips that require MySQL/Postgres for `SKIP LOCKED`)

Closes #171