### PR TITLE
chore(dispatch): name the live-vs-durable distinction in stream-gate errors

### DIFF
--- a/src/Runners/DispatchValidator.php
+++ b/src/Runners/DispatchValidator.php
@@ -82,13 +82,22 @@ class DispatchValidator
         throw new SwarmException(class_basename($swarm).': swarm has no agents. Add at least one agent to agents().');
     }
 
+    /**
+     * Gate the LIVE `stream()` API — a single ordered generator of token events for
+     * one in-process run. This is a different surface from durable causal-log
+     * streaming ({@see ensureDurableStreamingInfrastructure()}): a parallel swarm
+     * cannot yield one ordered live token stream (its branches run concurrently), but
+     * it DOES stream durably under `#[DurableStreaming]`, where each branch writes its
+     * own per-node rows to the causal log. Keep that live-vs-durable distinction in the
+     * error string below so the two gates are never read as contradicting each other.
+     */
     public function ensureStreamableTopology(Swarm $swarm): void
     {
         $topology = $this->resolver->resolveTopology($swarm);
         $streamable = [Topology::Sequential, Topology::StaticHierarchical, Topology::Hierarchical];
 
         if (! in_array($topology, $streamable, true)) {
-            throw new SwarmException("Streaming is only supported for sequential, static_hierarchical, and hierarchical swarms. {$topology->value} topology does not support streaming.");
+            throw new SwarmException("The live stream() API only supports sequential, static_hierarchical, and hierarchical swarms; a {$topology->value} swarm cannot yield a single ordered live token stream. (Durable per-node streaming via #[DurableStreaming] does support {$topology->value} — its branches stream as separate causal-log rows; see ensureDurableStreamingInfrastructure().)");
         }
     }
 

--- a/src/Runners/SequentialStreamRunner.php
+++ b/src/Runners/SequentialStreamRunner.php
@@ -73,7 +73,11 @@ class SequentialStreamRunner
         $this->ensureSwarmHasAgents($swarm);
 
         if ($topology !== Topology::Sequential) {
-            throw new SwarmException('Streaming is only supported for sequential swarms. '.$topology->value.' topology does not support streaming.');
+            // This is the live sequential stream() runner specifically; hierarchical and
+            // static_hierarchical live-stream via their own runners, and any topology
+            // (incl. parallel) can stream durably via #[DurableStreaming]. So this is a
+            // routing guard, not a claim that {$topology} cannot stream at all.
+            throw new SwarmException('The live sequential stream() runner only accepts sequential swarms; a '.$topology->value.' swarm streams via its own live runner or durably via #[DurableStreaming].');
         }
 
         $timeoutSeconds = $this->resolver->resolveTimeoutSeconds($swarm);

--- a/tests/Feature/BroadcastSwarmTest.php
+++ b/tests/Feature/BroadcastSwarmTest.php
@@ -203,7 +203,7 @@ test('broadcast job streams once and broadcasts immediately', function () {
 });
 
 test('broadcast helpers fail clearly for non sequential swarms', function () {
-    $message = 'Streaming is only supported for sequential, static_hierarchical, and hierarchical swarms. parallel topology does not support streaming.';
+    $message = 'The live stream() API only supports sequential, static_hierarchical, and hierarchical swarms; a parallel swarm cannot yield a single ordered live token stream.';
 
     expect(fn () => FakeParallelSwarm::make()->broadcast('broadcast-task', new Channel('swarm.run')))
         ->toThrow(SwarmException::class, $message);

--- a/tests/Feature/StreamingSwarmTest.php
+++ b/tests/Feature/StreamingSwarmTest.php
@@ -943,7 +943,7 @@ test('non sequential swarms cannot be streamed', function () {
 
     expect($stream)->toThrow(
         SwarmException::class,
-        'Streaming is only supported for sequential, static_hierarchical, and hierarchical swarms. parallel topology does not support streaming.',
+        'The live stream() API only supports sequential, static_hierarchical, and hierarchical swarms; a parallel swarm cannot yield a single ordered live token stream.',
     );
 });
 

--- a/tests/Unit/Runners/DispatchValidatorTest.php
+++ b/tests/Unit/Runners/DispatchValidatorTest.php
@@ -29,9 +29,15 @@ test('ensureSwarmHasAgents passes when agents are present', function (): void {
     expect(true)->toBeTrue();
 });
 
-test('ensureStreamableTopology blocks parallel topology', function (): void {
+test('ensureStreamableTopology blocks parallel topology with a live-vs-durable error', function (): void {
+    // The live stream() gate excludes parallel (no single ordered token stream); the
+    // error must name the live API and point at the durable path that DOES support it,
+    // so it never reads as contradicting durable parallel streaming (#312).
     expect(fn () => $this->validator->ensureStreamableTopology(new SwarmWithParallelTopologyAttribute))
-        ->toThrow(SwarmException::class, 'Streaming is only supported');
+        ->toThrow(SwarmException::class, 'The live stream() API only supports');
+
+    expect(fn () => $this->validator->ensureStreamableTopology(new SwarmWithParallelTopologyAttribute))
+        ->toThrow(SwarmException::class, '#[DurableStreaming] does support');
 });
 
 test('ensureStreamableTopology allows sequential topology', function (): void {


### PR DESCRIPTION
## Summary

The two live `stream()` topology gates rejected parallel with a flat "Streaming is only supported … does not support streaming" message — which now reads as a contradiction of the durable parallel streaming shipped in #312. Reworded so the **live-vs-durable distinction is on the page**:

- `DispatchValidator::ensureStreamableTopology` — names the **live `stream()` API** (single ordered token stream), explains why parallel can't, and points at `#[DurableStreaming]` / `ensureDurableStreamingInfrastructure()` which **does** support parallel via per-branch causal-log rows. Added a method docblock pinning the contract.
- `SequentialStreamRunner::stream` — clarifies it's the live **sequential** stream runner (a routing guard), not a claim that other topologies can't stream at all.

Tests updated to the new strings; the unit test now also positively asserts the error names the durable path. Pure clarity — no behavior change.

## Linked issue

_Follow-up cleanup from the #312 cross-topology review; no dedicated issue._

🤖 Generated with [Claude Code](https://claude.com/claude-code)