### PR TITLE
docs(contributing): document composer hooks:install setup step

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,17 @@ from the repository root unless a test or reproduction explicitly uses a
 Testbench application. If you need Artisan behavior, prefer a focused package
 test over ad hoc manual setup.
 
+Install the local commit-msg hook once per clone to validate Conventional Commits
+format before you commit:
+
+```bash
+composer hooks:install
+```
+
+This is a local-only check (`tools/git-hooks/commit-msg`) — it does not run in CI.
+Branch naming is enforced separately, server-side, by
+`.github/workflows/branch-naming.yml`.
+
 ## Required Checks
 
 Before opening a pull request, run the checks that match your change:


### PR DESCRIPTION
## Summary
- \`composer.json\` ships a \`hooks:install\` script that symlinks a local commit-msg hook validating Conventional Commits format, but \`CONTRIBUTING.md\` never mentioned it. Adds a short paragraph to the "Local Setup" section.

## Linked finding
From \`/improve-laravel\` standard-effort audit, finding TECH-DEBT-01 (vetted).

## Test plan
- [x] \`vendor/bin/pint --test\` clean
- [x] \`composer analyse\` clean
- Docs-only change, no executable behavior — no new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)