### PR TITLE
chore(release): v0.12.2 readiness followup — stale timeout() doc reference

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -420,8 +420,7 @@ For production database persistence:
 - use a dedicated queue for durable workflows that should not compete with
   ordinary application jobs
 - set the queue worker timeout above the longest expected provider call for one
-  step, and at or above `AdvanceDurableSwarm` / `AdvanceDurableBranch`
-  `timeout()` (`swarm.durable.step_timeout` +
+  step, and at or above the durable job timeout (`swarm.durable.step_timeout` +
   `swarm.durable.job.timeout_margin_seconds`)
 - set the queue connection `retry_after` above the worker timeout and above
   `swarm.durable.step_timeout` (and therefore above the durable advance job


### PR DESCRIPTION
Final-review low finding: docs/maintenance.md production checklist referenced `AdvanceDurableSwarm`/`AdvanceDurableBranch` `timeout()`, but #243 replaced that method with a `$timeout` property. Reworded to 'the durable job timeout (`swarm.durable.step_timeout` + `swarm.durable.job.timeout_margin_seconds`)'. Docs-only.