### PR TITLE
test(streaming): isolated serialization round-trip tests for events (#221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Hardening & hygiene — close the vetted improve-laravel audit findings (against
 
 ### Added
 
-_To be filled in during release wrap-up._
+- **Isolated serialization round-trip coverage for every `Streaming/Events/*` event (#221).** The 12 streaming event classes' `toArray()`/`fromArray()` were only exercised end-to-end via the crash-replay feature tests, where a silently dropped field (e.g. an error event losing `recoverable` or its `exception_class`) would surface only on a real replay. A new `tests/Unit/Streaming/EventSerializationRoundTripTest.php` asserts, per class over representative null/empty/full payloads, that `toArray()` → `SwarmStreamEvent::fromArray()` → `toArray()` round-trips identically and that every field — including the base-class `invocation_id` — survives. A directory-enumeration guard fails the suite if a new `src/Streaming/Events/*` class is added without a round-trip payload case. Coverage only — no event serialization shape changed.
 
 ### Changed
 

--- a/tests/Unit/Streaming/EventSerializationRoundTripTest.php
+++ b/tests/Unit/Streaming/EventSerializationRoundTripTest.php
@@ -1,0 +1,413 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Streaming\Events\SwarmReasoningDelta;
+use BuiltByBerry\LaravelSwarm\Streaming\Events\SwarmReasoningEnd;
+use BuiltByBerry\LaravelSwarm\Streaming\Events\SwarmStepEnd;
+use BuiltByBerry\LaravelSwarm\Streaming\Events\SwarmStepStart;
+use BuiltByBerry\LaravelSwarm\Streaming\Events\SwarmStreamEnd;
+use BuiltByBerry\LaravelSwarm\Streaming\Events\SwarmStreamError;
+use BuiltByBerry\LaravelSwarm\Streaming\Events\SwarmStreamEvent;
+use BuiltByBerry\LaravelSwarm\Streaming\Events\SwarmStreamStart;
+use BuiltByBerry\LaravelSwarm\Streaming\Events\SwarmTextDelta;
+use BuiltByBerry\LaravelSwarm\Streaming\Events\SwarmTextEnd;
+use BuiltByBerry\LaravelSwarm\Streaming\Events\SwarmToolCall;
+use BuiltByBerry\LaravelSwarm\Streaming\Events\SwarmToolResult;
+
+/**
+ * Direct, data-driven serialization coverage for every concrete
+ * `Streaming/Events/*` event. These classes are otherwise only exercised
+ * end-to-end via the crash-replay feature tests, where a silent field drop
+ * (e.g. an error event losing `recoverable` or its `exception_class`) would
+ * surface only on a real replay. Here we assert per class that
+ * `toArray()` → `SwarmStreamEvent::fromArray()` → `toArray()` is identical
+ * and that every field on the original payload survives the round trip.
+ *
+ * Deserialization goes through the base `SwarmStreamEvent::fromArray()`
+ * dispatcher rather than each class's own `fromArray()` because that is the
+ * realistic replay path: it routes on `type`, restores `invocation_id`, and
+ * delegates to the concrete class. Round-tripping through it proves the type
+ * tag and invocation-id plumbing survive alongside the class-specific fields.
+ */
+
+/**
+ * The concrete events under test. The directory-enumeration guard below
+ * asserts this list stays in lock-step with `src/Streaming/Events/*`, so a
+ * newly added event class fails the suite until it is given coverage here.
+ *
+ * @var array<class-string<SwarmStreamEvent>>
+ */
+const ROUND_TRIP_EVENT_CLASSES = [
+    SwarmReasoningDelta::class,
+    SwarmReasoningEnd::class,
+    SwarmStepEnd::class,
+    SwarmStepStart::class,
+    SwarmStreamEnd::class,
+    SwarmStreamError::class,
+    SwarmStreamStart::class,
+    SwarmTextDelta::class,
+    SwarmTextEnd::class,
+    SwarmToolCall::class,
+    SwarmToolResult::class,
+];
+
+/**
+ * Representative payloads per event class: a "full" payload exercising every
+ * field with a meaningful value, and a "null/empty" payload exercising the
+ * nullable/optional fields at their absent extreme. Every payload carries an
+ * explicit `invocation_id` so the round trip also covers that base-class field.
+ *
+ * Each payload is the canonical `toArray()` shape — what is actually persisted —
+ * so re-serializing the rehydrated event must reproduce it byte-for-byte.
+ *
+ * @return array<string, array{0: class-string<SwarmStreamEvent>, 1: array<string, mixed>}>
+ */
+function event_payload_cases(): array
+{
+    $cases = [];
+
+    // SwarmReasoningDelta — full + null delta/summary.
+    $cases['reasoning_delta full'] = [SwarmReasoningDelta::class, [
+        'id' => 'evt-rd-1',
+        'invocation_id' => 'inv-rd-1',
+        'type' => 'swarm_reasoning_delta',
+        'run_id' => 'run-1',
+        'step_index' => 3,
+        'agent_class' => 'App\\Agents\\Thinker',
+        'reasoning_id' => 'reason-1',
+        'delta' => 'because the sky is blue',
+        'timestamp' => 1_700_000_000,
+        'summary' => ['key' => 'value', 'nested' => ['deep' => true]],
+    ]];
+    $cases['reasoning_delta null delta and summary'] = [SwarmReasoningDelta::class, [
+        'id' => 'evt-rd-2',
+        'invocation_id' => 'inv-rd-2',
+        'type' => 'swarm_reasoning_delta',
+        'run_id' => 'run-1',
+        'step_index' => 0,
+        'agent_class' => 'App\\Agents\\Thinker',
+        'reasoning_id' => 'reason-2',
+        'delta' => null,
+        'timestamp' => 1_700_000_001,
+        'summary' => null,
+    ]];
+
+    // SwarmReasoningEnd — full + null summary.
+    $cases['reasoning_end full'] = [SwarmReasoningEnd::class, [
+        'id' => 'evt-re-1',
+        'invocation_id' => 'inv-re-1',
+        'type' => 'swarm_reasoning_end',
+        'run_id' => 'run-1',
+        'step_index' => 2,
+        'agent_class' => 'App\\Agents\\Thinker',
+        'reasoning_id' => 'reason-1',
+        'timestamp' => 1_700_000_002,
+        'summary' => ['turns' => 4],
+    ]];
+    $cases['reasoning_end null summary'] = [SwarmReasoningEnd::class, [
+        'id' => 'evt-re-2',
+        'invocation_id' => 'inv-re-2',
+        'type' => 'swarm_reasoning_end',
+        'run_id' => 'run-1',
+        'step_index' => 0,
+        'agent_class' => 'App\\Agents\\Thinker',
+        'reasoning_id' => 'reason-2',
+        'timestamp' => 1_700_000_003,
+        'summary' => null,
+    ]];
+
+    // SwarmStepEnd — full + null output / null duration / empty metadata.
+    $cases['step_end full'] = [SwarmStepEnd::class, [
+        'id' => 'evt-se-1',
+        'invocation_id' => 'inv-se-1',
+        'type' => 'swarm_step_end',
+        'run_id' => 'run-1',
+        'step_index' => 1,
+        'agent_class' => 'App\\Agents\\Writer',
+        'agent' => 'writer',
+        'output' => 'the finished draft',
+        'duration_ms' => 1234,
+        'metadata' => ['tokens' => 42, 'cached' => false],
+        'timestamp' => 1_700_000_004,
+    ]];
+    $cases['step_end null output and duration, empty metadata'] = [SwarmStepEnd::class, [
+        'id' => 'evt-se-2',
+        'invocation_id' => 'inv-se-2',
+        'type' => 'swarm_step_end',
+        'run_id' => 'run-1',
+        'step_index' => 0,
+        'agent_class' => 'App\\Agents\\Writer',
+        'agent' => 'writer',
+        'output' => null,
+        'duration_ms' => null,
+        'metadata' => [],
+        'timestamp' => 1_700_000_005,
+    ]];
+
+    // SwarmStepStart — full + null input.
+    $cases['step_start full'] = [SwarmStepStart::class, [
+        'id' => 'evt-ss-1',
+        'invocation_id' => 'inv-ss-1',
+        'type' => 'swarm_step_start',
+        'run_id' => 'run-1',
+        'step_index' => 1,
+        'agent_class' => 'App\\Agents\\Writer',
+        'agent' => 'writer',
+        'input' => 'write the intro',
+        'timestamp' => 1_700_000_006,
+    ]];
+    $cases['step_start null input'] = [SwarmStepStart::class, [
+        'id' => 'evt-ss-2',
+        'invocation_id' => 'inv-ss-2',
+        'type' => 'swarm_step_start',
+        'run_id' => 'run-1',
+        'step_index' => 0,
+        'agent_class' => 'App\\Agents\\Writer',
+        'agent' => 'writer',
+        'input' => null,
+        'timestamp' => 1_700_000_007,
+    ]];
+
+    // SwarmStreamEnd — full + null output / empty usage+metadata.
+    $cases['stream_end full'] = [SwarmStreamEnd::class, [
+        'id' => 'evt-end-1',
+        'invocation_id' => 'inv-end-1',
+        'type' => 'swarm_stream_end',
+        'run_id' => 'run-1',
+        'output' => 'final answer',
+        'usage' => ['input_tokens' => 100, 'output_tokens' => 50],
+        'metadata' => ['model' => 'demo'],
+        'timestamp' => 1_700_000_008,
+    ]];
+    $cases['stream_end null output, empty usage and metadata'] = [SwarmStreamEnd::class, [
+        'id' => 'evt-end-2',
+        'invocation_id' => 'inv-end-2',
+        'type' => 'swarm_stream_end',
+        'run_id' => 'run-1',
+        'output' => null,
+        'usage' => [],
+        'metadata' => [],
+        'timestamp' => 1_700_000_009,
+    ]];
+
+    // SwarmStreamError — full (recoverable true) + null message/class + recoverable false.
+    $cases['stream_error full recoverable'] = [SwarmStreamError::class, [
+        'id' => 'evt-err-1',
+        'invocation_id' => 'inv-err-1',
+        'type' => 'swarm_stream_error',
+        'run_id' => 'run-1',
+        'message' => 'provider timed out',
+        'exception_class' => 'RuntimeException',
+        'recoverable' => true,
+        'metadata' => ['attempt' => 2],
+        'timestamp' => 1_700_000_010,
+    ]];
+    $cases['stream_error null message and class, not recoverable'] = [SwarmStreamError::class, [
+        'id' => 'evt-err-2',
+        'invocation_id' => 'inv-err-2',
+        'type' => 'swarm_stream_error',
+        'run_id' => 'run-1',
+        'message' => null,
+        'exception_class' => null,
+        'recoverable' => false,
+        'metadata' => [],
+        'timestamp' => 1_700_000_011,
+    ]];
+
+    // SwarmStreamStart — full + null input / empty metadata.
+    $cases['stream_start full'] = [SwarmStreamStart::class, [
+        'id' => 'evt-start-1',
+        'invocation_id' => 'inv-start-1',
+        'type' => 'swarm_stream_start',
+        'run_id' => 'run-1',
+        'swarm_class' => 'App\\Swarms\\Demo',
+        'topology' => 'sequential',
+        'input' => 'kick off the run',
+        'metadata' => ['labels' => ['a', 'b']],
+        'timestamp' => 1_700_000_012,
+    ]];
+    $cases['stream_start null input, empty metadata'] = [SwarmStreamStart::class, [
+        'id' => 'evt-start-2',
+        'invocation_id' => 'inv-start-2',
+        'type' => 'swarm_stream_start',
+        'run_id' => 'run-1',
+        'swarm_class' => 'App\\Swarms\\Demo',
+        'topology' => 'hierarchical',
+        'input' => null,
+        'metadata' => [],
+        'timestamp' => 1_700_000_013,
+    ]];
+
+    // SwarmTextDelta — full + null delta.
+    $cases['text_delta full'] = [SwarmTextDelta::class, [
+        'id' => 'evt-td-1',
+        'invocation_id' => 'inv-td-1',
+        'type' => 'swarm_text_delta',
+        'run_id' => 'run-1',
+        'step_index' => 1,
+        'agent_class' => 'App\\Agents\\Writer',
+        'delta' => 'Hello, ',
+        'timestamp' => 1_700_000_014,
+    ]];
+    $cases['text_delta null delta'] = [SwarmTextDelta::class, [
+        'id' => 'evt-td-2',
+        'invocation_id' => 'inv-td-2',
+        'type' => 'swarm_text_delta',
+        'run_id' => 'run-1',
+        'step_index' => 0,
+        'agent_class' => 'App\\Agents\\Writer',
+        'delta' => null,
+        'timestamp' => 1_700_000_015,
+    ]];
+
+    // SwarmTextEnd — single representative payload (no nullable fields).
+    $cases['text_end full'] = [SwarmTextEnd::class, [
+        'id' => 'evt-te-1',
+        'invocation_id' => 'inv-te-1',
+        'type' => 'swarm_text_end',
+        'run_id' => 'run-1',
+        'step_index' => 1,
+        'agent_class' => 'App\\Agents\\Writer',
+        'message_id' => 'msg-1',
+        'timestamp' => 1_700_000_016,
+    ]];
+
+    // SwarmToolCall — full nested ToolCall + minimal nested ToolCall.
+    $cases['tool_call full'] = [SwarmToolCall::class, [
+        'id' => 'evt-tc-1',
+        'invocation_id' => 'inv-tc-1',
+        'type' => 'swarm_tool_call',
+        'run_id' => 'run-1',
+        'step_index' => 1,
+        'agent_class' => 'App\\Agents\\Worker',
+        'tool_call' => [
+            'id' => 'call-1',
+            'name' => 'search',
+            'arguments' => ['q' => 'laravel'],
+            'result_id' => 'res-1',
+            'reasoning_id' => 'reason-1',
+            'reasoning_summary' => ['step' => 'plan'],
+        ],
+        'timestamp' => 1_700_000_017,
+    ]];
+    $cases['tool_call minimal nested nulls'] = [SwarmToolCall::class, [
+        'id' => 'evt-tc-2',
+        'invocation_id' => 'inv-tc-2',
+        'type' => 'swarm_tool_call',
+        'run_id' => 'run-1',
+        'step_index' => 0,
+        'agent_class' => 'App\\Agents\\Worker',
+        'tool_call' => [
+            'id' => 'call-2',
+            'name' => 'noop',
+            'arguments' => [],
+            'result_id' => null,
+            'reasoning_id' => null,
+            'reasoning_summary' => null,
+        ],
+        'timestamp' => 1_700_000_018,
+    ]];
+
+    // SwarmToolResult — successful with scalar result + failed with null error/result.
+    $cases['tool_result successful'] = [SwarmToolResult::class, [
+        'id' => 'evt-tr-1',
+        'invocation_id' => 'inv-tr-1',
+        'type' => 'swarm_tool_result',
+        'run_id' => 'run-1',
+        'step_index' => 1,
+        'agent_class' => 'App\\Agents\\Worker',
+        'tool_result' => [
+            'id' => 'call-1',
+            'name' => 'search',
+            'arguments' => ['q' => 'laravel'],
+            'result' => ['hits' => 3],
+            'result_id' => 'res-1',
+        ],
+        'successful' => true,
+        'error' => null,
+        'timestamp' => 1_700_000_019,
+    ]];
+    $cases['tool_result failed null result and error'] = [SwarmToolResult::class, [
+        'id' => 'evt-tr-2',
+        'invocation_id' => 'inv-tr-2',
+        'type' => 'swarm_tool_result',
+        'run_id' => 'run-1',
+        'step_index' => 0,
+        'agent_class' => 'App\\Agents\\Worker',
+        'tool_result' => [
+            'id' => 'call-2',
+            'name' => 'noop',
+            'arguments' => [],
+            'result' => null,
+            'result_id' => null,
+        ],
+        'successful' => false,
+        'error' => 'tool exploded',
+        'timestamp' => 1_700_000_020,
+    ]];
+
+    return $cases;
+}
+
+dataset('event_payloads', fn (): array => event_payload_cases());
+
+test('event payload round-trips identically and preserves every field', function (string $expectedClass, array $payload): void {
+    $event = SwarmStreamEvent::fromArray($payload);
+
+    expect($event)->toBeInstanceOf($expectedClass);
+
+    $roundTripped = $event->toArray();
+
+    // toArray() → fromArray() → toArray() reproduces the canonical shape exactly.
+    expect($roundTripped)->toBe($payload);
+
+    // And re-hydrating once more is stable (idempotent past the first pass).
+    expect(SwarmStreamEvent::fromArray($roundTripped)->toArray())->toBe($payload);
+
+    // Every individual field on the original payload survives by key and value,
+    // so a silently dropped field would fail here even if toArray() happened to
+    // reorder or omit it.
+    foreach ($payload as $key => $value) {
+        expect($roundTripped)->toHaveKey($key);
+        expect($roundTripped[$key])->toEqual($value);
+    }
+
+    // The restored invocation id is carried on the base class, not just echoed
+    // inside the array — the realistic replay path must rehydrate it.
+    expect($event->invocationId)->toBe($payload['invocation_id']);
+})->with('event_payloads');
+
+test('every concrete event class has at least one round-trip payload case', function (): void {
+    $covered = [];
+
+    foreach (event_payload_cases() as $case) {
+        $covered[$case[0]] = true;
+    }
+
+    foreach (ROUND_TRIP_EVENT_CLASSES as $class) {
+        expect($covered)->toHaveKey($class, "Event class [{$class}] has no round-trip payload case.");
+    }
+});
+
+test('round-trip coverage list stays in lock-step with the events directory', function (): void {
+    $directory = dirname(__DIR__, 3).'/src/Streaming/Events';
+
+    $discovered = collect(glob($directory.'/*.php'))
+        ->map(fn (string $path): string => basename($path, '.php'))
+        // SwarmStreamEvent is the abstract base/dispatcher, not a serializable leaf event.
+        ->reject(fn (string $name): bool => $name === 'SwarmStreamEvent')
+        ->map(fn (string $name): string => 'BuiltByBerry\\LaravelSwarm\\Streaming\\Events\\'.$name)
+        ->sort()
+        ->values()
+        ->all();
+
+    $covered = collect(ROUND_TRIP_EVENT_CLASSES)->sort()->values()->all();
+
+    // A new src/Streaming/Events/*.php class added without a coverage entry
+    // (or a stale entry removed from disk) fails the suite here.
+    expect($covered)->toBe(
+        $discovered,
+        'Every src/Streaming/Events/* class (except the abstract SwarmStreamEvent base) must appear in ROUND_TRIP_EVENT_CLASSES with a round-trip payload case.',
+    );
+});


### PR DESCRIPTION
## Summary

The 12 `src/Streaming/Events/*` classes' `toArray()`/`fromArray()` were only exercised end-to-end via the crash-replay feature tests, where a silently dropped field (e.g. an error event losing `recoverable` or its `exception_class`) would surface only on a real replay. This PR adds direct, data-driven round-trip unit coverage per event class.

New `tests/Unit/Streaming/EventSerializationRoundTripTest.php`:

- Asserts, per concrete event class over representative **null/empty/full** payloads, that `toArray()` → `SwarmStreamEvent::fromArray()` → `toArray()` round-trips **identically** and that **every field survives** (by key and value), including the base-class `invocation_id` and nested `ToolCall`/`ToolResult` data.
- Deserializes through the realistic replay path — the base `SwarmStreamEvent::fromArray()` dispatcher — so the `type` tag and invocation-id plumbing are covered alongside class-specific fields.
- Includes a **directory-enumeration guard** that fails the suite if a new `src/Streaming/Events/*` class is added (or removed) without a matching round-trip payload case, keeping coverage in lock-step with the events directory.

Coverage only — no event serialization shape was changed.

### Verification

- `composer test` — 1543 passed (6113 assertions); the new file is 23 passing tests (487 assertions)
- `vendor/bin/pint --test` — passed
- `composer analyse` — no errors

### Deferred work

None — no real serialization bug was found. All 11 concrete events round-trip cleanly through the dispatcher.

Closes #221