### PR TITLE
test(durable): freeze the clock on time-boundary lease/stale assertions (#220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _To be filled in during release wrap-up._
 
 ### Changed
 
-_To be filled in during release wrap-up._
+- Test-determinism: time-boundary durable lease-expiry and stale-run recovery assertions now run inside a frozen clock window (`$this->freezeTime()`), so the past `leased_until`/`updated_at` markers and the runtime's live `now()` resolve to the same instant. Removes the tight sub-second real-clock margin that left the durable/lease/recovery lane vulnerable to execution jitter under load. (Cross-process `tests/ProcessConcurrency` subprocesses keep their generous margins — a frozen clock can't be shared across processes.)
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,24 @@ persisted payloads without coupling every test to the conservative production
 defaults. If your change depends on either default, set it explicitly inside
 the test rather than relying on the `TestCase` value.
 
+### Freeze the clock on time-boundary tests
+
+Durable lease-expiry and stale-run recovery assertions hinge on comparing a
+past timestamp (`leased_until`, `updated_at`) against the runtime's live
+`now()`. Constructing the past marker with `now()->sub…` and asserting against
+a separate live `now()` leaves a real-clock margin that flakes under execution
+jitter. **Freeze the clock with `$this->freezeTime()` before the time-boundary
+marker** so the marker and every `now()` the runtime reads resolve to the same
+instant — the boundary then holds exactly, with no margin to race against. The
+package `TestCase` extends Laravel's, so `$this->freezeTime()` is available in
+any `tests/Feature` or `tests/Unit` closure and is reset automatically after
+each test. The shared `expireDurableLease()`/`staleWaitingRun()` helpers in
+`tests/Feature/DurableSwarmTest.php` assume a frozen clock at their call site.
+
+This does **not** apply to `tests/ProcessConcurrency/*` subprocesses: a frozen
+clock can't be shared across processes, so keep those time-boundary margins
+generous instead.
+
 ### Writing `tests/ProcessConcurrency/*` worker closures
 
 Tests in this lane that pass anonymous closures to

--- a/tests/Feature/DurableStaticHierarchicalNestedLoopTest.php
+++ b/tests/Feature/DurableStaticHierarchicalNestedLoopTest.php
@@ -153,9 +153,13 @@ test('durable nested loop survives a crash before checkpoint mid inner loop', fu
     expect($manager->find($runId)['next_step_index'])->toBe(2)
         ->and($manager->find($runId)['route_cursor']['loop_iterations']['inner_loop'] ?? 0)->toBe(0);
 
+    // Freeze the clock so the expired lease below and the runtime's live now()
+    // resolve to the same instant — no real-clock margin to race against.
+    $this->freezeTime();
+
     DB::table('swarm_durable_runs')
         ->where('run_id', $runId)
-        ->update(['leased_until' => now()->subSecond()]);
+        ->update(['leased_until' => now('UTC')->subSeconds(5)]);
 
     // Resume and drive to completion — per-scope counts recompute exactly.
     $innerCounters = driveNestedDurableRun($runId, $manager, 'inner_loop');

--- a/tests/Feature/DurableStaticHierarchicalSwarmTest.php
+++ b/tests/Feature/DurableStaticHierarchicalSwarmTest.php
@@ -216,10 +216,14 @@ test('durable static hierarchical crash-replay is idempotent at worker step', fu
     expect($manager->find($runId)['status'])->toBe('running')
         ->and($manager->find($runId)['next_step_index'])->toBe(1);
 
+    // Freeze the clock so the expired lease below and the runtime's live now()
+    // resolve to the same instant — no real-clock margin to race against.
+    $this->freezeTime();
+
     // Expire the lease so step-1 can re-run
     DB::table('swarm_durable_runs')
         ->where('run_id', $runId)
-        ->update(['leased_until' => now()->subSecond()]);
+        ->update(['leased_until' => now('UTC')->subSeconds(5)]);
 
     // Re-advance step-1 — researcher_node re-executes (no snapshot was persisted on crash)
     (new AdvanceDurableSwarm($runId, 1))->handle($manager);
@@ -326,9 +330,13 @@ test('durable static hierarchical loop iteration is idempotent across a crash-re
         ->and($manager->find($runId)['route_cursor']['current_node_id'])->toBe('editor_node')
         ->and($manager->find($runId)['route_cursor']['loop_iterations']['editor_node'] ?? 0)->toBe(0);
 
+    // Freeze the clock so the expired lease below and the runtime's live now()
+    // resolve to the same instant — no real-clock margin to race against.
+    $this->freezeTime();
+
     DB::table('swarm_durable_runs')
         ->where('run_id', $runId)
-        ->update(['leased_until' => now()->subSecond()]);
+        ->update(['leased_until' => now('UTC')->subSeconds(5)]);
 
     // Re-run step 2 — the loop iteration accounting is replayed exactly once.
     (new AdvanceDurableSwarm($runId, 2))->handle($manager);

--- a/tests/Feature/DurableSwarmTest.php
+++ b/tests/Feature/DurableSwarmTest.php
@@ -229,16 +229,26 @@ function stealDurableLease(string $runId, string $replacementToken = 'replacemen
         ]);
 }
 
+/**
+ * Mark a durable run's lease as expired. Freeze the clock (`$this->freezeTime()`)
+ * before calling so the past `leased_until` and the runtime's live `now()`
+ * resolve to the same instant — no real-clock margin to race against.
+ */
 function expireDurableLease(string $runId): void
 {
     DB::table('swarm_durable_runs')
         ->where('run_id', $runId)
         ->update([
-            'leased_until' => now()->subSecond(),
-            'updated_at' => now(),
+            'leased_until' => now('UTC')->subSeconds(5),
+            'updated_at' => now('UTC'),
         ]);
 }
 
+/**
+ * Mark a durable run as stale enough to clear the recovery grace window
+ * (300s by default). Freeze the clock (`$this->freezeTime()`) before calling so
+ * the past `updated_at` and the recovery threshold share one frozen instant.
+ */
 function staleWaitingRun(string $runId): void
 {
     DB::table('swarm_durable_runs')
@@ -418,6 +428,10 @@ test('durable recovery releases waiting joins after branches checkpoint terminal
 
     (new AdvanceDurableSwarm($runId, 0))->handle($manager);
 
+    // Freeze the clock so the stale branch/run markers below and the recovery
+    // grace threshold share one instant — no real-clock margin to race against.
+    $this->freezeTime();
+
     foreach (app(DurableRunStore::class)->branchesFor($runId, 'parallel') as $branch) {
         DB::table('swarm_durable_branches')
             ->where('run_id', $runId)
@@ -457,6 +471,10 @@ test('durable recovery does not release waiting joins until every branch is term
 
     (new AdvanceDurableSwarm($runId, 0))->handle($manager);
 
+    // Freeze the clock so the stale branch/run markers below and the recovery
+    // grace threshold share one instant — no real-clock margin to race against.
+    $this->freezeTime();
+
     DB::table('swarm_durable_branches')
         ->where('run_id', $runId)
         ->where('branch_id', 'parallel:0')
@@ -483,6 +501,10 @@ test('durable recovery joins collected branch failures and fails the parent', fu
     $manager = app(DurableSwarmManager::class);
 
     (new AdvanceDurableSwarm($runId, 0))->handle($manager);
+
+    // Freeze the clock so the stale branch/run markers below and the recovery
+    // grace threshold share one instant — no real-clock margin to race against.
+    $this->freezeTime();
 
     DB::table('swarm_durable_branches')
         ->where('run_id', $runId)
@@ -1009,6 +1031,10 @@ test('durable hierarchical recovery reruns the same worker after a crash before 
         ->and(DB::table('swarm_durable_node_outputs')->where('run_id', $runId)->count())->toBe(0)
         ->and(DB::table('swarm_artifacts')->where('run_id', $runId)->count())->toBe(1);
 
+    // Freeze the clock so the expired lease below and the runtime's live now()
+    // resolve to the same instant — no real-clock margin to race against.
+    $this->freezeTime();
+
     expireDurableLease($runId);
 
     (new AdvanceDurableSwarm($runId, 1))->handle($manager);
@@ -1437,6 +1463,10 @@ test('durable workers stop cleanly when the lease expires before context persist
     app()->forgetInstance(DurableSwarmManager::class);
 
     Event::fake([SwarmCompleted::class]);
+
+    // Freeze the clock so the lease expiry triggered inside ContextStore::put()
+    // and the runtime's live now() share one instant — no real-clock margin.
+    $this->freezeTime();
 
     $manager = app(DurableSwarmManager::class);
     $manager->advance($runId, 0);


### PR DESCRIPTION
## Summary

Time-boundary durable/lease/stale-run assertions previously constructed a past timestamp with `now()->sub…` and asserted against a separate live `now()`, leaving a tight (sub-second) real-clock margin on the durable/lease/recovery lane vulnerable to execution jitter under load or on the concurrency lane.

This change freezes the clock (`$this->freezeTime()`) around each affected assertion window so the past marker (`leased_until` / `updated_at`) and every `now()` the runtime reads resolve to the same instant — the boundary holds exactly, with no margin to race against.

### What changed

- **Helpers** (`tests/Feature/DurableSwarmTest.php`): `expireDurableLease()` and `staleWaitingRun()` now document that they assume a frozen clock at the call site and pin to `now('UTC')`. `expireDurableLease()` widened from `subSecond()` to `subSeconds(5)` for self-documentation under frozen time.
- **`tests/Feature/DurableSwarmTest.php`**: added `$this->freezeTime()` before the stale-marker block in the three `staleWaitingRun()` recovery tests, before the `expireDurableLease()` lease-loss test, and before the `advance()` call in the lease-expires-during-`put()` test.
- **`tests/Feature/DurableStaticHierarchicalSwarmTest.php`** / **`DurableStaticHierarchicalNestedLoopTest.php`**: replaced the three inline `leased_until => now()->subSecond()` markers with a frozen-clock window pinned to `now('UTC')->subSeconds(5)`.
- **Out of scope (unchanged):** `tests/ProcessConcurrency/*` subprocesses — a frozen clock can't be shared across processes, so those keep their generous margins.
- **CHANGELOG.md**: entry under `## v0.12.2 - unreleased` → Changed.
- **CONTRIBUTING.md**: new "Freeze the clock on time-boundary tests" note under Test Tier Expectations.

### Verification

- `composer test` — 1520 passed (5626 assertions)
- `composer test:process-concurrency` — 5 passed, 2 skipped (sqlite engine limitation, pre-existing, unrelated)
- `vendor/bin/pint --test` — passed
- `composer analyse` — no errors

Closes #220