### PR TITLE
chore(release): v0.15.0 improve-laravel audit followups (PERF-01, IDIOM-01)

### DIFF
--- a/src/Attributes/ContextGrowthPolicy.php
+++ b/src/Attributes/ContextGrowthPolicy.php
@@ -21,5 +21,5 @@ use BuiltByBerry\LaravelSwarm\Enums\GrowthPolicy;
 #[Attribute(Attribute::TARGET_CLASS)]
 final class ContextGrowthPolicy
 {
-    public function __construct(public GrowthPolicy $policy) {}
+    public function __construct(public readonly GrowthPolicy $policy) {}
 }

--- a/src/Persistence/DatabaseCausalLogStore.php
+++ b/src/Persistence/DatabaseCausalLogStore.php
@@ -130,19 +130,27 @@ class DatabaseCausalLogStore extends DatabaseStreamEventStore implements CausalL
         $this->assertReady();
 
         $this->connection->transaction(function () use ($runId, $targetEventIds, $digestNodeId, $reason, $ttlSeconds): void {
+            // Idempotent: a target already carrying a rolled_up edge (a
+            // re-dispatched/re-executed pass) is skipped rather than voided twice.
+            // One indexed batch lookup over every target seeds the skip-set, instead
+            // of an exists() per target — the dedicated void columns keep it a single
+            // seek on the (run_id, void_type) index. We extend the set as we append
+            // below, so a target repeated within one call is still voided exactly once
+            // (matching the prior per-iteration exists(), which saw the just-inserted edge).
+            $rolledUp = array_fill_keys(
+                $this->table()
+                    ->where('run_id', $runId)
+                    ->where('void_type', CausalVoidEdgeType::RolledUp->value)
+                    ->whereIn('void_target_event_uuid', $targetEventIds)
+                    ->pluck('void_target_event_uuid')
+                    ->all(),
+                true,
+            );
+
             $emittedAny = false;
 
             foreach ($targetEventIds as $targetEventId) {
-                // Idempotent: a target already carrying a rolled_up edge (a
-                // re-dispatched/re-executed pass) is skipped rather than voided
-                // twice. The dedicated void columns make this an indexed lookup.
-                $alreadyRolledUp = $this->table()
-                    ->where('run_id', $runId)
-                    ->where('void_type', CausalVoidEdgeType::RolledUp->value)
-                    ->where('void_target_event_uuid', $targetEventId)
-                    ->exists();
-
-                if ($alreadyRolledUp) {
+                if (isset($rolledUp[$targetEventId])) {
                     continue;
                 }
 
@@ -150,6 +158,7 @@ class DatabaseCausalLogStore extends DatabaseStreamEventStore implements CausalL
                 // target; nesting it here runs under a savepoint, so any throw
                 // rolls back the whole rollup-seal — never a partial.
                 $this->appendVoidEdge($runId, CausalVoidEdgeType::RolledUp, $targetEventId, $reason, $ttlSeconds, $digestNodeId);
+                $rolledUp[$targetEventId] = true;
                 $emittedAny = true;
             }
 

--- a/tests/Feature/Streaming/RollupNodeTest.php
+++ b/tests/Feature/Streaming/RollupNodeTest.php
@@ -225,3 +225,42 @@ test('sealRollup is idempotent and atomic on re-dispatch (R8)', function () {
     expect($edges)->toBe(1)
         ->and($barriers)->toBe(1);
 });
+
+test('sealRollup voids a target repeated within one call exactly once (R8 batch skip-set)', function () {
+    // The idempotency check is a single batched lookup seeded into a skip-set the
+    // loop extends per appended edge — so a target id repeated inside one
+    // targetEventIds array is still voided exactly once, matching the prior
+    // per-iteration exists() that saw the just-inserted edge.
+    $store = app(CausalLogStore::class);
+    $runId = 'run-rollup-dup-target';
+
+    DB::table('swarm_run_histories')->insert([
+        'run_id' => $runId,
+        'swarm_class' => 'ExampleSwarm',
+        'topology' => 'static_hierarchical',
+        'status' => 'running',
+        'context' => json_encode([]),
+        'metadata' => json_encode([]),
+        'steps' => json_encode([]),
+        'output' => null,
+        'usage' => json_encode([]),
+        'error' => null,
+        'artifacts' => json_encode([]),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $store->record($runId, new SwarmStepEnd(
+        id: 'evt-1', runId: $runId, stepIndex: 0, agentClass: FakeResearcher::class,
+        agent: 'r', output: 'a', durationMs: 1, metadata: [], timestamp: 1,
+    ), 0);
+
+    // Same target id twice in one call.
+    $store->sealRollup($runId, ['evt-1', 'evt-1'], 'rollup_node', 'rolled up by [rollup_node]');
+
+    $edges = DB::table('swarm_stream_events')->where('run_id', $runId)->where('void_type', 'rolled_up')->count();
+    $barriers = DB::table('swarm_stream_events')->where('run_id', $runId)->where('event_type', 'swarm_causal_seal_barrier')->count();
+
+    expect($edges)->toBe(1)
+        ->and($barriers)->toBe(1);
+});


### PR DESCRIPTION
## Summary

The two actionable findings from the `/improve-laravel` audit of the v0.15.0 release branch (both small, neither blocking; everything else came back clean — no over-engineering, no correctness/security findings, Octane-safe, all hot-path indexes present, cursor-based streaming throughout).

- **PERF-01** — `DatabaseCausalLogStore::sealRollup()` issued a per-target `exists()` in a loop (O(N) queries for an N-target rollup). Now one batched `whereIn` seeds the already-rolled-up skip-set, extended per appended edge. Semantics preserved exactly: idempotency (R8), the per-edge `lockForUpdate` fence, savepoint rollback, and barrier-only-if-emitted-any. New test covers the within-call duplicate-target case the old per-iteration `exists()` handled implicitly.
- **IDIOM-01** — `ContextGrowthPolicy::$policy` is now `readonly`, matching the sibling `#[DurableStreaming]` attribute.

Rejected during vetting (recorded for context): a 'make event value objects readonly class' suggestion (incompatible — the base `StreamEvent` has mutable `nodeId`/`attemptEpoch` stamped by the sink); Collection-vs-array polish (correct as-is + `($value,$key)` arity risk in perf-sensitive code); a speculative index + a barrier-cache micro-opt.

pint + phpstan clean; RollupNode (incl. R8 + new duplicate test), causal-log store, and context-growth suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)