### PR TITLE
fix(idiom): readonly StreamedSwarmResponse events + Pulse Collection chain (#222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _To be filled in during release wrap-up._
 
 ### Changed
 
-_To be filled in during release wrap-up._
+- **Idiom/immutability nits (#222).** `StreamedSwarmResponse::$events` is now declared `readonly`, closing a value-object immutability hole — its parent `SwarmResponse` already marks every prop `readonly`, and `$events` is never reassigned after construction. The Pulse `SwarmRuns` card's topology/count assembly (`src/Pulse/Livewire/SwarmRuns.php`) is now expressed as Collection chains (`->filter()->sortByDesc()->values()`) instead of procedural `array_filter` + `usort` wrapped in `collect()`, matching the package's Laravel-native idiom. Zero behavior change: same filtering, same sort order, same Pulse card output.
 
 ### Fixed
 

--- a/src/Pulse/Livewire/SwarmRuns.php
+++ b/src/Pulse/Livewire/SwarmRuns.php
@@ -53,13 +53,14 @@ class SwarmRuns extends Card
             $durationSamples = (int) ($row->swarm_run_duration_samples ?? 0);
             $totalRuns = (int) ($row->swarm_run_total ?? 0);
             $failures = (int) ($row->swarm_run_failed ?? 0);
-            $topologyMix = array_filter([
+            $topologyMix = collect([
                 (object) ['topology' => 'sequential', 'count' => (int) ($row->swarm_topology_sequential ?? 0)],
                 (object) ['topology' => 'parallel', 'count' => (int) ($row->swarm_topology_parallel ?? 0)],
                 (object) ['topology' => 'hierarchical', 'count' => (int) ($row->swarm_topology_hierarchical ?? 0)],
-            ], fn (object $topology): bool => $topology->count > 0);
-
-            usort($topologyMix, fn (object $left, object $right): int => $right->count <=> $left->count);
+            ])
+                ->filter(fn (object $topology): bool => $topology->count > 0)
+                ->sortByDesc('count')
+                ->values();
 
             $counts[] = (object) [
                 'swarmClass' => $row->key,
@@ -67,12 +68,12 @@ class SwarmRuns extends Card
                 'failures' => $failures,
                 'failureRate' => $totalRuns === 0 ? 0.0 : round(($failures / $totalRuns) * 100, 1),
                 'averageRunDurationMs' => $durationSamples === 0 ? 0 : (int) round($durationTotalMs / $durationSamples),
-                'topologyMix' => collect($topologyMix),
+                'topologyMix' => $topologyMix,
             ];
         }
 
-        usort($counts, fn (object $left, object $right): int => $right->totalRuns <=> $left->totalRuns);
-
-        return collect($counts);
+        return collect($counts)
+            ->sortByDesc('totalRuns')
+            ->values();
     }
 }

--- a/src/Responses/StreamedSwarmResponse.php
+++ b/src/Responses/StreamedSwarmResponse.php
@@ -17,7 +17,7 @@ class StreamedSwarmResponse extends SwarmResponse
      */
     public function __construct(
         SwarmResponse $response,
-        public Collection $events,
+        public readonly Collection $events,
     ) {
         parent::__construct(
             output: $response->output,


### PR DESCRIPTION
## Summary

Two small, zero-behavior idiom corrections from the improve-laravel audit:

1. **`StreamedSwarmResponse::$events` is now `readonly`** (`src/Responses/StreamedSwarmResponse.php`). Closes a value-object immutability hole: the parent `SwarmResponse` already marks every prop `readonly`, and `$events` is never reassigned after construction (verified — every `$this->events` write across `src/` belongs to the unrelated `StreamableSwarmResponse` and other classes, never this DTO).

2. **Pulse `SwarmRuns` topology/count assembly is now a Collection chain** (`src/Pulse/Livewire/SwarmRuns.php`). The inner `array_filter` + `usort` + `collect()` is now `collect(...)->filter(...)->sortByDesc('count')->values()`, and the outer `usort($counts)` + `collect()` is now `collect($counts)->sortByDesc('totalRuns')->values()` — matching the package's Laravel-native idiom. Behavior-preserving: same filtering, same descending sort order (stable on ties, as PHP's `usort` was here), same final shape and Pulse card output.

## Verification

- `vendor/bin/pint --test` — passed
- `composer analyse` (PHPStan) — no errors
- `composer test` — 1520 passed (5626 assertions)

## Out of scope

Broader Collection-idiom sweeps elsewhere in `src/` — only the two cited sites were touched.

Closes #222