### PR TITLE
fix(compact): replace unbounded quarantine pluck with correlated subquery

### DIFF
--- a/src/Commands/SwarmCompactCommand.php
+++ b/src/Commands/SwarmCompactCommand.php
@@ -78,11 +78,6 @@ class SwarmCompactCommand extends Command
         $hotTable = (string) $config->get('swarm.tables.stream_events', 'swarm_stream_events');
         $durableTable = (string) $config->get('swarm.tables.durable', 'swarm_durable_runs');
 
-        $quarantinedIds = $connection->table($durableTable)
-            ->whereNotNull('compaction_quarantined_at')
-            ->pluck('run_id')
-            ->all();
-
         $query = $connection->table($hotTable)
             ->select('run_id')
             ->where('event_type', 'swarm_causal_seal_barrier')
@@ -95,12 +90,14 @@ class SwarmCompactCommand extends Command
             ->whereIn('run_id', function ($durable) use ($durableTable): void {
                 $durable->select('run_id')->from($durableTable);
             })
+            ->whereNotExists(function ($quarantined) use ($hotTable, $durableTable): void {
+                $quarantined->select($quarantined->raw(1))
+                    ->from($durableTable)
+                    ->whereColumn($durableTable.'.run_id', $hotTable.'.run_id')
+                    ->whereNotNull($durableTable.'.compaction_quarantined_at');
+            })
             ->distinct()
             ->limit($limit);
-
-        if ($quarantinedIds !== []) {
-            $query->whereNotIn('run_id', $quarantinedIds);
-        }
 
         /** @var list<string> */
         return $query->pluck('run_id')->all();


### PR DESCRIPTION
## Summary
- `SwarmCompactCommand::discoverEligibleRuns()` plucked the full quarantined-run-id set into memory and built an unbounded `whereNotIn()` from it.
- Replaced with a `whereNotExists` correlated subquery against `swarm_durable_runs`, so the exclusion runs entirely in SQL.
- Scoped strictly to the discovery query — no leasing/sealing/graduation changes.

## Design gate
Evaluated and skipped: this is a scoped SQL rewrite of a discovery query, not one of the subtle surfaces (encrypt/decrypt, process-global state, distributed leasing, streaming, resume/re-dispatch, audit delivery/signing, envelope schema).

## Linked issue
Closes #339

## Test plan
- [x] `vendor/bin/pint --dirty` clean
- [x] `composer analyse` clean
- [x] `vendor/bin/pest tests/Feature/Compaction/SwarmCompactCommandTest.php` — 9 passed, including the existing quarantine-exclusion case
- [x] Full suite: `vendor/bin/pest tests/Feature tests/Unit tests/Installer` — 1895 passed (7662 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)