### PR TITLE
chore(release): v0.11.0 readiness gate followups

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,8 @@ $approved = $memory->get(MemoryScope::Run, $runId, 'draft_approved');
 
 See [Swarm Memory](docs/memory.md) for the full reference: scope hierarchy, store drivers, lifecycle events, propagation and capture policies, snapshot inspection, replay semantics (`frozen_view` vs `fresh_execution`), and the `#[MemoryReplay]` / `#[PropagationPolicy]` attributes; and [Compliance & Audit](docs/compliance-audit.md) for the regulated-workload runbook (redaction, retention, audit-packet export). Vector-backed recall ships as the [laravel-swarm-memory-vector](https://github.com/builtbyberry/laravel-swarm-memory-vector) companion package.
 
+**Agent memory tools (v0.11.0+).** Agents can now read and write memory *mid-prompt* as ordinary `laravel/ai` tools — drop the shipped `Recall` and `Remember` tools into any agent's `tools()` array (or expose them via the `HasSwarmMemoryTools` trait). Scope ids resolve from the active run, never the model; reads honour the propagation policy and writes honour the capture policy, so the tools can never surface or persist anything the policies forbid. They are **disabled by default** (`swarm.memory.tools.enabled`) — granting an LLM access to shared memory is an explicit decision. Scaffold custom variants with `php artisan make:memory-tool`. See the [memory recipes](docs/memory-recipes.md) for worked patterns: per-user and tenant-scoped recall, policy-enforced custom tools, recall + redact, and sub-agent memory continuity.
+
 ## Topologies
 
 Laravel Swarm supports four topologies.

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "0.10.x-dev"
+            "dev-main": "0.11.x-dev"
         },
         "laravel": {
             "providers": [


### PR DESCRIPTION
Phase 3 (readiness review) follow-ups for v0.11.0. Two **medium** findings, both recurring per-release hygiene the readiness gate exists to catch. Verdict was `ship-with-followups` / non-blocker.

## Findings addressed

- **F1 — `composer.json` branch-alias** *(semver-guardian)*: `extra.branch-alias.dev-main` lagged at `0.10.x-dev` while we tag v0.11.0; bumped to `0.11.x-dev`. (Recurs the v0.10 `branch-alias-bump` fix.) `composer.lock` is gitignored, so no lock change is needed.
- **F2 — README marquee** *(open-source-steward + docs)*: the README Memory section had no mention of v0.11's headline — the `Recall`/`Remember` agent memory tools, `make:memory-tool`, or the recipe book. Added an "Agent memory tools (v0.11.0+)" subsection (disabled-by-default note, generator, link to `docs/memory-recipes.md`). (Recurs the v0.10 `readme-v010-operator-surface` fix.)

## Verification

- `composer validate` → valid.
- README link target `docs/memory-recipes.md` exists.

After merge → ready-for-tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)