### PR TITLE
chore(ci): add composer audit advisory gate (#219)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,42 @@
+name: audit
+
+on:
+  push:
+    branches:
+      - main
+      - '*.x'
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: composer audit (advisories)
+    runs-on: ubuntu-24.04
+    # Non-blocking for now: surfaces dependency advisories on every push/PR
+    # without gating merges on a transient upstream advisory that may land
+    # mid-review. Path to gating: drop `continue-on-error` once the tree has
+    # held advisory-clean for a release cycle (tracked alongside the v0.12.2
+    # hardening work). This package commits no composer.lock, so the audit
+    # runs against a freshly resolved --prefer-stable tree — the same
+    # resolution CI tests against in tests.yml.
+    continue-on-error: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          tools: composer:v2
+          coverage: none
+          ini-values: memory_limit=1G
+
+      - name: Resolve dependencies
+        run: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
+
+      - name: Audit dependencies for known advisories
+        run: composer audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _To be filled in during release wrap-up._
 
 ### Changed
 
-_To be filled in during release wrap-up._
+- **Added a `composer audit` CI job that surfaces dependency advisories on every push and PR (#219).** The new `.github/workflows/audit.yml` resolves a fresh `--prefer-stable` tree (this package commits no `composer.lock`, so CI always tests against a freshly resolved tree) and runs `composer audit`. It starts non-blocking (`continue-on-error: true`) so a transient upstream advisory landing mid-review never gates a merge; the documented path to gating is to drop `continue-on-error` once the tree has held advisory-clean for a release cycle. The advisory-affected transitive deps flagged at the time (`guzzlehttp/psr7`, `symfony/http-foundation`, `symfony/routing`, `symfony/polyfill-intl-idn`) resolve advisory-clean under the current constraints, so no top-level constraints in `composer.json` changed.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,14 @@ fast path without coverage. If workflow runtime becomes prohibitive, maintainers
 split **lowest**-resolution lint, coverage, or process-concurrency into a nightly job;
 until then, pull requests validate both matrices equally.
 
+**Dependency advisories** — a separate `audit` workflow runs `composer audit` on
+every push and pull request against a freshly resolved `--prefer-stable` tree (this
+package commits no `composer.lock`, so CI always audits the same resolution it tests).
+It is **non-blocking** today (`continue-on-error: true`) so a transient upstream
+advisory landing mid-review never gates a merge; the path to gating is to drop
+`continue-on-error` once the tree has held advisory-clean for a release cycle. Run
+`composer audit` locally to match it.
+
 **Process concurrency validation** — CI runs `composer test:process-concurrency:ci`
 on every matrix row. That script is like `composer test:process-concurrency` but adds
 Pest’s `--fail-on-skipped`, so the workflow **fails** if any test in that folder is


### PR DESCRIPTION
## Summary

Adds a `composer audit` advisory gate to CI so dependency advisories surface on every push and PR instead of landing silently.

- **New workflow** `.github/workflows/audit.yml` — resolves a fresh `--prefer-stable` tree and runs `composer audit`. Mirrors the existing CI style (ubuntu-24.04, `setup-php@v2`, PHP 8.5, `checkout@v6`).
- **Non-blocking to start** (`continue-on-error: true`) so a transient upstream advisory landing mid-review never gates a merge. Documented path to gating: drop `continue-on-error` once the tree has held advisory-clean for a release cycle.
- **No lockfile refresh needed / possible** — this package gitignores `composer.lock`, so CI always resolves fresh. The 8 advisories cited in the issue came from a stale local lockfile; a fresh `composer update --prefer-stable` resolves the advisory-affected transitive deps advisory-clean: `guzzlehttp/psr7` 2.11.0, `symfony/http-foundation`/`symfony/routing` v8.1.0, `symfony/polyfill-intl-idn` v1.38.1. **`composer audit` is clean locally.** No top-level `composer.json` constraints changed (per scope).
- **Docs** — CHANGELOG entry under `## v0.12.2` (Changed) and a short `Dependency advisories` note in CONTRIBUTING.md matching the existing CI-section style.

## Verification (local, stable-latest resolution)

- `composer audit` — No security vulnerability advisories found
- `composer test` — 1520 passed (5626 assertions)
- `vendor/bin/pint --test` — passed
- `composer analyse` — No errors

## Deferred

- The audit job is intentionally non-blocking; flip `continue-on-error` to `false` to gate once stable (noted in the workflow comment, CHANGELOG, and CONTRIBUTING).

Closes #219