### PR TITLE
chore: 0.16.1 review followups (F1)

### DIFF
--- a/tests/Unit/Audit/AuditOutboxTest.php
+++ b/tests/Unit/Audit/AuditOutboxTest.php
@@ -516,6 +516,41 @@ test('a failing batch upsert falls back to per-row writes and still persists eve
     expect((int) $rows['r-fallback-b']->attempts)->toBe(1);
 });
 
+test('a batch with both a failed entry and a dead-lettered entry writes each to its correct final state', function (): void {
+    config()->set('swarm.audit.outbox.max_attempts', 2);
+
+    $sink = new CountingThrowingSink(failFirstN: PHP_INT_MAX);
+    app()->instance(SwarmAuditSink::class, $sink);
+    app()->forgetInstance(AuditOutbox::class);
+
+    $outbox = app(AuditOutbox::class);
+    $outbox->enqueue('category.a', ['run_id' => 'r-repeat-fail']);
+
+    // First drain bumps r-repeat-fail to attempts=1 (still under max_attempts=2, stays pending).
+    $outbox->drain(100);
+
+    // Second entry enters fresh, so this drain call processes both:
+    // r-repeat-fail reaches attempts=2 (dead-lettered), r-fresh-fail reaches
+    // attempts=1 (stays failed/pending) — writeFailedGroup() and
+    // writeDeadLetterGroup() both run in the same drain() call.
+    $outbox->enqueue('category.b', ['run_id' => 'r-fresh-fail']);
+    $result = $outbox->drain(100);
+
+    expect($result->failed)->toBe(1);
+    expect($result->deadLettered)->toBe(1);
+
+    $rows = DB::table('swarm_audit_outbox')->orderBy('run_id')->get()->keyBy('run_id');
+    expect($rows)->toHaveCount(2);
+
+    expect($rows['r-repeat-fail']->status)->toBe('dead_letter');
+    expect((int) $rows['r-repeat-fail']->attempts)->toBe(2);
+    expect($rows['r-repeat-fail']->reserved_at)->toBeNull();
+
+    expect($rows['r-fresh-fail']->status)->toBe('pending');
+    expect((int) $rows['r-fresh-fail']->attempts)->toBe(1);
+    expect($rows['r-fresh-fail']->reserved_at)->toBeNull();
+});
+
 test('DatabaseAuditOutbox drain skips dead_letter rows', function (): void {
     $sink = new RecordingSwarmAuditSink;
     app()->instance(SwarmAuditSink::class, $sink);


### PR DESCRIPTION
## Summary
Multi-expert change review of `release/v0.16.1` vs `main` (8 lenses: laravel-package-maintainer, cto, em, security, qa, docs, systems-integrator, regulatory). Verdict: **approve-with-followups**, non-blocker — 0 high, 0 medium, 1 low.

## F1 · low · QA
The two batching regression tests for `DatabaseAuditOutbox::drain()` (added in #346) each exercised only one group (all-failed, or forced-fallback) — no test proved `writeFailedGroup()` and `writeDeadLetterGroup()` don't interfere when both run in the same `drain()` call.

**Fixed:** added a test seeding one entry that reaches `attempts=2` (dead-lettered, `max_attempts=2`) and a fresh entry that reaches `attempts=1` (stays failed/pending) within the same `drain()` call, asserting both land in their correct final DB state.

## Passes (no findings)
- Security — no new input path, encryption/sealing logic unchanged
- Regulatory — dead-letter audit trail's `Log::error` shape and fail-loud-on-write-failure posture both preserved exactly
- Systems-integrator — `upsert()`/`whereNotExists` are portable query-builder calls; CI matrix already green on mysql-8/postgres-16/PHP 8.5 stable+lowest
- EM — delivered as 5 small independently-revertible PRs
- Laravel-package-maintainer / CTO — no public-contract or package-registration surface touched

## Test plan
- [x] `vendor/bin/pint --test` clean
- [x] `composer analyse` clean
- [x] `vendor/bin/pest tests/Unit/Audit/AuditOutboxTest.php` — 23 passed (84 assertions)
- [x] Full suite: 1899 passed (7686 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)