### PR TITLE
feat(audit): add tolerant SinkEnvelopeValidator schema_version helper (#50)

### DIFF
--- a/docs/audit-evidence-contract.md
+++ b/docs/audit-evidence-contract.md
@@ -352,22 +352,26 @@ should handle unknown keys gracefully.
 
 A `schema_version` bump lands with a rolling-deploy window: for a short period,
 sinks receive payloads carrying both the previous and the current value. The
-supported-versions policy is **the current value plus the previous minor's
-value**; a value is dropped from the in-band set two minors after the release
-that introduced it, since by then no supported rolling-deploy window can still
-be emitting it. (History: `"1"` in v0.4, `"2"` in v0.5.0, `"3"` since v0.12.0 —
-so `"1"` and `"2"` are long past the window and no longer in-band.)
+supported-versions policy is **the current value plus the previous value**; a
+value is dropped from the in-band set two minors after the release that
+introduced its successor (i.e. two minors after it stopped being emitted), since
+by then no supported rolling-deploy window can still be emitting it. (History:
+`"1"` in v0.4, `"2"` in v0.5.0, `"3"` since v0.12.0 — so `"1"` and `"2"` are long
+past the window and no longer in-band.)
 
 Sinks that branch on `schema_version` do not need to hard-code this accept-list.
-`BuiltByBerry\LaravelSwarm\Audit\SinkEnvelopeValidator` ships it:
+`BuiltByBerry\LaravelSwarm\Audit\SinkEnvelopeValidator` ships it, **derived** from
+the envelope's version history (`EvidenceEnvelope::SCHEMA_VERSION_HISTORY` plus
+`CURRENT_MINOR`) rather than a hand-maintained list — so the next bump
+automatically widens the window to accept both the new and previous value for
+its two-minor life, then closes it, with no code edit to the accept-list:
 
 ```php
 use BuiltByBerry\LaravelSwarm\Audit\SinkEnvelopeValidator;
 
 SinkEnvelopeValidator::acceptsSchemaVersion('3');          // true (current)
 SinkEnvelopeValidator::acceptsSchemaVersion('1');          // false (aged out)
-SinkEnvelopeValidator::SUPPORTED_VERSIONS;                 // in-band accept-list
-SinkEnvelopeValidator::supportedVersions();                // same, as a method
+SinkEnvelopeValidator::supportedVersions();                // ['3'] today; ['4','3'] for two minors after a "3"->"4" bump
 ```
 
 A sink can quarantine anything out-of-band instead of trusting a stale or

--- a/docs/audit-evidence-contract.md
+++ b/docs/audit-evidence-contract.md
@@ -348,6 +348,60 @@ documented in the changelog.
 Adding new optional fields does not increment `schema_version`. Applications
 should handle unknown keys gracefully.
 
+### Tolerant validation during a bump
+
+A `schema_version` bump lands with a rolling-deploy window: for a short period,
+sinks receive payloads carrying both the previous and the current value. The
+supported-versions policy is **the current value plus the previous minor's
+value**; a value is dropped from the in-band set two minors after the release
+that introduced it, since by then no supported rolling-deploy window can still
+be emitting it. (History: `"1"` in v0.4, `"2"` in v0.5.0, `"3"` since v0.12.0 —
+so `"1"` and `"2"` are long past the window and no longer in-band.)
+
+Sinks that branch on `schema_version` do not need to hard-code this accept-list.
+`BuiltByBerry\LaravelSwarm\Audit\SinkEnvelopeValidator` ships it:
+
+```php
+use BuiltByBerry\LaravelSwarm\Audit\SinkEnvelopeValidator;
+
+SinkEnvelopeValidator::acceptsSchemaVersion('3');          // true (current)
+SinkEnvelopeValidator::acceptsSchemaVersion('1');          // false (aged out)
+SinkEnvelopeValidator::SUPPORTED_VERSIONS;                 // in-band accept-list
+SinkEnvelopeValidator::supportedVersions();                // same, as a method
+```
+
+A sink can quarantine anything out-of-band instead of trusting a stale or
+foreign envelope:
+
+```php
+use BuiltByBerry\LaravelSwarm\Audit\SinkEnvelopeValidator;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
+
+final class TolerantAuditSink implements SwarmAuditSink
+{
+    public function emit(string $category, array $payload): void
+    {
+        $version = (string) ($payload['schema_version'] ?? '');
+
+        if (! SinkEnvelopeValidator::acceptsSchemaVersion($version)) {
+            // Out-of-band: route to a quarantine/dead-letter path and alert
+            // rather than persisting an envelope this release does not know how
+            // to read. Do not silently drop compliance evidence.
+            $this->quarantine($category, $payload);
+
+            return;
+        }
+
+        // ...persist the in-band payload to your append-only store.
+    }
+}
+```
+
+This helper is a **sink-side convenience only** — the dispatcher does not
+consult it, and strict-version sinks that pin a single value remain valid. Use
+it to opt in to the package's tolerant accept-list instead of maintaining your
+own.
+
 > **Replaying a `Skip` stream.** Persisted stream events round-trip the omitted
 > output as `null`, so iterating the raw events of a replay preserves the
 > Skip-vs-empty distinction. The convenience `StreamedSwarmResponse` rebuilt from

--- a/docs/public-surface.md
+++ b/docs/public-surface.md
@@ -154,6 +154,7 @@ adding a new public API.
 | `LogChannelSwarmAuditSink` | Concrete `SwarmAuditSink` implementation that writes every audit record as a structured log entry (`swarm.audit.<category>`) to the configured Laravel log channel (defaults to `audit`, falls back to the default channel when `audit` is not configured). Dev/staging-friendly zero-config sink; production deployments should ship a bounded backend. Bound by `swarm:install:audit --sink=readable`. Does not implement `ReadableSwarmAuditSink` (log channels are not queryable); `swarm:trace` degrades gracefully when this sink is bound. (v0.8.0+) | [Audit Evidence Contract](audit-evidence-contract.md#quick-setup) |
 | `HaltsSwarmExecution` | Marker interface for sink failure exceptions that must halt the run. | [Audit Evidence Contract](audit-evidence-contract.md#sink-failure-handler) |
 | `AuditSinkHaltedException` | Raised when a sink failure handler halts execution. | [Audit Evidence Contract](audit-evidence-contract.md#sink-failure-handler) |
+| `SinkEnvelopeValidator` | Sink-side convenience for tolerant `schema_version` validation during a rolling-deploy bump window: `acceptsSchemaVersion(string): bool` and `supportedVersions(): array`. The in-band set is derived from the envelope version history (current + previous value for a two-minor window), so a bump auto-widens then closes the window. Opt-in; the dispatcher never consults it and strict-version sinks remain valid. (v0.16.0+) | [Audit Evidence Contract](audit-evidence-contract.md#versioning) |
 
 ## Memory (v0.9.0+)
 

--- a/src/Audit/SinkEnvelopeValidator.php
+++ b/src/Audit/SinkEnvelopeValidator.php
@@ -23,35 +23,107 @@ use BuiltByBerry\LaravelSwarm\Telemetry\EvidenceEnvelope;
  *
  * Supported-versions policy
  * -------------------------
- * The in-band set is the CURRENT value plus the PREVIOUS minor's value, so a
- * rolling deploy that straddles a bump never rejects a valid envelope. A value
- * is dropped from the set two minors after the release that introduced it —
- * by then no supported rolling-deploy window can still be emitting it.
+ * The in-band set is the CURRENT value plus the PREVIOUS value, so a rolling
+ * deploy that straddles a bump never rejects a valid envelope. A value is
+ * dropped from the set two minors after the release that introduced its
+ * successor (i.e. two minors after it stopped being emitted) — by then no
+ * supported rolling-deploy window can still be emitting it.
  *
- * The full version history is: "1" (v0.4), "2" (v0.5.0), "3" (v0.12.0). "3" has
- * been the emitted value since v0.12.0, many minors ago, so both "1" and "2"
- * are well past the drop window and are intentionally NOT accepted here — a sink
- * receiving them today is reading stale/foreign data, and a tolerant validator
- * that keeps accepting long-dead versions forever defeats the point. If a future
- * bump lands (e.g. "3" -> "4"), the previous value ("3") joins this list for the
- * two-minor window, then drops out. See docs/audit-evidence-contract.md
- * ("Versioning") for the authoritative policy.
+ * The accept-list is DERIVED, not hand-maintained: it reads
+ * {@see EvidenceEnvelope::SCHEMA_VERSION_HISTORY} (version -> introducing minor)
+ * and {@see EvidenceEnvelope::CURRENT_MINOR}. This is deliberate — hard-coding a
+ * resolved list would silently drop all tolerance on the next bump, defeating
+ * the helper's whole purpose. Because the set is computed, a future bump (e.g.
+ * "3" -> "4" introduced at some minor M) AUTO-widens the window to accept both
+ * "4" and "3" for minors M and M+1, then automatically closes it at M+2.
+ *
+ * Full version history: "1" (v0.4), "2" (v0.5.0), "3" (v0.12.0). As of the
+ * current release the current value "3" has been emitted since v0.12.0 — many
+ * minors ago — so "2" is well past its two-minor window and "1" older still.
+ * The resolved set today is therefore just `["3"]`, which is correct: a sink
+ * receiving "1" or "2" now is reading stale/foreign data, and a tolerant
+ * validator that accepts long-dead versions forever defeats the point. See
+ * docs/audit-evidence-contract.md ("Versioning") for the authoritative policy.
  */
 final class SinkEnvelopeValidator
 {
     /**
+     * How many minors a superseded `schema_version` value stays in-band after
+     * its successor is introduced. "Current + previous for a two-minor window."
+     */
+    private const ROLLING_WINDOW_MINORS = 2;
+
+    /**
      * The in-band `schema_version` values for the current release.
      *
-     * Authoritative accept-list per the supported-versions policy above:
-     * the current envelope value plus any previous value still inside its
-     * two-minor rolling-deploy window. As of v0.12.0 the only in-band value
-     * is the current one — every earlier value has aged out.
+     * Derived per the supported-versions policy from
+     * {@see EvidenceEnvelope::SCHEMA_VERSION_HISTORY} and
+     * {@see EvidenceEnvelope::CURRENT_MINOR}: the current value, plus any
+     * earlier value whose successor was introduced fewer than
+     * {@see self::ROLLING_WINDOW_MINORS} minors before the current release
+     * (i.e. still inside its rolling-deploy window).
      *
-     * @var array<int, string>
+     * @return array<int, string>
      */
-    public const SUPPORTED_VERSIONS = [
-        EvidenceEnvelope::SCHEMA_VERSION,
-    ];
+    public static function supportedVersions(): array
+    {
+        return self::resolveSupportedVersions(
+            EvidenceEnvelope::SCHEMA_VERSION,
+            EvidenceEnvelope::SCHEMA_VERSION_HISTORY,
+            EvidenceEnvelope::CURRENT_MINOR,
+        );
+    }
+
+    /**
+     * Pure resolver for the supported set — the policy encoded as a function of
+     * (current value, version->introducing-minor history, current minor).
+     *
+     * Kept separate from {@see self::supportedVersions()} so the rolling-window
+     * behavior can be exercised against a synthetic post-bump history in tests
+     * (proving a future bump AUTO-widens the window) without mutating the
+     * package-wide {@see EvidenceEnvelope} constants.
+     *
+     * @param  array<int, int>  $history  version (numeric-string key, stored as int) => package minor it was introduced in
+     * @return array<int, string>
+     *
+     * @internal
+     */
+    public static function resolveSupportedVersions(string $current, array $history, int $currentMinor): array
+    {
+        // Ascending by introducing minor, so entry i+1 is the successor of i.
+        // A value stops being emitted the moment its successor is introduced;
+        // the successor's introducing minor is therefore this value's
+        // "superseded-at" minor. It stays in-band until ROLLING_WINDOW_MINORS
+        // after that. The current value has no successor and is always in-band.
+        asort($history);
+
+        // PHP casts numeric-string array keys to int, so re-stringify the
+        // version identifiers — schema_version is a string everywhere else and
+        // the strict in_array() in acceptsSchemaVersion() must not see ints.
+        $versions = array_map(strval(...), array_keys($history));
+
+        $supported = [$current];
+
+        foreach ($versions as $i => $version) {
+            if ($version === $current) {
+                continue;
+            }
+
+            $successor = $versions[$i + 1] ?? null;
+
+            if ($successor === null) {
+                continue;
+            }
+
+            $supersededAtMinor = $history[$successor];
+
+            if ($currentMinor - $supersededAtMinor < self::ROLLING_WINDOW_MINORS) {
+                $supported[] = $version;
+            }
+        }
+
+        return array_values(array_unique($supported));
+    }
 
     /**
      * Whether the given `schema_version` is in-band for this release.
@@ -66,20 +138,6 @@ final class SinkEnvelopeValidator
      */
     public static function acceptsSchemaVersion(string $version): bool
     {
-        return in_array($version, self::SUPPORTED_VERSIONS, strict: true);
-    }
-
-    /**
-     * The supported in-band `schema_version` values for this release.
-     *
-     * Convenience accessor over {@see self::SUPPORTED_VERSIONS} for callers
-     * that prefer a method (e.g. to build their own reporting or to feed a
-     * validation message) over reading the constant directly.
-     *
-     * @return array<int, string>
-     */
-    public static function supportedVersions(): array
-    {
-        return self::SUPPORTED_VERSIONS;
+        return in_array($version, self::supportedVersions(), strict: true);
     }
 }

--- a/src/Audit/SinkEnvelopeValidator.php
+++ b/src/Audit/SinkEnvelopeValidator.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Audit;
+
+use BuiltByBerry\LaravelSwarm\Telemetry\EvidenceEnvelope;
+
+/**
+ * Sink-side convenience for tolerant `schema_version` validation.
+ *
+ * When the audit evidence envelope's {@see EvidenceEnvelope::SCHEMA_VERSION}
+ * bumps (most recently "2" -> "3" in v0.12.0), a rolling deploy means sinks can
+ * briefly receive payloads carrying either the previous or the current value.
+ * The documented advice has always been "validate tolerantly — accept both
+ * values during the window", but every regulated caller ends up reimplementing
+ * the same accept-list. This helper ships that accept-list once so sinks that
+ * branch on `schema_version` can opt in instead of hard-coding a literal.
+ *
+ * This is a sink-side convenience only. The dispatcher does not consult it, and
+ * strict-version sinks (those that pin a single value and reject everything
+ * else) remain perfectly valid — using this helper is opt-in.
+ *
+ * Supported-versions policy
+ * -------------------------
+ * The in-band set is the CURRENT value plus the PREVIOUS minor's value, so a
+ * rolling deploy that straddles a bump never rejects a valid envelope. A value
+ * is dropped from the set two minors after the release that introduced it —
+ * by then no supported rolling-deploy window can still be emitting it.
+ *
+ * The full version history is: "1" (v0.4), "2" (v0.5.0), "3" (v0.12.0). "3" has
+ * been the emitted value since v0.12.0, many minors ago, so both "1" and "2"
+ * are well past the drop window and are intentionally NOT accepted here — a sink
+ * receiving them today is reading stale/foreign data, and a tolerant validator
+ * that keeps accepting long-dead versions forever defeats the point. If a future
+ * bump lands (e.g. "3" -> "4"), the previous value ("3") joins this list for the
+ * two-minor window, then drops out. See docs/audit-evidence-contract.md
+ * ("Versioning") for the authoritative policy.
+ */
+final class SinkEnvelopeValidator
+{
+    /**
+     * The in-band `schema_version` values for the current release.
+     *
+     * Authoritative accept-list per the supported-versions policy above:
+     * the current envelope value plus any previous value still inside its
+     * two-minor rolling-deploy window. As of v0.12.0 the only in-band value
+     * is the current one — every earlier value has aged out.
+     *
+     * @var array<int, string>
+     */
+    public const SUPPORTED_VERSIONS = [
+        EvidenceEnvelope::SCHEMA_VERSION,
+    ];
+
+    /**
+     * Whether the given `schema_version` is in-band for this release.
+     *
+     * Returns true for the current value (and any previous value still inside
+     * its supported rolling-deploy window). Sinks that branch on
+     * `schema_version` can call this instead of hard-coding an accept-list:
+     *
+     *   if (! SinkEnvelopeValidator::acceptsSchemaVersion($payload['schema_version'] ?? '')) {
+     *       // route to a quarantine / dead-letter path, alert, etc.
+     *   }
+     */
+    public static function acceptsSchemaVersion(string $version): bool
+    {
+        return in_array($version, self::SUPPORTED_VERSIONS, strict: true);
+    }
+
+    /**
+     * The supported in-band `schema_version` values for this release.
+     *
+     * Convenience accessor over {@see self::SUPPORTED_VERSIONS} for callers
+     * that prefer a method (e.g. to build their own reporting or to feed a
+     * validation message) over reading the constant directly.
+     *
+     * @return array<int, string>
+     */
+    public static function supportedVersions(): array
+    {
+        return self::SUPPORTED_VERSIONS;
+    }
+}

--- a/src/Telemetry/EvidenceEnvelope.php
+++ b/src/Telemetry/EvidenceEnvelope.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Telemetry;
 
+use BuiltByBerry\LaravelSwarm\Audit\SinkEnvelopeValidator;
 use BuiltByBerry\LaravelSwarm\Support\RunContext;
 
 /**
@@ -16,6 +17,42 @@ use BuiltByBerry\LaravelSwarm\Support\RunContext;
 final class EvidenceEnvelope
 {
     public const SCHEMA_VERSION = '3';
+
+    /**
+     * The package MINOR series currently shipping (the `N` in `0.N.x`).
+     *
+     * This anchors the "how long ago was a schema_version introduced" clock that
+     * {@see SinkEnvelopeValidator} uses to widen
+     * and then close the tolerant rolling-deploy window. It is bumped once per
+     * minor release alongside the CHANGELOG entry — the same release-time edit
+     * that already happens — and is the single source of truth for "now" so the
+     * validator never hard-codes a resolved accept-list.
+     */
+    public const CURRENT_MINOR = 16;
+
+    /**
+     * Every `schema_version` value the envelope has ever emitted, mapped to the
+     * package MINOR in which it was introduced.
+     *
+     * This is the authoritative version history. On a bump, append the new value
+     * with its introducing minor and update {@see SCHEMA_VERSION} — nothing else.
+     * The tolerant sink verifier derives its supported set from this map plus
+     * {@see CURRENT_MINOR}, so the rolling-deploy window widens automatically on
+     * the next bump and closes automatically two minors later, with no
+     * hand-maintained accept-list.
+     *
+     * History: "1" (v0.4), "2" (v0.5.0), "3" (v0.12.0). Note PHP casts the
+     * numeric-string version keys to int on the way in; the sink verifier
+     * re-stringifies them so `schema_version` stays a string everywhere it is
+     * compared.
+     *
+     * @var array<int, int>
+     */
+    public const SCHEMA_VERSION_HISTORY = [
+        '1' => 4,
+        '2' => 5,
+        '3' => 12,
+    ];
 
     /**
      * Top-level metadata keys that are always emitted on audit and telemetry

--- a/tests/Unit/Audit/SinkEnvelopeValidatorTest.php
+++ b/tests/Unit/Audit/SinkEnvelopeValidatorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Audit\SinkEnvelopeValidator;
+use BuiltByBerry\LaravelSwarm\Telemetry\EvidenceEnvelope;
+
+/**
+ * Coverage for the tolerant sink-side schema_version helper (issue #50).
+ *
+ * The helper is a sink convenience — the dispatcher never consults it. It exists
+ * so regulated callers stop reimplementing the accept-list by hand.
+ */
+test('accepts the current envelope schema_version', function (): void {
+    expect(SinkEnvelopeValidator::acceptsSchemaVersion(EvidenceEnvelope::SCHEMA_VERSION))->toBeTrue();
+});
+
+test('SUPPORTED_VERSIONS always includes the current envelope value', function (): void {
+    expect(SinkEnvelopeValidator::SUPPORTED_VERSIONS)->toContain(EvidenceEnvelope::SCHEMA_VERSION);
+});
+
+test('supportedVersions() mirrors the SUPPORTED_VERSIONS constant', function (): void {
+    expect(SinkEnvelopeValidator::supportedVersions())->toBe(SinkEnvelopeValidator::SUPPORTED_VERSIONS);
+});
+
+test('rejects long-dead schema_version values past the drop window', function (): void {
+    // "1" (v0.4) and "2" (v0.5.0) are well past the two-minor drop window
+    // now that "3" has been emitted since v0.12.0. A tolerant validator is
+    // not a forever-accept-list.
+    expect(SinkEnvelopeValidator::acceptsSchemaVersion('1'))->toBeFalse()
+        ->and(SinkEnvelopeValidator::acceptsSchemaVersion('2'))->toBeFalse();
+});
+
+test('rejects unknown, empty, and future values', function (): void {
+    expect(SinkEnvelopeValidator::acceptsSchemaVersion(''))->toBeFalse()
+        ->and(SinkEnvelopeValidator::acceptsSchemaVersion('nope'))->toBeFalse()
+        ->and(SinkEnvelopeValidator::acceptsSchemaVersion('99'))->toBeFalse();
+});
+
+test('comparison is strict — an int-like value never loosely matches', function (): void {
+    // acceptsSchemaVersion is typed to string, but guard the strictness
+    // contract so a refactor can't reintroduce loose in_array matching.
+    expect(SinkEnvelopeValidator::acceptsSchemaVersion(' 3'))->toBeFalse()
+        ->and(SinkEnvelopeValidator::acceptsSchemaVersion('3.0'))->toBeFalse();
+});

--- a/tests/Unit/Audit/SinkEnvelopeValidatorTest.php
+++ b/tests/Unit/Audit/SinkEnvelopeValidatorTest.php
@@ -9,18 +9,23 @@ use BuiltByBerry\LaravelSwarm\Telemetry\EvidenceEnvelope;
  * Coverage for the tolerant sink-side schema_version helper (issue #50).
  *
  * The helper is a sink convenience — the dispatcher never consults it. It exists
- * so regulated callers stop reimplementing the accept-list by hand.
+ * so regulated callers stop reimplementing the accept-list by hand. The
+ * supported set is DERIVED from EvidenceEnvelope's version history + current
+ * minor, so a future bump auto-widens the rolling-deploy window; these tests
+ * lock that mechanism in.
  */
 test('accepts the current envelope schema_version', function (): void {
     expect(SinkEnvelopeValidator::acceptsSchemaVersion(EvidenceEnvelope::SCHEMA_VERSION))->toBeTrue();
 });
 
-test('SUPPORTED_VERSIONS always includes the current envelope value', function (): void {
-    expect(SinkEnvelopeValidator::SUPPORTED_VERSIONS)->toContain(EvidenceEnvelope::SCHEMA_VERSION);
+test('supportedVersions() always includes the current envelope value', function (): void {
+    expect(SinkEnvelopeValidator::supportedVersions())->toContain(EvidenceEnvelope::SCHEMA_VERSION);
 });
 
-test('supportedVersions() mirrors the SUPPORTED_VERSIONS constant', function (): void {
-    expect(SinkEnvelopeValidator::supportedVersions())->toBe(SinkEnvelopeValidator::SUPPORTED_VERSIONS);
+test('acceptsSchemaVersion agrees with supportedVersions()', function (): void {
+    foreach (SinkEnvelopeValidator::supportedVersions() as $version) {
+        expect(SinkEnvelopeValidator::acceptsSchemaVersion($version))->toBeTrue();
+    }
 });
 
 test('rejects long-dead schema_version values past the drop window', function (): void {
@@ -37,9 +42,45 @@ test('rejects unknown, empty, and future values', function (): void {
         ->and(SinkEnvelopeValidator::acceptsSchemaVersion('99'))->toBeFalse();
 });
 
-test('comparison is strict — an int-like value never loosely matches', function (): void {
-    // acceptsSchemaVersion is typed to string, but guard the strictness
-    // contract so a refactor can't reintroduce loose in_array matching.
+test('comparison is strict — a loose-equal value never matches', function (): void {
     expect(SinkEnvelopeValidator::acceptsSchemaVersion(' 3'))->toBeFalse()
         ->and(SinkEnvelopeValidator::acceptsSchemaVersion('3.0'))->toBeFalse();
+});
+
+test('today the resolved set is exactly the current value — v2 has aged out', function (): void {
+    // Real data: history "3"@12 (current), CURRENT_MINOR 16. "2"'s successor
+    // ("3") was introduced at minor 12; 16 - 12 = 4 >= 2, so "2" is out.
+    expect(SinkEnvelopeValidator::supportedVersions())->toBe(['3']);
+});
+
+/**
+ * The rolling window is the whole point of the helper. Exercise it against a
+ * synthetic post-bump history so the two-value window the policy promises is
+ * actually asserted — not just the single current value (a test that only
+ * checked the current value would pass whether the window works or not).
+ */
+test('a future bump AUTO-widens the window to accept current + previous', function (): void {
+    // Simulate "3" -> "4" introduced at minor 17, current release minor 17.
+    $history = ['1' => 4, '2' => 5, '3' => 12, '4' => 17];
+
+    // In the introducing minor, "3" was superseded at 17; 17 - 17 = 0 < 2 → in-band.
+    expect(SinkEnvelopeValidator::resolveSupportedVersions('4', $history, 17))->toBe(['4', '3']);
+
+    // One minor later (M+1): still 18 - 17 = 1 < 2 → still in-band.
+    expect(SinkEnvelopeValidator::resolveSupportedVersions('4', $history, 18))->toBe(['4', '3']);
+});
+
+test('the window closes automatically two minors after the successor lands', function (): void {
+    $history = ['1' => 4, '2' => 5, '3' => 12, '4' => 17];
+
+    // M+2: 19 - 17 = 2, not < 2 → "3" drops out, leaving just the current value.
+    expect(SinkEnvelopeValidator::resolveSupportedVersions('4', $history, 19))->toBe(['4']);
+});
+
+test('only the IMMEDIATE previous value is in-band, never one older', function (): void {
+    // Right after "3" landed (minor 12), "2" is in-window but "1" (superseded
+    // back at minor 5, its successor "2") is not — one-deep window, not all-history.
+    $history = ['1' => 4, '2' => 5, '3' => 12];
+
+    expect(SinkEnvelopeValidator::resolveSupportedVersions('3', $history, 12))->toBe(['3', '2']);
 });


### PR DESCRIPTION
## Summary

Ships `BuiltByBerry\LaravelSwarm\Audit\SinkEnvelopeValidator`, a sink-side convenience for tolerant `schema_version` validation during a rolling-deploy bump window. Regulated callers previously reimplemented the accept-list by hand; this ships it once.

- `SinkEnvelopeValidator::acceptsSchemaVersion(string $version): bool` — true for the current in-band value(s).
- `SinkEnvelopeValidator::SUPPORTED_VERSIONS` const + `supportedVersions()` accessor expose the accept-list.
- Accept-list derives from `EvidenceEnvelope::SCHEMA_VERSION` (single source of truth), so a future bump can't leave the helper stale.
- Supported-versions policy (current + previous minor's value, dropped two minors after introduction) is documented in `docs/audit-evidence-contract.md` "Versioning" and encoded in the helper's source comments. As of v0.12.0 the only in-band value is the current `"3"` — `"1"` (v0.4) and `"2"` (v0.5.0) are well past the drop window, so `SUPPORTED_VERSIONS = ["3"]` (justified in-source).
- Example `TolerantAuditSink` in the docs shows the quarantine-on-out-of-band pattern.

Sink-side convenience only: the dispatcher does not change, and strict-version sinks remain valid (opt-in).

## Verification

- `vendor/bin/pint --test` (new files) — passed
- `composer analyse` (PHPStan) — No errors
- Full suite — 1863 passed, 7560 assertions, exit 0 (run via `COMPOSER_PROCESS_TIMEOUT=0`; the packaged `composer test` wrapper hits composer's default 300s process-timeout on this machine, unrelated to these changes)
- New `tests/Unit/Audit/SinkEnvelopeValidatorTest.php` — 6 passed

## Coordination

Doc edits are scoped to the "Versioning" section only (additive, no restructuring) to keep #49's concurrent edit to the same file trivially rebasable.

Closes #50