### PR TITLE
chore: 0.12.0 review followups (F1-F2, OG2)

### DIFF
--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -218,6 +218,20 @@ Two things make such a run recoverable:
 > *upstream* text/tool events are not). Treat these framework step events as
 > per-attempt, not exactly-once: a consumer that bills or counts per
 > `step.completed` should key on `(run_id, step_index)` to dedupe across resumes.
+>
+> A skipped step still re-runs its **step guardrails** against the rehydrated
+> output (parity with a fresh run), so step guardrails must be **deterministic** —
+> a guardrail that depends on wall-clock or external state (e.g. a rate or
+> time-window rule) can reject on resume a step the original attempt passed.
+
+> **Sequential only.** This skip-on-resume optimisation applies to sequential
+> `stream()`. A **static-hierarchical** streamed run re-executes every reachable
+> worker on resume — each runs under its frozen snapshot, so the memory it sees
+> is deterministic, but its provider *is* re-invoked and usage / `step.completed`
+> telemetry / stream events are re-emitted across the crashed and resumed
+> attempts. The byte-identical-memory guarantee holds; the per-step *skip* does
+> not. For cross-process idempotent checkpointing of hierarchical work, use
+> `dispatchDurable()` ([Durable Execution](durable-execution.md)).
 
 The frozen view is scoped per-invocation on the run's internal active-run frame
 rather than rebound globally, so two streams running concurrently in one process

--- a/src/Runners/StaticHierarchicalStreamRunner.php
+++ b/src/Runners/StaticHierarchicalStreamRunner.php
@@ -80,6 +80,19 @@ use Throwable;
  *   concurrent  — branches run via ConcurrencyManager (no text deltas from branches).
  *   sequential  — branches stream one at a time in declaration order.
  *
+ * Resume scope — hierarchical re-executes, it does not skip. The idempotent
+ * multi-step resume that skips already-completed steps (issue #202,
+ * {@see SequentialRunner}'s checkpoint store) is Sequential-only. On a
+ * crash-resume re-run, this runner re-executes every reachable worker — each
+ * runs under its frozen-snapshot view (issue #192), so the agent-visible memory
+ * is deterministic, but the worker's provider IS re-invoked and the observable
+ * side effects repeat: usage is re-accounted, `step.completed` telemetry/audit
+ * fire again, and stream events are re-emitted to the consumer. A consumer
+ * streaming a hierarchical run therefore sees duplicate usage/telemetry across
+ * the crashed and resumed attempts; a Sequential consumer does not. The
+ * determinism guarantee (frozen-view replay) holds for both; only the skip
+ * optimisation is Sequential-only.
+ *
  * @phpstan-import-type SwarmTaskInput from \BuiltByBerry\LaravelSwarm\Support\PhpStanTypeAliases
  *
  * @internal

--- a/tests/Feature/StreamingCrashReplayTest.php
+++ b/tests/Feature/StreamingCrashReplayTest.php
@@ -32,10 +32,12 @@ use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Guardrails\CountingStepGuardrail;
 use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\CountingEchoSwarm;
 use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\CountingEchoThreeStepSwarm;
 use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\FakeRichStreamingSwarm;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\StreamingConversationRecallSwarm;
 use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\StreamingRecallOnlySwarm;
 use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\StreamingRecallSwarm;
 use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\StreamingRememberSwarm;
 use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\StreamingUnpairedToolCallSwarm;
+use BuiltByBerry\LaravelSwarm\Tests\Support\ConversationDeclaringPropagationPolicy;
 use BuiltByBerry\LaravelSwarm\Tools\Recall;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
@@ -418,6 +420,63 @@ test('two concurrent in-process streams each replay their own frozen snapshot wi
     expect(app(SwarmMemory::class))->toBeInstanceOf(DefaultSwarmMemory::class);
     expect(app(SwarmMemory::class)->get(MemoryScope::Run, $runA, 'finding'))->toBe('A-DRIFTED');
     expect(app(SwarmMemory::class)->get(MemoryScope::Run, $runB, 'finding'))->toBe('B-DRIFTED');
+    expect(ActiveRunContext::current())->toBeNull();
+    expect(ActiveRunContext::currentMemory())->toBeNull();
+});
+
+test('two interleaved in-process streams each read their own conversation-scoped memory with no handle bleed', function () {
+    // Companion to the frozen-snapshot interleave test above: that one locks the
+    // per-invocation frozen-VIEW override on the run frame; this one locks the
+    // per-run CONVERSATION HANDLE (#186) on the same frame. Together they prove
+    // both per-run carriers stay frame-isolated when two streamed runs interleave
+    // in one process (the Octane fiber model). The Recall tool resolves the
+    // conversation scope id from the active frame's RunContext::conversationId(),
+    // so a frame bleed would surface the other run's conversation entry.
+    config()->set('swarm.memory.propagation_policy', ConversationDeclaringPropagationPolicy::class);
+
+    app(SwarmMemory::class)->put(MemoryScope::Conversation, 'conv-A', 'finding', 'A-conv');
+    app(SwarmMemory::class)->put(MemoryScope::Conversation, 'conv-B', 'finding', 'B-conv');
+
+    $genA = StreamingConversationRecallSwarm::make()
+        ->stream(RunContext::from('recall-task', 'conv-handle-run-A')->withConversationId('conv-A'))
+        ->getIterator();
+    $genB = StreamingConversationRecallSwarm::make()
+        ->stream(RunContext::from('recall-task', 'conv-handle-run-B')->withConversationId('conv-B'))
+        ->getIterator();
+
+    // Suspend A right after its recall (the recall already ran by the time the
+    // tool result surfaces), leaving A's frame live on the stack.
+    $aResult = null;
+    $genA->rewind();
+    while ($genA->valid()) {
+        $event = $genA->current();
+        if ($event instanceof SwarmToolResult) {
+            $aResult = $event->toolResult->result;
+            break;
+        }
+        $genA->next();
+    }
+
+    // Drive B to completion while A is suspended.
+    $bResult = null;
+    $genB->rewind();
+    while ($genB->valid()) {
+        $event = $genB->current();
+        if ($event instanceof SwarmToolResult) {
+            $bResult = $event->toolResult->result;
+        }
+        $genB->next();
+    }
+
+    while ($genA->valid()) {
+        $genA->next();
+    }
+
+    // Each stream recalled ITS OWN conversation's entry — the handle never bled.
+    expect($aResult)->toBe('finding: A-conv');
+    expect($bResult)->toBe('finding: B-conv');
+
+    // No frame residue after both finish.
     expect(ActiveRunContext::current())->toBeNull();
     expect(ActiveRunContext::currentMemory())->toBeNull();
 });

--- a/tests/Fixtures/Agents/StreamingConversationRecallAgent.php
+++ b/tests/Fixtures/Agents/StreamingConversationRecallAgent.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents;
+
+use BuiltByBerry\LaravelSwarm\Contracts\Agent;
+use BuiltByBerry\LaravelSwarm\Tools\Recall;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Container\Container;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Responses\AgentResponse;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\ToolCall as ToolCallData;
+use Laravel\Ai\Responses\Data\ToolResult as ToolResultData;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\QueuedAgentResponse;
+use Laravel\Ai\Responses\StreamableAgentResponse;
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\TextEnd;
+use Laravel\Ai\Streaming\Events\ToolCall;
+use Laravel\Ai\Streaming\Events\ToolResult;
+use Laravel\Ai\Tools\Request;
+use RuntimeException;
+use Stringable;
+
+/**
+ * Final streaming agent that recalls the **Conversation**-scoped `finding`
+ * mid-stream. The Recall tool resolves the conversation scope id from the active
+ * run's `RunContext::conversationId()`, so the value this agent surfaces depends
+ * on which run's frame is active — making it the right probe for asserting that
+ * the conversation handle stays frame-isolated when two streamed runs are
+ * interleaved in one process (the Octane fiber model).
+ *
+ * @phpstan-import-type LaravelAiAgentAttachments from \BuiltByBerry\LaravelSwarm\Support\PhpStanTypeAliases
+ * @phpstan-import-type LaravelAiAgentProvider from \BuiltByBerry\LaravelSwarm\Support\PhpStanTypeAliases
+ * @phpstan-import-type SwarmBroadcastChannels from \BuiltByBerry\LaravelSwarm\Support\PhpStanTypeAliases
+ */
+class StreamingConversationRecallAgent implements Agent
+{
+    public function instructions(): Stringable|string
+    {
+        return 'You read conversation-scoped memory before answering.';
+    }
+
+    /**
+     * @param  LaravelAiAgentAttachments  $attachments
+     * @param  LaravelAiAgentProvider  $provider
+     */
+    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    {
+        return new AgentResponse(
+            invocationId: 'streaming-conversation-recall',
+            text: 'unused',
+            usage: new Usage,
+            meta: new Meta('fake', 'test'),
+        );
+    }
+
+    /**
+     * @param  LaravelAiAgentAttachments  $attachments
+     * @param  LaravelAiAgentProvider  $provider
+     */
+    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    {
+        return new StreamableAgentResponse('streaming-conversation-recall-invocation', function (): \Generator {
+            $timestamp = 1_710_000_000;
+            $arguments = ['key' => 'finding', 'scope' => 'conversation'];
+
+            // The Recall tool resolves the conversation scope id from the active
+            // run frame's conversation handle — so a frame bleed would surface the
+            // other run's conversation entry here.
+            $result = Container::getInstance()->make(Recall::class)->handle(new Request($arguments));
+
+            $toolCall = new ToolCallData(
+                id: 'recall-call-1',
+                name: 'recall',
+                arguments: $arguments,
+                resultId: 'recall-result-1',
+            );
+            $toolResult = new ToolResultData(
+                id: 'recall-call-1',
+                name: 'recall',
+                arguments: $arguments,
+                result: $result,
+                resultId: 'recall-result-1',
+            );
+
+            yield new ToolCall('tool-call-recall', $toolCall, $timestamp);
+            yield new ToolResult('tool-result-recall', $toolResult, true, null, $timestamp);
+            yield new TextDelta('delta-recall', 'message-recall', $result, $timestamp);
+            yield new TextEnd('text-end-recall', 'message-recall', $timestamp);
+            yield new StreamEnd('stream-end-recall', 'stop', new Usage(promptTokens: 1, completionTokens: 1), $timestamp);
+        }, new Meta('fake', 'test'));
+    }
+
+    /**
+     * @param  LaravelAiAgentAttachments  $attachments
+     * @param  LaravelAiAgentProvider  $provider
+     */
+    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    {
+        throw new RuntimeException('Queueing is not supported in this test fixture.');
+    }
+
+    /**
+     * @param  SwarmBroadcastChannels  $channels
+     * @param  LaravelAiAgentAttachments  $attachments
+     * @param  LaravelAiAgentProvider  $provider
+     */
+    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    {
+        throw new RuntimeException('Broadcasting is not supported in this test fixture.');
+    }
+
+    /**
+     * @param  SwarmBroadcastChannels  $channels
+     * @param  LaravelAiAgentAttachments  $attachments
+     * @param  LaravelAiAgentProvider  $provider
+     */
+    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    {
+        throw new RuntimeException('Broadcasting is not supported in this test fixture.');
+    }
+
+    /**
+     * @param  SwarmBroadcastChannels  $channels
+     * @param  LaravelAiAgentAttachments  $attachments
+     * @param  LaravelAiAgentProvider  $provider
+     */
+    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    {
+        throw new RuntimeException('Broadcast queueing is not supported in this test fixture.');
+    }
+}

--- a/tests/Fixtures/Swarms/StreamingConversationRecallSwarm.php
+++ b/tests/Fixtures/Swarms/StreamingConversationRecallSwarm.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms;
+
+use BuiltByBerry\LaravelSwarm\Attributes\Topology;
+use BuiltByBerry\LaravelSwarm\Concerns\Runnable;
+use BuiltByBerry\LaravelSwarm\Contracts\Swarm;
+use BuiltByBerry\LaravelSwarm\Enums\Topology as TopologyEnum;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\StreamingConversationRecallAgent;
+
+/**
+ * Single-step sequential swarm whose only agent recalls Conversation-scoped
+ * memory mid-stream. Used (with a Conversation-declaring propagation policy) to
+ * assert the conversation handle stays frame-isolated across two interleaved
+ * in-process streamed runs (#186 × the streaming run frame).
+ */
+#[Topology(TopologyEnum::Sequential)]
+class StreamingConversationRecallSwarm implements Swarm
+{
+    use Runnable;
+
+    public function agents(): array
+    {
+        return [
+            new StreamingConversationRecallAgent,
+        ];
+    }
+}


### PR DESCRIPTION
Phase 1 (review-followups) of the v0.12.0 wrap. A **focused integration review** of the assembled release branch (`release/v0.12.0` vs `main` — the whole milestone) was run, since each component had only been reviewed individually. The integrated diff came back **integration-clean**: no high, no correctness blockers (store-keying, frozen-view override lifecycle, per-run frame composition under Octane, purge accounting, migration ordering, and the deferred-durable scope all verified sound).

This PR closes the 1 medium + 1 low (both docs) and the 1 actionable open gap.

## Resolutions
- **F1 (medium, docs)** — Documented the Sequential-vs-hierarchical resume asymmetry: #202's skip-on-resume is Sequential-only; static-hierarchical streamed resume re-executes every node under the frozen view (memory deterministic, but usage/`step.completed` telemetry/events duplicated across attempts). `StaticHierarchicalStreamRunner` docblock + `docs/streaming.md`.
- **F2 (low, docs)** — Caveat that the skip path re-runs step guardrails on the rehydrated output, so step guardrails must be deterministic. `docs/streaming.md`.
- **OG2 (test)** — Added an Octane-style interleave test (`StreamingConversationRecallAgent`/`Swarm` + test) asserting two interleaved in-process streamed runs with distinct conversation ids each read their own conversation entry (no handle bleed). Composes with the existing frozen-view interleave test to lock the per-run frame seam.

## Deferred
- **OG1** — The `2026_06_08` capture-columns-nullable migration's `->nullable()->change()` on pre-populated columns is driver-sensitive (mysql/pgsql); low risk on Laravel 13 (native change support, no FK/rename). **Verify via the CI migrate matrix.** Tracked as `capture-nullable-multidriver-migrate`.

## Verification
Full suite **1492 passed**, PHPStan clean, Pint clean (PHP 8.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)