### PR TITLE
chore(release): v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,23 @@
 # Changelog
 
-## v0.16.1 - unreleased
+## v0.16.1 - 2026-07-03
 
-Core hardening pass: tighten the operator-contract surface shipped in v0.16.0 before v0.17.0 Phase-0 (Pulse extract + contract prune + driver-surface promotions) and the adoption packages. Scoped via `/improve-laravel` audit rather than pre-filed issues.
+Core hardening pass: tighten the operator-contract surface shipped in v0.16.0 before v0.17.0 Phase-0 (Pulse extract + contract prune + driver-surface promotions) and the adoption packages. Scoped via an `/improve-laravel` audit rather than pre-filed issues.
 
 ### Fixed
 
-_To be filled in during release wrap-up._
+- **`swarm:compact` discovery no longer plucks the full quarantined-run-id set into memory (#339).** `SwarmCompactCommand::discoverEligibleRuns()` loaded every quarantined `run_id` from `swarm_durable_runs` into a PHP array, then built an unbounded `whereNotIn()` from it, before applying the discovery `--limit`. Replaced with a `whereNotExists` correlated subquery against `swarm_durable_runs`, so the exclusion runs entirely in SQL and scales with the quarantine table size instead of the process's memory. Scoped strictly to the discovery query — no change to leasing, sealing, or graduation. No public API change.
+- **`DatabaseAuditOutbox::drain()` batches retry/dead-letter writes instead of issuing one `UPDATE` per row (#345 improve-laravel finding, hardened via a pre-implementation design gate).** A drain batch with many failed or dead-lettered entries (e.g. during a sustained sink outage) previously issued one individual `UPDATE ... WHERE id = ?` per entry. Writes are now batched via two `upsert()` calls (failed vs. dead-lettered — different column sets), each falling back to the original independent per-row `UPDATE` loop if the atomic batch statement throws. The fallback exists because a single-statement `upsert()` is all-or-nothing: one malformed row would otherwise fail the whole batch's writes, silently losing already-computed state for every sibling in the group — a regression the design gate caught before any code was written. The per-row `Log::error` dead-letter alert still fires once per row, only after that row's write has actually succeeded, matching the original ordering. No public API change; `AuditDrainResult`'s shape is unchanged.
+
+### Tested
+
+- **`swarm:relay --type=audit` lane isolation now has direct coverage (#338).** `--type=audit` alone was untested — only `--type=step`, `--type=bogus`, and the no-flag (both-lanes) case were covered. A new test asserts an audit-only relay drains the audit lane while leaving a pending durable-lane entry untouched, mirroring the existing `--type=step` asymmetric-drain test.
+- **A batch spanning both the failed and dead-lettered outcome in one `drain()` call is now covered (change-review F1).** The two regression tests added for the batching fix above each exercised only one outcome group; a new test seeds one entry that stays failed and another that reaches `dead_letter` within a single `drain()` call, confirming the two independent `upsert()` calls don't interfere with each other.
+
+### Documentation
+
+- **`AGENTS.md`'s Tech Stack section corrected to `laravel/ai` `^0.8`.** It still read `^0.6`, one range behind the floor `composer.json` has required since v0.13.0.
+- **`CONTRIBUTING.md` documents the `composer hooks:install` setup step.** The local commit-msg Conventional Commits hook (`tools/git-hooks/commit-msg`) existed but was never mentioned in the contributor setup docs — a new paragraph in "Local Setup" covers it.
 
 ## v0.16.0 - 2026-07-02
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -269,6 +269,10 @@ This package’s `composer.json` uses `"minimum-stability": "dev"` with
 still prefers tagged releases. Your application may need compatible Composer
 stability settings while Laravel AI remains pre-stable.
 
+## Upgrading to v0.16.1
+
+**No required action.** v0.16.1 is a core hardening pass with no migration, no config change, and no breaking API — `swarm:compact` discovery is now a bounded SQL query instead of an unbounded in-memory pluck (#339), `DatabaseAuditOutbox::drain()` batches its retry/dead-letter writes with a per-row fallback (no observable change to `AuditDrainResult`'s shape or the audit trail), and two documentation lines (`AGENTS.md`'s `laravel/ai` version, `CONTRIBUTING.md`'s hook setup step) were corrected.
+
 ## Upgrading to v0.16.0
 
 **No required action for most applications.** v0.16.0 is additive and backward-compatible — it promotes a public operator control contract and finalizes several audit and relay surfaces. Notes if any apply to you:


### PR DESCRIPTION
## Summary
Phase 2 of the v0.16.1 release wrap.

- Fills in `CHANGELOG.md`'s `## v0.16.1` entry (dated, Fixed/Tested/Documentation sections) from the 6 merged topic PRs (#341, #342, #344, #345, #346, #347).
- Adds an `## Upgrading to v0.16.1` block to `UPGRADING.md` — no required action, no breaking changes, no migration.
- `composer.json`'s `branch-alias` (`0.16.x-dev`) already matches the release minor — no bump needed.
- No README marquee update — this is an internal hardening pass with no user-facing headline feature, consistent with prior hardening-style releases (v0.12.2, v0.12.3).

## Deploy safety / breaking changes
None. No migration, no config change, no public API change.

## Next phase
Readiness review (`swarm-release-readiness`, tag mode) once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)