### PR TITLE
chore(deps): floor guzzle above the medium advisories (<7.12.1 conflict)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _To be filled in during release wrap-up._
 
 ### Changed
 
-_To be filled in during release wrap-up._
+- **Refuse known-vulnerable `guzzlehttp/guzzle` (`< 7.12.1`) via a `conflict` constraint.** The `composer audit` CI job (added in v0.12.2, non-blocking) flagged two medium advisories — CVE-2026-55767 (dot-only cookie domains match all hosts) and CVE-2026-55568 (silent HTTPS proxy downgrade to cleartext) — both fixed in guzzle `7.12.1`. Guzzle is a purely transitive dependency here (pulled by `laravel/framework` and `aws/aws-sdk-php`), and only the `--prefer-lowest` resolution picked the vulnerable range; `--prefer-stable` already resolved a patched version. A root `conflict` on `guzzlehttp/guzzle: <7.12.1` floors the transitive resolution above the advisory without taking a direct runtime dependency on a package Swarm does not use, so the lowest-resolution audit is advisory-clean. No `require` constraint changed; the full suite passes under `--prefer-lowest` with guzzle `7.12.1`.
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,9 @@
         "pestphp/pest": "^4.4",
         "pestphp/pest-plugin-laravel": "^4.1"
     },
+    "conflict": {
+        "guzzlehttp/guzzle": "<7.12.1"
+    },
     "suggest": {
         "laravel/pulse": "Optional Pulse cards and recorders for swarm observability."
     },


### PR DESCRIPTION
## Summary

- The non-blocking `composer audit` CI job flagged two **medium** advisories in `guzzlehttp/guzzle` — [CVE-2026-55767](https://github.com/guzzle/guzzle/security/advisories/GHSA-cwxw-98qj-8qjx) (dot-only cookie domains match all hosts) and [CVE-2026-55568](https://github.com/guzzle/guzzle/security/advisories/GHSA-wpwq-4j6v-78m3) (silent HTTPS proxy downgrade to cleartext) — both fixed in guzzle **7.12.1**. They surfaced only in the `--prefer-lowest` resolution; `--prefer-stable` already resolved a patched version.
- Guzzle is a **purely transitive** dependency here (via `laravel/framework` and `aws/aws-sdk-php`). Add a root `conflict` of `guzzlehttp/guzzle: <7.12.1` to floor the transitive resolution above the advisory **without** taking a direct runtime dependency on a package Swarm doesn't use. No `require` constraint changed.

This **keeps the audit signal** (rather than deleting the job) and turns the `prefer-lowest` audit green.

## Verification

- `composer audit` under `--prefer-lowest --prefer-stable`: **No security vulnerability advisories found** (resolves guzzle 7.12.1).
- `composer validate`: valid.
- `composer test` under `--prefer-lowest`: **1619 passed**.

## Notes

- The v0.13.0 milestone keeps "flip the audit gate to **blocking**" out-of-scope; this PR is the prerequisite hygiene that lets the tree hold advisory-clean toward that.
- No GitHub issue was filed — surfaced from CI mid-release; tracked as a release-plan component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)