### PR TITLE
chore(release): v0.12.2 readiness gate followups

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -344,10 +344,10 @@ contributing here:
   category names.
 - **Breaking change → `schema_version` bump.** Removing, renaming, or
   retyping a frozen field, or removing/renaming a frozen category, requires
-  incrementing `schema_version` (currently `"2"`) and an `UPGRADING.md` entry.
+  incrementing `schema_version` (currently `"3"`) and an `UPGRADING.md` entry.
   The v0.4-to-v0.5 `command.*` envelope unification (`actor` moved into
   `metadata.actor`, `schema_version` bumped from `"1"` to `"2"`) is the
-  reference example.
+  reference example; it was bumped again from `"2"` to `"3"` in v0.12.0.
 - **Update the frozen-fields tables.** Any change to a category’s correlation
   fields needs the matching row updated in the
   "Frozen Categories" section of `docs/audit-evidence-contract.md`. The doc

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -282,7 +282,7 @@ The `ok` key in `swarm:health --json` output previously returned `false` wheneve
 
 Also, audit-outbox checks (`runAuditOutboxChecks()`) are now skipped for failure policies that do not use the outbox (`swallow`, `log`, `halt`). Those configurations now return a single `note` row and exit 0 instead of potentially erroring if the audit-outbox migration has not been run. Scripts monitoring these configurations should expect a `note` row rather than the outbox table/staleness/dead-letter rows.
 
-### `DurableRunStore` interface: `recoverableQueuedResumes()` added (#246)
+### `DurableRunStore` interface: `recoverableQueuedResumes()` added (#244)
 
 `DurableRunStore` gained a new required method in v0.12.2:
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -224,8 +224,8 @@ When to use: no durable execution, or a short-lived pilot where worker isolation
 # Application workers
 php artisan queue:work --queue=default --timeout=60
 
-# Durable workers — timeout must exceed swarm.durable.step_timeout + swarm.durable.job.timeout_margin_seconds
-php artisan queue:work --queue=swarm-durable --timeout=120 --tries=3
+# Durable workers — timeout must exceed swarm.durable.step_timeout + swarm.durable.job.timeout_margin_seconds (default 360s)
+php artisan queue:work --queue=swarm-durable --timeout=400 --tries=3
 ```
 
 Set `SWARM_DURABLE_QUEUE=swarm-durable`. The queue connection `retry_after` must exceed the worker `--timeout`; set it in `config/queue.php` for the connection your durable queue uses.
@@ -236,8 +236,8 @@ When to use: any production durable workflow. Keeps durable step jobs off the ap
 
 ```bash
 php artisan queue:work --queue=default --timeout=60
-php artisan queue:work --queue=swarm-durable --timeout=120 --tries=3
-php artisan queue:work --queue=swarm-branches --timeout=120 --tries=3
+php artisan queue:work --queue=swarm-durable --timeout=400 --tries=3
+php artisan queue:work --queue=swarm-branches --timeout=400 --tries=3
 ```
 
 Set `SWARM_DURABLE_PARALLEL_QUEUE=swarm-branches`. Without this separation, branch jobs queue behind sequential step jobs on the same connection. On a saturated step queue, branches can never start — a deadlock that silently stalls the entire parallel group.


### PR DESCRIPTION
Phase 3 (readiness) followups from swarm-release-readiness.

- **F1 (medium, operations)** docs/maintenance.md: durable worker `--timeout=120` examples raised to `400` to exceed the now-enforced job timeout (step_timeout+margin, default 360s, #243) — keeps the examples consistent with their own guidance and correct `retry_after` sizing.
- **F2 (medium, docs)** CONTRIBUTING.md: `schema_version` baseline corrected from `"2"` to `"3"` (bumped in v0.12.0; EvidenceEnvelope::SCHEMA_VERSION is `3`).
- **F3 (low, api-contract)** UPGRADING.md: recoverableQueuedResumes attribution corrected #246 → #244.

Docs-only; no code/test impact. Final readiness gate for the v0.12.2 tag.