### PR TITLE
chore: v0.15.1 review followups (F1-F2)

### DIFF
--- a/tests/Feature/Streaming/StructuredOutputStreamGuardTest.php
+++ b/tests/Feature/Streaming/StructuredOutputStreamGuardTest.php
@@ -2,14 +2,23 @@
 
 declare(strict_types=1);
 
+use BuiltByBerry\LaravelSwarm\Contracts\ArtifactRepository;
+use BuiltByBerry\LaravelSwarm\Contracts\ContextStore;
+use BuiltByBerry\LaravelSwarm\Contracts\RunHistoryStore;
+use BuiltByBerry\LaravelSwarm\Enums\ExecutionMode;
+use BuiltByBerry\LaravelSwarm\Enums\Topology;
 use BuiltByBerry\LaravelSwarm\Exceptions\StructuredOutputStreamingException;
+use BuiltByBerry\LaravelSwarm\Runners\SequentialRunner;
+use BuiltByBerry\LaravelSwarm\Support\RunContext;
+use BuiltByBerry\LaravelSwarm\Support\SwarmExecutionState;
 use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\SequentialStructuredWorkerStreamSwarm;
 use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\StaticHierarchicalStructuredWorkerStreamSwarm;
 
 // These prove the LIVE stream() surfaces fail loud with a swarm-domain error — never
 // laravel/ai's bare InvalidArgumentException — the moment a structured-output worker
 // would be streamed. The durable surfaces are guarded earlier, at dispatch (see
-// DispatchValidatorTest).
+// DispatchValidatorTest), but the per-site guard is a real backstop too (see the
+// durable streamSingleStep test below).
 
 test('a live sequential stream() fails loud when its streamed agent is structured-output (#321)', function (): void {
     expect(fn (): array => iterator_to_array(SequentialStructuredWorkerStreamSwarm::make()->stream('task')))
@@ -18,5 +27,33 @@ test('a live sequential stream() fails loud when its streamed agent is structure
 
 test('a live static-hierarchical stream() fails loud when a worker is structured-output (#321)', function (): void {
     expect(fn (): array => iterator_to_array(StaticHierarchicalStructuredWorkerStreamSwarm::make()->stream('task')))
+        ->toThrow(StructuredOutputStreamingException::class, 'cannot be streamed');
+});
+
+test('the durable per-node stream site guards a structured-output worker even past dispatch (#321 backstop)', function (): void {
+    // The dispatch guard normally rejects this before any job runs. This drives the
+    // durable stream site (SequentialRunner::streamSingleStep) directly to prove the
+    // per-site guard is a genuine backstop — e.g. if agents() were to resolve a
+    // structured-output worker at execution that was absent at dispatch. The guard
+    // throws before the sink or the agent's stream() is ever touched.
+    $state = new SwarmExecutionState(
+        swarm: new SequentialStructuredWorkerStreamSwarm,
+        topology: Topology::Sequential,
+        executionMode: ExecutionMode::Durable,
+        deadlineMonotonic: hrtime(true) + 1_000_000_000,
+        maxAgentExecutions: 10,
+        ttlSeconds: 3600,
+        leaseSeconds: null,
+        executionToken: null,
+        verifyOwnership: null,
+        context: RunContext::from('task', 'run-321-backstop'),
+        contextStore: app(ContextStore::class),
+        artifactRepository: app(ArtifactRepository::class),
+        historyStore: app(RunHistoryStore::class),
+        events: app('events'),
+        queueHierarchicalParallelCoordination: null,
+    );
+
+    expect(fn (): mixed => app(SequentialRunner::class)->streamSingleStep($state, 0, fn (object $event) => null))
         ->toThrow(StructuredOutputStreamingException::class, 'cannot be streamed');
 });


### PR DESCRIPTION
Multi-expert change review of `release/v0.15.1` vs `main` → **approve-with-followups · non-blocker** (0 high · 1 medium · 1 low).

## Findings

- **F1 (medium) — semver on new public surface.** The new public `Testing\InteractsWithSwarmEvents` trait and `StructuredOutputStreamingException` are additive public API in a patch. **Deferred** to the Phase-3 readiness (semver-guardian) gate to rule v0.15.1 (restores a documented-but-missing surface; 0.x additive-in-patch) vs a v0.16.0 bump. No code change.
- **F2 (low) — durable stream-site guard coverage.** The three durable-path stream-site guards were defense-in-depth behind the dispatch guard with no direct test. **Fixed** here: this PR adds a backstop test driving `SequentialRunner::streamSingleStep` directly with a structured-output worker, proving the per-site guard fires before the sink/agent stream is touched.

## Change

One test added (`tests/Feature/Streaming/StructuredOutputStreamGuardTest.php`). No source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)