### PR TITLE
chore(release): v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.15.1 - unreleased
+## v0.15.1 - 2026-07-01
 
 Three follow-up fixes to v0.15.0: compaction is scoped to durable streaming (a live `stream()` run no longer generates compaction work it cannot perform, and `swarm:prune` is the documented hot-log bound for live streaming); streaming a structured-output agent now fails loud in-package instead of leaking an internal `laravel/ai` error; and the documented `Testing\InteractsWithSwarmEvents` trait ships, so `assertEventFired()` is finally usable.
 

--- a/README.md
+++ b/README.md
@@ -516,6 +516,20 @@ ContentPipeline::assertDispatchedDurably(['document_id' => 100]);
 
 Use database-backed feature tests when you need to prove durable leases, checkpoints, retries, branch joins, wait release, recovery, or webhook idempotency. `SwarmFake` records intent; it does not execute the durable runtime.
 
+To assert that swarm lifecycle events (started, step, completed, failed, …) fired during a real run, add the `InteractsWithSwarmEvents` trait to your test case and call `assertEventFired()` (v0.15.1+):
+
+```php
+use BuiltByBerry\LaravelSwarm\Testing\InteractsWithSwarmEvents;
+
+class ContentPipelineTest extends TestCase
+{
+    use InteractsWithSwarmEvents;
+}
+
+ContentPipeline::make()->run('Draft an intro');
+ContentPipeline::assertEventFired(SwarmCompleted::class);
+```
+
 See [Testing](docs/testing.md) and [Testing Swarms](examples/testing-swarms/README.md).
 
 ## Configuration

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -269,6 +269,14 @@ This package’s `composer.json` uses `"minimum-stability": "dev"` with
 still prefers tagged releases. Your application may need compatible Composer
 stability settings while Laravel AI remains pre-stable.
 
+## Upgrading to v0.15.1
+
+**No required action.** v0.15.1 is three fixes to v0.15.0, with no migration, no config change, and no breaking API. A few notes if any apply to you:
+
+- **`assertEventFired()` now works.** If you followed the testing docs and hit *"Swarm event recording is only available in tests where the recorder has been activated,"* add `use BuiltByBerry\LaravelSwarm\Testing\InteractsWithSwarmEvents;` to your test case — the trait the docs referenced now ships. See [docs/testing.md](docs/testing.md#asserting-lifecycle-events).
+- **Compaction is now scoped to durable streaming.** `swarm:compact` only ever graduated durable per-node streaming runs (`#[DurableStreaming]`); it now no longer generates phantom work for live, non-durable `stream()` runs. Those runs' hot `swarm_stream_events` rows are bounded by TTL via `swarm:prune` — schedule that command if you run high-volume live streaming and weren't already. (This was the effective behaviour before; v0.15.1 just stops the no-op churn and documents it.)
+- **Streaming a structured-output agent now fails loud in-package.** A worker implementing `HasStructuredOutput` placed on a streaming path previously surfaced a bare `laravel/ai` `InvalidArgumentException`; it now throws a `StructuredOutputStreamingException` naming the node, the agent, and the remedy — and, for `#[DurableStreaming]` swarms, fails at dispatch rather than mid-run. The hierarchical coordinator (which legitimately uses structured output and runs via `prompt()`) is unaffected.
+
 ## Upgrading to v0.15.0
 
 ### New migration: `swarm_cold_archives`


### PR DESCRIPTION
Phase 2 of the v0.15.1 wrap — CHANGELOG / UPGRADING / README finalization.

## Changes

- **CHANGELOG** dated `2026-07-01` (the three Fixed bullets landed with the topic PRs #323/#325/#326).
- **UPGRADING** — new `## Upgrading to v0.15.1` block: **no required action** (three fixes, no migration, no config change, no breaking API), with notes on the now-working `assertEventFired()` trait, the durable-only compaction scoping (`swarm:prune` for live streams), and the fail-loud structured-output guard.
- **README** — added a lifecycle-event assertion snippet (`InteractsWithSwarmEvents` + `assertEventFired()`) to the Testing section, closing the same docs-parity gap #324 was about.

## Roll-up

- Breaking changes: **none**.
- Deploy safety: **n/a** (package; no migration).
- `composer.json` branch-alias already `0.15.x-dev` (no bump).

Next: Phase 3 readiness review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)