### PR TITLE
chore(release): v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.12.1 - unreleased
+## v0.12.1 - 2026-06-14
 
 Operational resume reads decrypt strictly via `openStrict()`, independent of the display `decrypt_failure_policy`.
 


### PR DESCRIPTION
Phase 2 of the v0.12.1 wrap.

## Changes
- **CHANGELOG:** stamp `## v0.12.1 - 2026-06-14` (the #212 durable decrypt-strict entry was filled on the topic branch).

## Wrap hygiene (verified, no change needed)
- `composer.json` `branch-alias.dev-main` already `0.12.x-dev` (matches the release minor).
- `UPGRADING.md` v0.12.1 block already present (filled on the topic branch).
- No README marquee — v0.12.1 is an internal durable-runtime correctness/hardening patch with no new user-facing feature; the operator-facing behavior (wrong `APP_KEY` now fails durable resume loud) is documented in UPGRADING.

## Breaking / deploy-safety roll-up
- **No** breaking changes, **no** migrations, no application-code change. `DurableRunStore` public read API unchanged.

Next phase: release-readiness review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)