### PR TITLE
docs(scheduler): standardize scheduler-location docs on routes/console.php (#218)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _To be filled in during release wrap-up._
 
 ### Fixed
 
-_To be filled in during release wrap-up._
+- Standardized scheduler-location docs on `routes/console.php` (the only valid location for this Laravel-13-only package). Removed stale `bootstrap/app.php` and `app/Console/Kernel.php` references from `docs/durable-execution.md`, `docs/configuration.md`, and `docs/execution-modes.md` so copying the relay/recover/prune schedule into the wrong file can no longer leave the scheduler silently non-running. (#218)
 
 ## v0.12.1 - 2026-06-14
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -205,7 +205,7 @@ Settings for `dispatchDurable()` execution. Durable runs are database-backed and
 The transactional outbox relay (`swarm:relay`) drains `swarm_durable_outbox` rows and dispatches the corresponding queue jobs. **You must schedule this command for durable execution to advance:**
 
 ```php
-// app/Console/Kernel.php or routes/console.php
+// routes/console.php
 Schedule::command('swarm:relay')->everyMinute();
 ```
 
@@ -362,7 +362,7 @@ SWARM_OBSERVABILITY_FAILURE_POLICY=swallow
 SWARM_AUDIT_FAILURE_POLICY=swallow
 ```
 
-Schedule in `routes/console.php` or `app/Console/Kernel.php`:
+Schedule in `routes/console.php`:
 
 ```php
 Schedule::command('swarm:prune')->daily();
@@ -391,7 +391,7 @@ SWARM_WEBHOOK_SECRET=your-secret-here
 SWARM_WEBHOOK_TOLERANCE_SECONDS=300
 ```
 
-Schedule in `routes/console.php` or `app/Console/Kernel.php`:
+Schedule in `routes/console.php`:
 
 ```php
 Schedule::command('swarm:relay')->everyMinute();

--- a/docs/durable-execution.md
+++ b/docs/durable-execution.md
@@ -83,7 +83,7 @@ next queue job. Without it, the swarm starts but never advances past the first
 step.
 
 ```php
-// bootstrap/app.php or Console/Kernel.php
+// routes/console.php
 Schedule::command('swarm:relay')->everyMinute();
 ```
 

--- a/docs/execution-modes.md
+++ b/docs/execution-modes.md
@@ -322,7 +322,7 @@ Make sure the following is in place before switching to durable execution:
     'driver' => 'database', // required for durable execution
 ],
 
-// app/Console/Kernel.php or routes/console.php
+// routes/console.php
 Schedule::command('swarm:recover')->everyMinute();
 Schedule::command('swarm:prune')->daily();
 ```


### PR DESCRIPTION
## Summary

Several docs referenced scheduler locations that don't exist in this Laravel-13-only package (`illuminate/* ^13.0`). `bootstrap/app.php` is never a scheduler location, and `app/Console/Kernel.php` was removed in Laravel 11+. A reader copying these into the wrong file gets a silently non-running scheduler (`swarm:relay`/`swarm:recover`/`swarm:prune` never fire).

This is a location-string correction only — the scheduler setup guidance itself is unchanged.

- `docs/durable-execution.md` — `// bootstrap/app.php or Console/Kernel.php` → `// routes/console.php`
- `docs/execution-modes.md` — `// app/Console/Kernel.php or routes/console.php` → `// routes/console.php`
- `docs/configuration.md` (3 spots) — dropped the `app/Console/Kernel.php` alternative, standardized on `routes/console.php`
- CHANGELOG entry added under v0.12.2 (Fixed)

The one remaining `app/Console/Kernel.php` reference (`docs/advanced-setup.md:173`) is left intact because it explicitly documents Laravel 10 history.

## Verification

- `grep -rn "bootstrap/app.php\|Console/Kernel.php" docs/` — only the intentional Laravel 10 history note remains
- `pint --test` — passed (docs-only; no PHP touched)

Closes #218