### PR TITLE
release: v0.16.1 — Core hardening pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ If a gap is deferred, it must be recorded as a named follow-up with an owner, no
 
 - PHP ^8.5
 - Laravel ^13.0
-- `laravel/ai` ^0.6
+- `laravel/ai` ^0.8
 - `orchestra/testbench` ^11
 - `pestphp/pest` ^4.4 + `pest-plugin-laravel` ^4.1
 - `larastan/larastan` ^3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,23 @@
 # Changelog
 
-## v0.16.1 - unreleased
+## v0.16.1 - 2026-07-03
 
-Core hardening pass: tighten the operator-contract surface shipped in v0.16.0 before v0.17.0 Phase-0 (Pulse extract + contract prune + driver-surface promotions) and the adoption packages. Scoped via `/improve-laravel` audit rather than pre-filed issues.
+Core hardening pass: tighten the operator-contract surface shipped in v0.16.0 before v0.17.0 Phase-0 (Pulse extract + contract prune + driver-surface promotions) and the adoption packages. Scoped via an `/improve-laravel` audit rather than pre-filed issues.
 
 ### Fixed
 
-_To be filled in during release wrap-up._
+- **`swarm:compact` discovery no longer plucks the full quarantined-run-id set into memory (#339).** `SwarmCompactCommand::discoverEligibleRuns()` loaded every quarantined `run_id` from `swarm_durable_runs` into a PHP array, then built an unbounded `whereNotIn()` from it, before applying the discovery `--limit`. Replaced with a `whereNotExists` correlated subquery against `swarm_durable_runs`, so the exclusion runs entirely in SQL and scales with the quarantine table size instead of the process's memory. Scoped strictly to the discovery query — no change to leasing, sealing, or graduation. No public API change.
+- **`DatabaseAuditOutbox::drain()` batches retry/dead-letter writes instead of issuing one `UPDATE` per row (#345 improve-laravel finding, hardened via a pre-implementation design gate).** A drain batch with many failed or dead-lettered entries (e.g. during a sustained sink outage) previously issued one individual `UPDATE ... WHERE id = ?` per entry. Writes are now batched via two `upsert()` calls (failed vs. dead-lettered — different column sets), each falling back to the original independent per-row `UPDATE` loop if the atomic batch statement throws. The fallback exists because a single-statement `upsert()` is all-or-nothing: one malformed row would otherwise fail the whole batch's writes, silently losing already-computed state for every sibling in the group — a regression the design gate caught before any code was written. The per-row `Log::error` dead-letter alert still fires once per row, only after that row's write has actually succeeded, matching the original ordering. No public API change; `AuditDrainResult`'s shape is unchanged.
+
+### Tested
+
+- **`swarm:relay --type=audit` lane isolation now has direct coverage (#338).** `--type=audit` alone was untested — only `--type=step`, `--type=bogus`, and the no-flag (both-lanes) case were covered. A new test asserts an audit-only relay drains the audit lane while leaving a pending durable-lane entry untouched, mirroring the existing `--type=step` asymmetric-drain test.
+- **A batch spanning both the failed and dead-lettered outcome in one `drain()` call is now covered (change-review F1).** The two regression tests added for the batching fix above each exercised only one outcome group; a new test seeds one entry that stays failed and another that reaches `dead_letter` within a single `drain()` call, confirming the two independent `upsert()` calls don't interfere with each other.
+
+### Documentation
+
+- **`AGENTS.md`'s Tech Stack section corrected to `laravel/ai` `^0.8`.** It still read `^0.6`, one range behind the floor `composer.json` has required since v0.13.0.
+- **`CONTRIBUTING.md` documents the `composer hooks:install` setup step.** The local commit-msg Conventional Commits hook (`tools/git-hooks/commit-msg`) existed but was never mentioned in the contributor setup docs — a new paragraph in "Local Setup" covers it.
 
 ## v0.16.0 - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.16.1 - unreleased
+
+Core hardening pass: tighten the operator-contract surface shipped in v0.16.0 before v0.17.0 Phase-0 (Pulse extract + contract prune + driver-surface promotions) and the adoption packages. Scoped via `/improve-laravel` audit rather than pre-filed issues.
+
+### Fixed
+
+_To be filled in during release wrap-up._
+
 ## v0.16.0 - 2026-07-02
 
 Public surface & operator contract: promote a stable public operator control contract out of `@internal DurableSwarmManager` (the epic #254 keystone), complete the `@internal` promotion survey, and finalize the audit contract/envelope shapes (`RelayLane` split, tolerant `schema_version` verifier, `signature_key_id`). Additive and backward-compatible.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,17 @@ from the repository root unless a test or reproduction explicitly uses a
 Testbench application. If you need Artisan behavior, prefer a focused package
 test over ad hoc manual setup.
 
+Install the local commit-msg hook once per clone to validate Conventional Commits
+format before you commit:
+
+```bash
+composer hooks:install
+```
+
+This is a local-only check (`tools/git-hooks/commit-msg`) — it does not run in CI.
+Branch naming is enforced separately, server-side, by
+`.github/workflows/branch-naming.yml`.
+
 ## Required Checks
 
 Before opening a pull request, run the checks that match your change:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -269,6 +269,10 @@ This package’s `composer.json` uses `"minimum-stability": "dev"` with
 still prefers tagged releases. Your application may need compatible Composer
 stability settings while Laravel AI remains pre-stable.
 
+## Upgrading to v0.16.1
+
+**No required action.** v0.16.1 is a core hardening pass with no migration, no config change, and no breaking API — `swarm:compact` discovery is now a bounded SQL query instead of an unbounded in-memory pluck (#339), `DatabaseAuditOutbox::drain()` batches its retry/dead-letter writes with a per-row fallback (no observable change to `AuditDrainResult`'s shape or the audit trail), and two documentation lines (`AGENTS.md`'s `laravel/ai` version, `CONTRIBUTING.md`'s hook setup step) were corrected.
+
 ## Upgrading to v0.16.0
 
 **No required action for most applications.** v0.16.0 is additive and backward-compatible — it promotes a public operator control contract and finalizes several audit and relay surfaces. Notes if any apply to you:

--- a/src/Commands/SwarmCompactCommand.php
+++ b/src/Commands/SwarmCompactCommand.php
@@ -78,11 +78,6 @@ class SwarmCompactCommand extends Command
         $hotTable = (string) $config->get('swarm.tables.stream_events', 'swarm_stream_events');
         $durableTable = (string) $config->get('swarm.tables.durable', 'swarm_durable_runs');
 
-        $quarantinedIds = $connection->table($durableTable)
-            ->whereNotNull('compaction_quarantined_at')
-            ->pluck('run_id')
-            ->all();
-
         $query = $connection->table($hotTable)
             ->select('run_id')
             ->where('event_type', 'swarm_causal_seal_barrier')
@@ -95,12 +90,14 @@ class SwarmCompactCommand extends Command
             ->whereIn('run_id', function ($durable) use ($durableTable): void {
                 $durable->select('run_id')->from($durableTable);
             })
+            ->whereNotExists(function ($quarantined) use ($hotTable, $durableTable): void {
+                $quarantined->select($quarantined->raw(1))
+                    ->from($durableTable)
+                    ->whereColumn($durableTable.'.run_id', $hotTable.'.run_id')
+                    ->whereNotNull($durableTable.'.compaction_quarantined_at');
+            })
             ->distinct()
             ->limit($limit);
-
-        if ($quarantinedIds !== []) {
-            $query->whereNotIn('run_id', $quarantinedIds);
-        }
 
         /** @var list<string> */
         return $query->pluck('run_id')->all();

--- a/src/Persistence/DatabaseAuditOutbox.php
+++ b/src/Persistence/DatabaseAuditOutbox.php
@@ -118,6 +118,10 @@ class DatabaseAuditOutbox implements AuditOutbox
         $deadLettered = 0;
         $failed = 0;
         $replayedIds = [];
+        /** @var list<array{id: int, category: string, run_id: ?string, attempts: int, error: string}> $failedGroup */
+        $failedGroup = [];
+        /** @var list<array{id: int, category: string, run_id: ?string, attempts: int, error: string}> $deadLetterGroup */
+        $deadLetterGroup = [];
 
         foreach ($entries as $entry) {
             $attempts = (int) $entry->attempts + 1;
@@ -131,14 +135,14 @@ class DatabaseAuditOutbox implements AuditOutbox
                 // Permanently invalid stored payload; route to dead-letter and
                 // surface via the error handler so it's investigable.
                 $this->safeReport($exception);
-                $this->markDeadLetter((int) $entry->id, (string) $entry->category, $entry->run_id, $attempts, 'invalid_json');
+                $deadLetterGroup[] = ['id' => (int) $entry->id, 'category' => (string) $entry->category, 'run_id' => $entry->run_id, 'attempts' => $attempts, 'error' => 'invalid_json'];
                 $deadLettered++;
 
                 continue;
             }
 
             if (! is_array($payload)) {
-                $this->markDeadLetter((int) $entry->id, (string) $entry->category, $entry->run_id, $attempts, 'payload_not_array');
+                $deadLetterGroup[] = ['id' => (int) $entry->id, 'category' => (string) $entry->category, 'run_id' => $entry->run_id, 'attempts' => $attempts, 'error' => 'payload_not_array'];
                 $deadLettered++;
 
                 continue;
@@ -153,16 +157,10 @@ class DatabaseAuditOutbox implements AuditOutbox
                 $error = mb_substr($exception->getMessage(), 0, 1000);
 
                 if ($attempts >= $maxAttempts) {
-                    $this->markDeadLetter((int) $entry->id, (string) $entry->category, $entry->run_id, $attempts, $error);
+                    $deadLetterGroup[] = ['id' => (int) $entry->id, 'category' => (string) $entry->category, 'run_id' => $entry->run_id, 'attempts' => $attempts, 'error' => $error];
                     $deadLettered++;
                 } else {
-                    $this->table()->where('id', $entry->id)->update([
-                        'attempts' => $attempts,
-                        'last_error' => $this->cipher->seal($error),
-                        'last_attempted_at' => Carbon::now('UTC'),
-                        'reserved_at' => null,
-                        'updated_at' => Carbon::now('UTC'),
-                    ]);
+                    $failedGroup[] = ['id' => (int) $entry->id, 'category' => (string) $entry->category, 'run_id' => $entry->run_id, 'attempts' => $attempts, 'error' => $error];
                     $failed++;
                 }
             }
@@ -172,31 +170,124 @@ class DatabaseAuditOutbox implements AuditOutbox
             $this->table()->whereIn('id', $replayedIds)->delete();
         }
 
+        if ($failedGroup !== []) {
+            $this->writeFailedGroup($failedGroup);
+        }
+
+        if ($deadLetterGroup !== []) {
+            $this->writeDeadLetterGroup($deadLetterGroup);
+        }
+
         return new AuditDrainResult($replayed, $deadLettered, $failed, $claimed, $reclaimed);
     }
 
     /**
-     * Mark a single entry as dead-lettered, persist the sealed last_error, and
-     * emit a Log::error at the moment of transition so monitoring stacks can
-     * alert on undelivered audit evidence.
+     * Batch-persist a group of retry writes via upsert(), falling back to
+     * independent per-row updates if the atomic batch statement fails (e.g. a
+     * single malformed row) so the rest of the group still persists.
+     *
+     * @param  list<array{id: int, category: string, run_id: ?string, attempts: int, error: string}>  $group
      */
-    protected function markDeadLetter(int $id, string $category, ?string $runId, int $attempts, string $reason): void
+    protected function writeFailedGroup(array $group): void
     {
-        $this->table()->where('id', $id)->update([
-            'status' => 'dead_letter',
-            'attempts' => $attempts,
-            'last_error' => $this->cipher->seal($reason),
-            'last_attempted_at' => Carbon::now('UTC'),
+        $now = Carbon::now('UTC');
+        $rows = array_map(fn (array $e): array => [
+            'id' => $e['id'],
+            'attempts' => $e['attempts'],
+            'last_error' => $this->cipher->seal($e['error']),
+            'last_attempted_at' => $now,
             'reserved_at' => null,
-            'updated_at' => Carbon::now('UTC'),
-        ]);
+            'updated_at' => $now,
+        ], $group);
 
+        try {
+            $this->upsertBatch($rows, ['attempts', 'last_error', 'last_attempted_at', 'reserved_at', 'updated_at']);
+
+            return;
+        } catch (Throwable $exception) {
+            // A single malformed row can fail the whole atomic upsert statement.
+            // Fall back to independent per-row writes so the rest of the group
+            // still persists — matches the pre-batching failure isolation.
+            $this->safeReport($exception);
+        }
+
+        foreach ($group as $entry) {
+            $this->table()->where('id', $entry['id'])->update([
+                'attempts' => $entry['attempts'],
+                'last_error' => $this->cipher->seal($entry['error']),
+                'last_attempted_at' => $now,
+                'reserved_at' => null,
+                'updated_at' => $now,
+            ]);
+        }
+    }
+
+    /**
+     * Batch-persist a group of dead-letter transitions via upsert(), falling
+     * back to independent per-row updates on batch failure. The per-row
+     * dead-letter log fires only after that row's write has succeeded,
+     * regardless of which write path ran.
+     *
+     * @param  list<array{id: int, category: string, run_id: ?string, attempts: int, error: string}>  $group
+     */
+    protected function writeDeadLetterGroup(array $group): void
+    {
+        $now = Carbon::now('UTC');
+        $rows = array_map(fn (array $e): array => [
+            'id' => $e['id'],
+            'status' => 'dead_letter',
+            'attempts' => $e['attempts'],
+            'last_error' => $this->cipher->seal($e['error']),
+            'last_attempted_at' => $now,
+            'reserved_at' => null,
+            'updated_at' => $now,
+        ], $group);
+
+        try {
+            $this->upsertBatch($rows, ['status', 'attempts', 'last_error', 'last_attempted_at', 'reserved_at', 'updated_at']);
+
+            foreach ($group as $entry) {
+                $this->logDeadLetter($entry);
+            }
+
+            return;
+        } catch (Throwable $exception) {
+            $this->safeReport($exception);
+        }
+
+        foreach ($group as $entry) {
+            $this->table()->where('id', $entry['id'])->update([
+                'status' => 'dead_letter',
+                'attempts' => $entry['attempts'],
+                'last_error' => $this->cipher->seal($entry['error']),
+                'last_attempted_at' => $now,
+                'reserved_at' => null,
+                'updated_at' => $now,
+            ]);
+            $this->logDeadLetter($entry);
+        }
+    }
+
+    /**
+     * @param  array{id: int, category: string, run_id: ?string, attempts: int, error: string}  $entry
+     */
+    protected function logDeadLetter(array $entry): void
+    {
         $this->safeLog($this->logger, 'error', 'Swarm audit record reached dead_letter status.', [
-            'category' => $category,
-            'run_id' => $runId,
-            'attempts' => $attempts,
-            'last_error' => $reason,
+            'category' => $entry['category'],
+            'run_id' => $entry['run_id'],
+            'attempts' => $entry['attempts'],
+            'last_error' => $entry['error'],
         ]);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @param  list<string>  $updateColumns
+     */
+    protected function upsertBatch(array $rows, array $updateColumns): void
+    {
+        $this->table()->upsert($rows, ['id'], $updateColumns);
     }
 
     public function isAvailable(): bool

--- a/tests/Feature/DurableOutboxTest.php
+++ b/tests/Feature/DurableOutboxTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use BuiltByBerry\LaravelSwarm\Contracts\ArtifactRepository;
+use BuiltByBerry\LaravelSwarm\Contracts\AuditOutbox;
 use BuiltByBerry\LaravelSwarm\Contracts\ContextStore;
 use BuiltByBerry\LaravelSwarm\Contracts\DurableOutbox;
 use BuiltByBerry\LaravelSwarm\Contracts\DurableRunStore;
@@ -344,6 +345,29 @@ test('swarm:relay --type=step filters by step type', function (): void {
 
     expect($exitCode)->toBe(0)
         ->and(DB::table('swarm_durable_outbox')->where('run_id', $response->runId)->count())->toBe(0);
+});
+
+test('swarm:relay --type=audit filters to the audit lane and leaves the durable lane untouched', function (): void {
+    $outbox = app(DurableOutbox::class);
+    $response = FakeSequentialSwarm::make()->dispatchDurable('task');
+
+    // Drain the initial row first
+    $outbox->drain([], 100);
+
+    // Seed the durable lane — must stay untouched by an audit-only relay.
+    $outbox->enqueueStep($response->runId, 1, null, null);
+
+    // Seed the audit lane.
+    app(AuditOutbox::class)->enqueue('run.failed', [
+        'run_id' => 'r-audit-only',
+        'category' => 'run.failed',
+    ]);
+
+    $exitCode = Artisan::call('swarm:relay --type=audit');
+
+    expect($exitCode)->toBe(0)
+        ->and(DB::table('swarm_audit_outbox')->where('run_id', 'r-audit-only')->count())->toBe(0)
+        ->and(DB::table('swarm_durable_outbox')->where('run_id', $response->runId)->count())->toBe(1);
 });
 
 test('swarm:relay --type=bogus exits failure with error message', function (): void {

--- a/tests/Unit/Audit/AuditOutboxTest.php
+++ b/tests/Unit/Audit/AuditOutboxTest.php
@@ -516,6 +516,41 @@ test('a failing batch upsert falls back to per-row writes and still persists eve
     expect((int) $rows['r-fallback-b']->attempts)->toBe(1);
 });
 
+test('a batch with both a failed entry and a dead-lettered entry writes each to its correct final state', function (): void {
+    config()->set('swarm.audit.outbox.max_attempts', 2);
+
+    $sink = new CountingThrowingSink(failFirstN: PHP_INT_MAX);
+    app()->instance(SwarmAuditSink::class, $sink);
+    app()->forgetInstance(AuditOutbox::class);
+
+    $outbox = app(AuditOutbox::class);
+    $outbox->enqueue('category.a', ['run_id' => 'r-repeat-fail']);
+
+    // First drain bumps r-repeat-fail to attempts=1 (still under max_attempts=2, stays pending).
+    $outbox->drain(100);
+
+    // Second entry enters fresh, so this drain call processes both:
+    // r-repeat-fail reaches attempts=2 (dead-lettered), r-fresh-fail reaches
+    // attempts=1 (stays failed/pending) — writeFailedGroup() and
+    // writeDeadLetterGroup() both run in the same drain() call.
+    $outbox->enqueue('category.b', ['run_id' => 'r-fresh-fail']);
+    $result = $outbox->drain(100);
+
+    expect($result->failed)->toBe(1);
+    expect($result->deadLettered)->toBe(1);
+
+    $rows = DB::table('swarm_audit_outbox')->orderBy('run_id')->get()->keyBy('run_id');
+    expect($rows)->toHaveCount(2);
+
+    expect($rows['r-repeat-fail']->status)->toBe('dead_letter');
+    expect((int) $rows['r-repeat-fail']->attempts)->toBe(2);
+    expect($rows['r-repeat-fail']->reserved_at)->toBeNull();
+
+    expect($rows['r-fresh-fail']->status)->toBe('pending');
+    expect((int) $rows['r-fresh-fail']->attempts)->toBe(1);
+    expect($rows['r-fresh-fail']->reserved_at)->toBeNull();
+});
+
 test('DatabaseAuditOutbox drain skips dead_letter rows', function (): void {
     $sink = new RecordingSwarmAuditSink;
     app()->instance(SwarmAuditSink::class, $sink);

--- a/tests/Unit/Audit/AuditOutboxTest.php
+++ b/tests/Unit/Audit/AuditOutboxTest.php
@@ -9,7 +9,11 @@ use BuiltByBerry\LaravelSwarm\Contracts\IdentifiesSigningKey;
 use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSigner;
 use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
 use BuiltByBerry\LaravelSwarm\Persistence\DatabaseAuditOutbox;
+use BuiltByBerry\LaravelSwarm\Persistence\SwarmPersistenceCipher;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\CountingThrowingSink;
 use BuiltByBerry\LaravelSwarm\Tests\Fixtures\RecordingSwarmAuditSink;
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Database\Connection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
@@ -455,6 +459,61 @@ test('a directly-emitted and a queued-then-drained record carry the same signatu
     expect($direct[0]['signature_key_id'])->toBe('kid-both-paths');
     expect($drained[0]['signature_key_id'])->toBe('kid-both-paths');
     expect($drained[0]['signature_key_id'])->toBe($direct[0]['signature_key_id']);
+});
+
+test('a batch of failed entries retains each entry\'s own attempts and error, not a mixed-up value', function (): void {
+    $sink = new CountingThrowingSink(failFirstN: PHP_INT_MAX);
+    app()->instance(SwarmAuditSink::class, $sink);
+    app()->forgetInstance(AuditOutbox::class);
+
+    $outbox = app(AuditOutbox::class);
+    $outbox->enqueue('category.a', ['run_id' => 'r-a']);
+    $outbox->enqueue('category.b', ['run_id' => 'r-b']);
+    $outbox->enqueue('category.c', ['run_id' => 'r-c']);
+
+    $outbox->drain(100);
+
+    $rows = DB::table('swarm_audit_outbox')->orderBy('run_id')->get()->keyBy('run_id');
+
+    expect($rows)->toHaveCount(3);
+    expect((int) $rows['r-a']->attempts)->toBe(1);
+    expect((int) $rows['r-b']->attempts)->toBe(1);
+    expect((int) $rows['r-c']->attempts)->toBe(1);
+    // Each row's reservation must be released so it's re-claimable, not stuck.
+    expect($rows['r-a']->reserved_at)->toBeNull();
+    expect($rows['r-b']->reserved_at)->toBeNull();
+    expect($rows['r-c']->reserved_at)->toBeNull();
+});
+
+test('a failing batch upsert falls back to per-row writes and still persists every entry in the group', function (): void {
+    $sink = new CountingThrowingSink(failFirstN: PHP_INT_MAX);
+    app()->instance(SwarmAuditSink::class, $sink);
+
+    $outbox = new class(app(Connection::class), app(Repository::class), app(SwarmAuditSink::class), app(SwarmPersistenceCipher::class)) extends DatabaseAuditOutbox
+    {
+        public int $upsertCalls = 0;
+
+        protected function upsertBatch(array $rows, array $updateColumns): void
+        {
+            $this->upsertCalls++;
+
+            // Fail every batch call once to force the fallback path.
+            throw new RuntimeException('simulated batch upsert failure');
+        }
+    };
+
+    $outbox->enqueue('category.a', ['run_id' => 'r-fallback-a']);
+    $outbox->enqueue('category.b', ['run_id' => 'r-fallback-b']);
+
+    $result = $outbox->drain(100);
+
+    expect($result->failed)->toBe(2);
+    expect($outbox->upsertCalls)->toBeGreaterThan(0);
+
+    $rows = DB::table('swarm_audit_outbox')->orderBy('run_id')->get()->keyBy('run_id');
+    expect($rows)->toHaveCount(2);
+    expect((int) $rows['r-fallback-a']->attempts)->toBe(1);
+    expect((int) $rows['r-fallback-b']->attempts)->toBe(1);
 });
 
 test('DatabaseAuditOutbox drain skips dead_letter rows', function (): void {


### PR DESCRIPTION
Release session for v0.16.1.

This PR is the long-lived integration branch for the v0.16.1 release. Topic branches target this branch, not `main`.

## Theme

Core hardening pass: tighten the operator-contract surface shipped in v0.16.0 before v0.17.0 Phase-0 (Pulse extract + contract prune + driver-surface promotions) and the adoption packages. Scoped via `/improve-laravel` audit rather than pre-filed issues.

## Session contents

- #341 — fix(compact): replace unbounded quarantine pluck with correlated subquery (closes #339)
- #342 — test(relay): cover swarm:relay --type=audit lane isolation (closes #338)
- #344 — docs(agents): correct laravel/ai version reference to ^0.8
- #345 — docs(contributing): document composer hooks:install setup step
- #346 — fix(audit): batch outbox retry/dead-letter writes with per-row fallback
- #347 — chore: 0.16.1 review followups (F1)
- #348 — chore(release): v0.16.1 (CHANGELOG + UPGRADING wrap)

## Wrap status

- [x] All topic PRs merged
- [x] Multi-expert review run (`chore/0.16.1-review-followups` complete — approve-with-followups, F1 fixed and merged in #347)
- [x] CHANGELOG + UPGRADING filled (`chore/0.16.1-release-wrap` complete, #348)
- [x] Release-readiness review run (`swarm-release-readiness` — ship, 0 findings, no readiness-followups branch needed)
- [x] Ready for merge + tag

Closes #338
Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)