### PR TITLE
fix(persistence): resolve the encrypter lazily so boot needs no APP_KEY (#122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## v0.12.3 - 2026-06-21
+## v0.12.4 - 2026-06-23
+
+Hotfix: the persistence cipher no longer requires an `APP_KEY` at boot, so a fresh `composer install` (and Laravel Cloud builds) succeed before a key is generated.
+
+### Fixed
+
+- **`SwarmServiceProvider` no longer forces an `APP_KEY` at boot / `package:discover` time (#122).** `SwarmPersistenceCipher` autowired Laravel's `Encrypter` into its constructor, so merely *resolving* the cipher resolved the encrypter — which throws `Illuminate\Encryption\MissingAppKeyException` when no `APP_KEY` is set. Because `composer install` runs `package:discover` (which boots every service provider) on a fresh checkout *before* the consumer has generated a key, every fresh install and the Laravel Cloud build threw (the build previously needed a throwaway build-time `APP_KEY` workaround). The provider now binds the cipher with a lazy `Closure(): Encrypter` resolver instead of autowiring the encrypter, and the cipher resolves it only when a `seal()`/`open()` actually needs it. Encryption is opt-in (`encrypt_at_rest`) and the (de)cipher methods early-return before touching the encrypter when there is nothing to process, so booting without a key is safe — while a genuinely missing key still **fails loud at use time** (a real `seal()` with encryption enabled throws `MissingAppKeyException`), never silently. No public API or configuration change; the cipher is `@internal`. Covered by a regression test that resolves the cipher through the container with no `APP_KEY` and asserts no exception, plus fail-loud-at-use and key-present round-trip cases.
 
 CTO review follow-ups on the v0.12.2 tree — truthful audit-backlog health signal and degrade-safe failure-path hardening.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## v0.12.4 - 2026-06-23
 
-Hotfix: the persistence cipher no longer requires an `APP_KEY` at boot, so a fresh `composer install` (and Laravel Cloud builds) succeed before a key is generated.
+Hotfix: the persistence cipher no longer requires an `APP_KEY` at boot, so a fresh `composer install` (and Laravel Cloud builds) succeed before a key is generated. Also floors the transitive `guzzlehttp/guzzle` above two medium advisories.
+
+### Changed
+
+- **Refuse known-vulnerable `guzzlehttp/guzzle` (`< 7.12.1`) via a `conflict` constraint.** The `composer audit` CI job flagged two medium advisories — CVE-2026-55767 (dot-only cookie domains match all hosts) and CVE-2026-55568 (silent HTTPS proxy downgrade to cleartext) — both fixed in guzzle `7.12.1`. Guzzle is a purely transitive dependency here (pulled by `laravel/framework` and `aws/aws-sdk-php`), and only the `--prefer-lowest` resolution picked the vulnerable range; `--prefer-stable` already resolved a patched version. A root `conflict` on `guzzlehttp/guzzle: <7.12.1` floors the transitive resolution above the advisory without taking a direct runtime dependency on a package Swarm does not use, so the lowest-resolution audit is advisory-clean. No `require` constraint changed. (Mirrors the same floor on the v0.13.0 line, #262.)
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,9 @@
         "pestphp/pest": "^4.4",
         "pestphp/pest-plugin-laravel": "^4.1"
     },
+    "conflict": {
+        "guzzlehttp/guzzle": "<7.12.1"
+    },
     "suggest": {
         "laravel/pulse": "Optional Pulse cards and recorders for swarm observability."
     },

--- a/src/Persistence/SwarmPersistenceCipher.php
+++ b/src/Persistence/SwarmPersistenceCipher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BuiltByBerry\LaravelSwarm\Persistence;
 
 use BuiltByBerry\LaravelSwarm\Enums\PersistenceDecryptFailurePolicy;
+use Closure;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Encryption\Encrypter;
@@ -14,6 +15,16 @@ use Psr\Log\LoggerInterface;
  * Application-level encryption for sensitive string columns written by database
  * persistence drivers, mirroring Laravel's Encrypter usage (same as encrypted casts).
  *
+ * The encrypter is resolved **lazily** (the constructor accepts a
+ * `Closure(): Encrypter` from the container binding, or a ready instance for
+ * tests). Laravel's encrypter binding throws `MissingAppKeyException` when no
+ * `APP_KEY` is set, and `package:discover` boots service providers during a
+ * fresh `composer install` *before* the consumer has generated a key — so
+ * resolving this cipher (e.g. while booting) must not force the encrypter.
+ * Encryption is opt-in (`encrypt_at_rest`), and `seal()`/`open()` only touch the
+ * encrypter when they actually have a value to (de)cipher; a genuinely missing
+ * key therefore still fails loud at use time, never at boot. See #122.
+ *
  * @internal
  */
 class SwarmPersistenceCipher
@@ -22,11 +33,34 @@ class SwarmPersistenceCipher
 
     protected ?PersistenceDecryptFailurePolicy $resolvedDecryptFailurePolicy = null;
 
+    /**
+     * @param  (Closure(): Encrypter)|Encrypter  $encrypter  A ready encrypter,
+     *                                                       or a resolver
+     *                                                       invoked on first
+     *                                                       (de)cipher use.
+     */
     public function __construct(
         protected ConfigRepository $config,
-        protected Encrypter $encrypter,
+        protected Closure|Encrypter $encrypter,
         protected LoggerInterface $logger,
     ) {}
+
+    /**
+     * Resolve (once) and return the encrypter. When constructed with a resolver
+     * closure, the encrypter — and thus the `APP_KEY` requirement — is not
+     * touched until the first seal/open actually needs it.
+     */
+    protected function encrypter(): Encrypter
+    {
+        $encrypter = $this->encrypter;
+
+        if ($encrypter instanceof Closure) {
+            $encrypter = $encrypter();
+            $this->encrypter = $encrypter;
+        }
+
+        return $encrypter;
+    }
 
     public function enabled(): bool
     {
@@ -39,7 +73,7 @@ class SwarmPersistenceCipher
             return $value;
         }
 
-        return self::PREFIX.$this->encrypter->encryptString($value);
+        return self::PREFIX.$this->encrypter()->encryptString($value);
     }
 
     /**
@@ -64,7 +98,7 @@ class SwarmPersistenceCipher
         }
 
         try {
-            return $this->encrypter->decryptString(substr($value, strlen(self::PREFIX)));
+            return $this->encrypter()->decryptString(substr($value, strlen(self::PREFIX)));
         } catch (DecryptException $e) {
             return match ($this->decryptFailurePolicy()) {
                 PersistenceDecryptFailurePolicy::Legacy => $value,
@@ -99,7 +133,7 @@ class SwarmPersistenceCipher
             return $value;
         }
 
-        return $this->encrypter->decryptString(substr($value, strlen(self::PREFIX)));
+        return $this->encrypter()->decryptString(substr($value, strlen(self::PREFIX)));
     }
 
     /**

--- a/src/SwarmServiceProvider.php
+++ b/src/SwarmServiceProvider.php
@@ -133,6 +133,7 @@ use BuiltByBerry\LaravelSwarm\Telemetry\SwarmTelemetryEventListener;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Encryption\Encrypter;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Octane\Contracts\OperationTerminated;
@@ -210,7 +211,16 @@ class SwarmServiceProvider extends ServiceProvider
         $this->app->singleton(SwarmTelemetryDispatcher::class);
         $this->app->singleton(PackageJobTelemetryState::class);
 
-        $this->app->singleton(SwarmPersistenceCipher::class);
+        // Bind the cipher with a lazy encrypter resolver rather than autowiring
+        // the Encrypter into its constructor: resolving the encrypter throws
+        // MissingAppKeyException when no APP_KEY is set, and package:discover
+        // boots providers during a fresh `composer install` before a key exists
+        // (#122). The resolver is invoked only when the cipher first seals/opens.
+        $this->app->singleton(SwarmPersistenceCipher::class, fn (Application $app): SwarmPersistenceCipher => new SwarmPersistenceCipher(
+            config: $app->make(ConfigRepository::class),
+            encrypter: static fn (): Encrypter => $app->make(Encrypter::class),
+            logger: $app->make(LoggerInterface::class),
+        ));
         $this->app->singleton(SwarmAttributeResolver::class);
         $this->app->singleton(SequentialRunner::class);
         $this->app->singleton(SequentialStreamRunner::class);

--- a/tests/Feature/Persistence/CipherAppKeyBootTest.php
+++ b/tests/Feature/Persistence/CipherAppKeyBootTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Persistence\SwarmPersistenceCipher;
+use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Encryption\Encrypter;
+use Illuminate\Encryption\MissingAppKeyException;
+
+/**
+ * Regression for #122: SwarmServiceProvider used to autowire the Encrypter into
+ * SwarmPersistenceCipher's constructor, so *resolving* the cipher resolved the
+ * encrypter — which throws MissingAppKeyException when no APP_KEY is set. Because
+ * `package:discover` boots service providers during a fresh `composer install`
+ * (and the Laravel Cloud build) before a key exists, every fresh install threw.
+ *
+ * The cipher now resolves the encrypter lazily, only when a seal/open actually
+ * needs it, so it can be constructed without an APP_KEY.
+ */
+
+/** Drop the encrypter (and its aliases) and the cipher so the next resolve rebuilds against the current key. */
+function dropKeyAndEncryptionSingletons(Application $app): void
+{
+    config()->set('app.key', null);
+
+    foreach (['encrypter', Encrypter::class, EncrypterContract::class, SwarmPersistenceCipher::class] as $abstract) {
+        $app->forgetInstance($abstract);
+    }
+}
+
+test('the persistence cipher resolves with no APP_KEY so package:discover boot does not throw (#122)', function () {
+    dropKeyAndEncryptionSingletons($this->app);
+
+    // The exact thing package:discover does transitively: resolve the cipher
+    // through the container. Before the fix this threw MissingAppKeyException.
+    $cipher = $this->app->make(SwarmPersistenceCipher::class);
+
+    expect($cipher)->toBeInstanceOf(SwarmPersistenceCipher::class);
+});
+
+test('seal still fails loud when encryption is enabled but no APP_KEY is set', function () {
+    dropKeyAndEncryptionSingletons($this->app);
+    config()->set('swarm.persistence.encrypt_at_rest', true);
+
+    $cipher = $this->app->make(SwarmPersistenceCipher::class);
+
+    // Constructing the cipher is fine; the key is only required at actual use,
+    // where a genuinely-missing key must still fail loud rather than silently.
+    expect(fn () => $cipher->seal('secret'))->toThrow(MissingAppKeyException::class);
+});
+
+test('the container-resolved cipher seals and opens once an APP_KEY is present', function () {
+    config()->set('swarm.persistence.encrypt_at_rest', true);
+    $this->app->forgetInstance(SwarmPersistenceCipher::class);
+
+    // The base TestCase sets a valid app.key; this proves the lazy resolver
+    // path produces a working encrypter and round-trips a sealed value.
+    $cipher = $this->app->make(SwarmPersistenceCipher::class);
+    $sealed = $cipher->seal('secret prompt');
+
+    expect($sealed)->toStartWith(SwarmPersistenceCipher::PREFIX)
+        ->and($cipher->open($sealed))->toBe('secret prompt');
+});


### PR DESCRIPTION
## Summary

`SwarmPersistenceCipher` autowired Laravel's `Encrypter` into its constructor, so *resolving* the cipher resolved the encrypter — which throws `MissingAppKeyException` when no `APP_KEY` is set. `composer install` runs `package:discover` (booting every provider) on a fresh checkout **before** a key exists, so every fresh install and the Laravel Cloud build threw (the build used a throwaway build-time `APP_KEY` workaround).

The provider now binds the cipher with a lazy `Closure(): Encrypter` resolver instead of autowiring the encrypter; the cipher resolves it only when a `seal()`/`open()` actually needs it. Encryption is opt-in (`encrypt_at_rest`) and the (de)cipher methods early-return before touching the encrypter, so booting without a key is safe — while a genuinely missing key still **fails loud at use time**, never silently.

No public API/config change (cipher is `@internal`). The constructor accepts `(Closure(): Encrypter)|Encrypter`, so existing direct-construction tests pass a ready `Encrypter` unchanged.

## Tests
- New `tests/Feature/Persistence/CipherAppKeyBootTest.php`: resolve the cipher via the container with no `APP_KEY` (no throw) + fail-loud-at-use + key-present round-trip.
- Full suite 1613 passed; `pint --test` + PHPStan clean; `test:process-concurrency` green.

Closes #122.