### PR TITLE
chore(release): 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.12.0 - unreleased
+## v0.12.0 - 2026-06-12
 
 Close every open-ended / half-built feature surfaced by the v0.11.0 audit: memory completeness, audit fidelity, durable/streaming execution, and contract surface.
 

--- a/README.md
+++ b/README.md
@@ -294,6 +294,21 @@ $stream = ContentPipeline::make()
 
 Replay later with `SwarmHistory::replay($runId)`. See [Streaming](docs/streaming.md) for event schemas, replay behavior, capture, limits, and failure handling.
 
+### Crash-replay resume (v0.12.0)
+
+A streamed run that is abandoned mid-stream — a worker crash, a dropped connection, an early `break` — can be resumed by re-running the same swarm with the **same run id**:
+
+```php
+$runId = (string) Str::uuid();
+
+ArticlePipeline::make()->stream(RunContext::from($task, $runId)); // abandoned mid-stream
+
+// Resume on a fresh worker: same run id picks up where it left off.
+return ArticlePipeline::make()->stream(RunContext::from($task, $runId));
+```
+
+On resume, already-completed non-final steps are **skipped** (their providers are not re-invoked and tool side effects do not re-fire — their output is rehydrated from a per-step checkpoint), and the terminal streamed step **replays byte-identically** from its frozen memory snapshot. Governed by the memory replay mode (`frozen_view` default; `fresh_execution` opts out) and the database persistence driver. See [Streaming — Crash-Replay Durability](docs/streaming.md#crash-replay-durability).
+
 ## Durable Execution
 
 Use `dispatchDurable()` when the workflow is too important or too long-lived for one queue job:

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "0.11.x-dev"
+            "dev-main": "0.12.x-dev"
         },
         "laravel": {
             "providers": [


### PR DESCRIPTION
Phase 2 (release-wrap) of the v0.12.0 wrap. Deterministic every-release chores; no behavior change.

## Changes
- **CHANGELOG** — flipped `## v0.12.0 - unreleased` → `## v0.12.0 - 2026-06-12`. The entries were already complete: all 10 feature/fix PRs represented (#190 #191 #192 #203 #202 #186 #187 #189 #198 #159); the test (#204) and chore (#209) PRs need no entry.
- **branch-alias** — `extra.branch-alias.dev-main` bumped `0.11.x-dev` → `0.12.x-dev` (the recurring lag). `composer.lock` is gitignored for this package, so no lock refresh.
- **README** — added a **Crash-replay resume (v0.12.0)** subsection to the Streaming section. The marquee streaming feature (#192/#202: re-run the same run id to resume — non-final steps skipped, terminal step replays byte-identically) was previously invisible there; the section only documented persisted SSE replay (`storeForReplay`), a different thing.
- **UPGRADING** — already complete: all 3 breaking (#187 Skip omission, #187 schema_version 3, #189 HasStructuredOutput) + 2 behavior-change (#159, #202) + 1 new (#191) blocks present. No change.

## Breaking-change roll-up (for the release notes / tag)
- **#187** — `CaptureDecision::Skip` now omits fields entirely (column NULL / key absent) instead of `[redacted]`; `EvidenceEnvelope::SCHEMA_VERSION` → `"3"`.
- **#189** — `Contracts\HasStructuredOutput` removed (switch the `use` to `Laravel\Ai\Contracts\HasStructuredOutput`).

All covered in [UPGRADING.md](UPGRADING.md#upgrading-to-v0120).

Next: Phase 3 — readiness review (`swarm-release-readiness`, tag mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)