### PR TITLE
fix(persistence): forward-port the APP_KEY-safe boot fix to v0.13.0 (#122)

### DIFF
--- a/src/Persistence/SwarmPersistenceCipher.php
+++ b/src/Persistence/SwarmPersistenceCipher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BuiltByBerry\LaravelSwarm\Persistence;
 
 use BuiltByBerry\LaravelSwarm\Enums\PersistenceDecryptFailurePolicy;
+use Closure;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Encryption\Encrypter;
@@ -14,6 +15,16 @@ use Psr\Log\LoggerInterface;
  * Application-level encryption for sensitive string columns written by database
  * persistence drivers, mirroring Laravel's Encrypter usage (same as encrypted casts).
  *
+ * The encrypter is resolved **lazily** (the constructor accepts a
+ * `Closure(): Encrypter` from the container binding, or a ready instance for
+ * tests). Laravel's encrypter binding throws `MissingAppKeyException` when no
+ * `APP_KEY` is set, and `package:discover` boots service providers during a
+ * fresh `composer install` *before* the consumer has generated a key — so
+ * resolving this cipher (e.g. while booting) must not force the encrypter.
+ * Encryption is opt-in (`encrypt_at_rest`), and `seal()`/`open()` only touch the
+ * encrypter when they actually have a value to (de)cipher; a genuinely missing
+ * key therefore still fails loud at use time, never at boot. See #122.
+ *
  * @internal
  */
 class SwarmPersistenceCipher
@@ -22,11 +33,34 @@ class SwarmPersistenceCipher
 
     protected ?PersistenceDecryptFailurePolicy $resolvedDecryptFailurePolicy = null;
 
+    /**
+     * @param  (Closure(): Encrypter)|Encrypter  $encrypter  A ready encrypter,
+     *                                                       or a resolver
+     *                                                       invoked on first
+     *                                                       (de)cipher use.
+     */
     public function __construct(
         protected ConfigRepository $config,
-        protected Encrypter $encrypter,
+        protected Closure|Encrypter $encrypter,
         protected LoggerInterface $logger,
     ) {}
+
+    /**
+     * Resolve (once) and return the encrypter. When constructed with a resolver
+     * closure, the encrypter — and thus the `APP_KEY` requirement — is not
+     * touched until the first seal/open actually needs it.
+     */
+    protected function encrypter(): Encrypter
+    {
+        $encrypter = $this->encrypter;
+
+        if ($encrypter instanceof Closure) {
+            $encrypter = $encrypter();
+            $this->encrypter = $encrypter;
+        }
+
+        return $encrypter;
+    }
 
     public function enabled(): bool
     {
@@ -39,7 +73,7 @@ class SwarmPersistenceCipher
             return $value;
         }
 
-        return self::PREFIX.$this->encrypter->encryptString($value);
+        return self::PREFIX.$this->encrypter()->encryptString($value);
     }
 
     /**
@@ -64,7 +98,7 @@ class SwarmPersistenceCipher
         }
 
         try {
-            return $this->encrypter->decryptString(substr($value, strlen(self::PREFIX)));
+            return $this->encrypter()->decryptString(substr($value, strlen(self::PREFIX)));
         } catch (DecryptException $e) {
             return match ($this->decryptFailurePolicy()) {
                 PersistenceDecryptFailurePolicy::Legacy => $value,
@@ -99,7 +133,7 @@ class SwarmPersistenceCipher
             return $value;
         }
 
-        return $this->encrypter->decryptString(substr($value, strlen(self::PREFIX)));
+        return $this->encrypter()->decryptString(substr($value, strlen(self::PREFIX)));
     }
 
     /**

--- a/src/SwarmServiceProvider.php
+++ b/src/SwarmServiceProvider.php
@@ -133,6 +133,7 @@ use BuiltByBerry\LaravelSwarm\Telemetry\SwarmTelemetryEventListener;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Encryption\Encrypter;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Octane\Contracts\OperationTerminated;
@@ -210,7 +211,16 @@ class SwarmServiceProvider extends ServiceProvider
         $this->app->singleton(SwarmTelemetryDispatcher::class);
         $this->app->singleton(PackageJobTelemetryState::class);
 
-        $this->app->singleton(SwarmPersistenceCipher::class);
+        // Bind the cipher with a lazy encrypter resolver rather than autowiring
+        // the Encrypter into its constructor: resolving the encrypter throws
+        // MissingAppKeyException when no APP_KEY is set, and package:discover
+        // boots providers during a fresh `composer install` before a key exists
+        // (#122). The resolver is invoked only when the cipher first seals/opens.
+        $this->app->singleton(SwarmPersistenceCipher::class, fn (Application $app): SwarmPersistenceCipher => new SwarmPersistenceCipher(
+            config: $app->make(ConfigRepository::class),
+            encrypter: static fn (): Encrypter => $app->make(Encrypter::class),
+            logger: $app->make(LoggerInterface::class),
+        ));
         $this->app->singleton(SwarmAttributeResolver::class);
         $this->app->singleton(SequentialRunner::class);
         $this->app->singleton(SequentialStreamRunner::class);

--- a/tests/Feature/Persistence/CipherAppKeyBootTest.php
+++ b/tests/Feature/Persistence/CipherAppKeyBootTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Persistence\SwarmPersistenceCipher;
+use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Encryption\Encrypter;
+use Illuminate\Encryption\MissingAppKeyException;
+
+/**
+ * Regression for #122: SwarmServiceProvider used to autowire the Encrypter into
+ * SwarmPersistenceCipher's constructor, so *resolving* the cipher resolved the
+ * encrypter — which throws MissingAppKeyException when no APP_KEY is set. Because
+ * `package:discover` boots service providers during a fresh `composer install`
+ * (and the Laravel Cloud build) before a key exists, every fresh install threw.
+ *
+ * The cipher now resolves the encrypter lazily, only when a seal/open actually
+ * needs it, so it can be constructed without an APP_KEY.
+ */
+
+/** Drop the encrypter (and its aliases) and the cipher so the next resolve rebuilds against the current key. */
+function dropKeyAndEncryptionSingletons(Application $app): void
+{
+    config()->set('app.key', null);
+
+    foreach (['encrypter', Encrypter::class, EncrypterContract::class, SwarmPersistenceCipher::class] as $abstract) {
+        $app->forgetInstance($abstract);
+    }
+}
+
+test('the persistence cipher resolves with no APP_KEY so package:discover boot does not throw (#122)', function () {
+    dropKeyAndEncryptionSingletons($this->app);
+
+    // The exact thing package:discover does transitively: resolve the cipher
+    // through the container. Before the fix this threw MissingAppKeyException.
+    $cipher = $this->app->make(SwarmPersistenceCipher::class);
+
+    expect($cipher)->toBeInstanceOf(SwarmPersistenceCipher::class);
+});
+
+test('seal still fails loud when encryption is enabled but no APP_KEY is set', function () {
+    dropKeyAndEncryptionSingletons($this->app);
+    config()->set('swarm.persistence.encrypt_at_rest', true);
+
+    $cipher = $this->app->make(SwarmPersistenceCipher::class);
+
+    // Constructing the cipher is fine; the key is only required at actual use,
+    // where a genuinely-missing key must still fail loud rather than silently.
+    expect(fn () => $cipher->seal('secret'))->toThrow(MissingAppKeyException::class);
+});
+
+test('the container-resolved cipher seals and opens once an APP_KEY is present', function () {
+    config()->set('swarm.persistence.encrypt_at_rest', true);
+    $this->app->forgetInstance(SwarmPersistenceCipher::class);
+
+    // The base TestCase sets a valid app.key; this proves the lazy resolver
+    // path produces a working encrypter and round-trips a sealed value.
+    $cipher = $this->app->make(SwarmPersistenceCipher::class);
+    $sealed = $cipher->seal('secret prompt');
+
+    expect($sealed)->toStartWith(SwarmPersistenceCipher::PREFIX)
+        ->and($cipher->open($sealed))->toBe('secret prompt');
+});


### PR DESCRIPTION
Forward-port of the **v0.12.4** hotfix onto the v0.13.0 line so the next release also boots without an `APP_KEY`. `release/v0.13.0` was cut from v0.12.3 (before the hotfix), so without this it would **reintroduce #122**.

`SwarmPersistenceCipher` now resolves the `Encrypter` via a lazy `Closure(): Encrypter` resolver instead of autowiring it, so resolving the cipher (e.g. during `package:discover`) no longer throws `MissingAppKeyException`; a genuinely missing key still fails loud at actual seal/open.

**Code only:** the guzzle `<7.12.1` floor already landed on v0.13.0 (#262), and the v0.12.4 CHANGELOG entry documenting #122 arrives via the eventual v0.13.0 → main merge — so no CHANGELOG change here.

Cherry-pick of `e85d4d6`; code applied cleanly. Full suite 1637 passed; pint + PHPStan clean. Relates to #122.