### PR TITLE
test(relay): cover swarm:relay --type=audit lane isolation

### DIFF
--- a/tests/Feature/DurableOutboxTest.php
+++ b/tests/Feature/DurableOutboxTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use BuiltByBerry\LaravelSwarm\Contracts\ArtifactRepository;
+use BuiltByBerry\LaravelSwarm\Contracts\AuditOutbox;
 use BuiltByBerry\LaravelSwarm\Contracts\ContextStore;
 use BuiltByBerry\LaravelSwarm\Contracts\DurableOutbox;
 use BuiltByBerry\LaravelSwarm\Contracts\DurableRunStore;
@@ -344,6 +345,29 @@ test('swarm:relay --type=step filters by step type', function (): void {
 
     expect($exitCode)->toBe(0)
         ->and(DB::table('swarm_durable_outbox')->where('run_id', $response->runId)->count())->toBe(0);
+});
+
+test('swarm:relay --type=audit filters to the audit lane and leaves the durable lane untouched', function (): void {
+    $outbox = app(DurableOutbox::class);
+    $response = FakeSequentialSwarm::make()->dispatchDurable('task');
+
+    // Drain the initial row first
+    $outbox->drain([], 100);
+
+    // Seed the durable lane — must stay untouched by an audit-only relay.
+    $outbox->enqueueStep($response->runId, 1, null, null);
+
+    // Seed the audit lane.
+    app(AuditOutbox::class)->enqueue('run.failed', [
+        'run_id' => 'r-audit-only',
+        'category' => 'run.failed',
+    ]);
+
+    $exitCode = Artisan::call('swarm:relay --type=audit');
+
+    expect($exitCode)->toBe(0)
+        ->and(DB::table('swarm_audit_outbox')->where('run_id', 'r-audit-only')->count())->toBe(0)
+        ->and(DB::table('swarm_durable_outbox')->where('run_id', $response->runId)->count())->toBe(1);
 });
 
 test('swarm:relay --type=bogus exits failure with error message', function (): void {


### PR DESCRIPTION
## Summary
- `--type=audit` alone was untested — only `--type=step`, `--type=bogus`, and the no-flag (both-lanes) case were covered.
- Adds a test asserting the audit lane drains while the durable lane stays untouched, mirroring the existing `--type=step` asymmetric-drain test (`tests/Feature/DurableOutboxTest.php`).

## Design gate
Evaluated: touches the audit/durable-delivery-reliability surface, but the change is test-only — locks down existing, already-implemented lane isolation behavior with no new invariant or code path. Gate skipped.

## Linked issue
Closes #338

## Test plan
- [x] `vendor/bin/pint --dirty` clean
- [x] `composer analyse` clean
- [x] `vendor/bin/pest tests/Feature/DurableOutboxTest.php` — 45 passed, including the new audit-lane test
- [x] Full suite: `vendor/bin/pest tests/Feature tests/Unit tests/Installer` — 1896 passed (7665 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)