### PR TITLE
chore(ci): raise coverage memory_limit to 1G

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -31,7 +31,7 @@ jobs:
           php-version: '8.5'
           tools: composer:v2
           coverage: pcov
-          ini-values: memory_limit=512M
+          ini-values: memory_limit=1G
 
       - name: Install dependencies
         run: composer update --prefer-stable --prefer-dist --no-interaction --no-progress

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
           php-version: '8.5'
           tools: composer:v2
           coverage: pcov
-          ini-values: memory_limit=512M
+          ini-values: memory_limit=1G
 
       - name: Require Laravel framework dev-main
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
           php-version: '8.5'
           tools: composer:v2
           coverage: pcov
-          ini-values: memory_limit=512M
+          ini-values: memory_limit=1G
 
       - name: Install dependencies
         if: matrix.dependencies == 'stable-latest'


### PR DESCRIPTION
## Summary

The `tests.yml` coverage job started failing with a PHP fatal — `Allowed memory size of 536870912 bytes exhausted` in `vendor/pestphp/pest/.temp/coverage.php` — **after all 1333 tests pass**. The OOM is in Pest's coverage-report aggregation, not in any test. The suite had grown to the 512M ceiling and the new v0.11.0 memory-tool tests (#128) tipped the `stable-latest` matrix leg over it (the `lowest` leg squeaks under).

Raises `memory_limit` from 512M → 1G for the three workflows that run pcov coverage: `tests.yml`, `nightly.yml`, `mutation.yml`. The real-db workflows use `coverage: none` and don't aggregate, so they're left as-is.

No code or test changes.

Closes the merge-blocker on #178.