### PR TITLE
docs(agents): correct laravel/ai version reference to ^0.8

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ If a gap is deferred, it must be recorded as a named follow-up with an owner, no
 
 - PHP ^8.5
 - Laravel ^13.0
-- `laravel/ai` ^0.6
+- `laravel/ai` ^0.8
 - `orchestra/testbench` ^11
 - `pestphp/pest` ^4.4 + `pest-plugin-laravel` ^4.1
 - `larastan/larastan` ^3.0


### PR DESCRIPTION
## Summary
- \`AGENTS.md\`'s Tech Stack section listed \`laravel/ai ^0.6\`; \`composer.json\` requires \`^0.8\`. Corrects the single line.

## Linked finding
From \`/improve-laravel\` standard-effort audit, finding DOCS-01 (vetted).

## Test plan
- [x] \`vendor/bin/pint --test\` clean
- [x] \`composer analyse\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)