### PR TITLE
feat(contracts): promote CausalLogStore + ColdArchiveDriver to public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Phase-0 surface-settle: Pulse extract + contract prune + driver-surface promotio
 
 ### Added
 
-_To be filled in during release wrap-up._
+- **`CausalLogStore` and `ColdArchiveDriver` are now public contracts (#349).** Both have been stable for two minors since their v0.15.0 introduction. They are **read/query-seam extension points only** — a custom implementation is consumed by durable per-node streaming's void-on-resume path, hierarchical stream causal-log resolution, and `TieredStreamEventStore`'s hot/cold read seam. A pre-implementation design gate confirmed, and this release explicitly discloses, two scope limits that a driver author must know before implementing: compaction (graduation to cold, hot reclaim) stays coupled to the concrete `DatabaseCausalLogStore`/`DatabaseColdArchiveDriver` classes, so a custom driver's runs are never compacted; and `#[DurableStreaming]` per-node streaming requires the concrete database implementation and fails loud at dispatch otherwise. `ColdArchiveDriver::readSnapshot()` is contract-ready for a forthcoming snapshot-based resume feature but has no production caller yet. See the new [Streaming Substrate Driver Guide](docs/streaming-substrate-driver-guide.md) for the full driver-author story. Also fixes a stale `docs/public-surface.md` description that incorrectly listed `graduate()`/`reclaim()` as part of the `ColdArchiveDriver` contract — those methods are internal to the compactor and were never part of this interface.
 
 ### Changed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -269,6 +269,10 @@ This package’s `composer.json` uses `"minimum-stability": "dev"` with
 still prefers tagged releases. Your application may need compatible Composer
 stability settings while Laravel AI remains pre-stable.
 
+## Upgrading to v0.17.0
+
+**No required action.** `CausalLogStore` and `ColdArchiveDriver` are now public contracts (#349) — no behavior change, no config change, no migration. If you want to implement a custom persistence backend for the streaming substrate's hot/cold tiering, see the new [Streaming Substrate Driver Guide](docs/streaming-substrate-driver-guide.md) for what's actually pluggable (the read/query seam) and what isn't yet (compaction, `#[DurableStreaming]` per-node streaming both stay coupled to the concrete database implementations).
+
 ## Upgrading to v0.16.1
 
 **No required action.** v0.16.1 is a core hardening pass with no migration, no config change, and no breaking API — `swarm:compact` discovery is now a bounded SQL query instead of an unbounded in-memory pluck (#339), `DatabaseAuditOutbox::drain()` batches its retry/dead-letter writes with a per-row fallback (no observable change to `AuditDrainResult`'s shape or the audit trail), and two documentation lines (`AGENTS.md`'s `laravel/ai` version, `CONTRIBUTING.md`'s hook setup step) were corrected.

--- a/docs/internal-audit-1.0.md
+++ b/docs/internal-audit-1.0.md
@@ -46,20 +46,20 @@ public. What remains `@internal` is genuinely internal.
 | `Runners\LeaseManager` | **Keep `@internal` — no action** | Durable-leasing internal for the runner orchestrator (queue-lease-seconds policy + coordination-run fail/complete inside a freshly acquired lease). This is a **subtle surface** (distributed leasing) whose contract is entangled with orchestrator flow control; exposing it would freeze leasing mechanics. No interface, concrete singleton, consumed only by `SwarmRunner`. Fails criteria 1, 2 (leasing mechanics still evolve), and 3. |
 | `Audit\SwarmAuditDispatcher` | **Keep `@internal` — document the workaround** | The "dispatcher chain" the issue mentions is customized by *binding the public contracts it composes* (`SwarmAuditSink`, `SinkFailureHandler`, `AuditOutbox`, `SwarmAuditSigner`, `CapturePolicy`), not by replacing the concrete dispatcher. Exposing it would freeze its enrichment/retry internals. Fails criterion 1. |
 
-## The only `@internal` interfaces — streaming substrate (v0.15.0+)
+## Streaming substrate contracts (v0.15.0+) — promoted in v0.17.0
 
-Two `@internal` **contracts** exist in `src/Contracts/` (every other `@internal`
-class is a concrete implementation or support object):
+Two contracts in `src/Contracts/` were `@internal` at the time of this survey
+(v0.16.0) and have since been promoted:
 
 | Class | Recommendation | Justification |
 | --- | --- | --- |
-| `Contracts\CausalLogStore` | **Deferred — needs design review** | Already documented in `docs/public-surface.md` as "provisional, not yet semver-stable, on the roadmap to promote out of `@internal`". Schema-coupled to `DatabaseCausalLogStore`; only ONE minor old (v0.15.0) — fails criterion 2 (two minors). Subtle surface (persistence + sealed-window/void-edge semantics). Promote in a later release once the shape has settled and cache-driver parity is decided, not speculatively now. |
-| `Contracts\ColdArchiveDriver` | **Deferred — needs design review** | Same footing: provisional, schema-coupled to `DatabaseColdArchiveDriver` (`swarm_cold_archives`), one minor old, and a subtle surface (encrypt-at-rest `openStrict` decrypt-or-throw, atomic base-pointer swap). Fails criterion 2; deliberately flagged in the docs as a future promotion. Defer. |
+| `Contracts\CausalLogStore` | **Promoted — public since v0.17.0 (#349)** | Stable for two minors since its v0.15.0 introduction, satisfying criterion 2. A design gate ahead of the promotion (#349) confirmed the schema-coupling and sealed-window/void-edge semantics don't block a *read/query-seam* extension point — the gate's finding was that compaction and `#[DurableStreaming]` remain concrete-class-coupled, not that the contract itself is unsafe to expose. Scoped and disclosed accordingly; see the [Streaming Substrate Driver Guide](streaming-substrate-driver-guide.md). |
+| `Contracts\ColdArchiveDriver` | **Promoted — public since v0.17.0 (#349)** | Same footing: stable for two minors, schema-coupled to `DatabaseColdArchiveDriver` (`swarm_cold_archives`). The design gate confirmed the atomic base-pointer-swap obligation binds the internal compactor, not contract implementers (graduate()/reclaim() were never part of this interface), and that `readSnapshot()`'s decrypt-or-throw responsibility already sat correctly with callers. Promoted as a read-only extension point; see the [Streaming Substrate Driver Guide](streaming-substrate-driver-guide.md). |
 
-These two are the natural *next* promotion candidates — but only after they have
-been stable for two minors and the driver-author story is designed. Promoting
-them in this survey would be exactly the speculative over-broad move the issue
-exists to prevent.
+Both promotions are scoped to the read/query seam only — compaction and
+`#[DurableStreaming]` per-node streaming remain coupled to the concrete
+database implementations and are explicitly out of scope for a custom driver
+in v0.17.0. See the driver guide for the full disclosure.
 
 ## Everything else — grouped keep
 

--- a/docs/public-surface.md
+++ b/docs/public-surface.md
@@ -221,17 +221,20 @@ engine behavior for orientation only.
 The append-only causal-log substrate that makes dynamic swarms streamable, with
 background-compacted hot/cold durability and author-owned context bounding.
 
-> **Stability.** The first three contracts/decorators below — `CausalLogStore`,
-> `ColdArchiveDriver`, `TieredStreamEventStore` — are `@internal` and
-> schema-coupled to their database implementations. They are documented here for
-> operators and driver authors, but are **provisional and not yet semver-stable**
-> (on the roadmap to promote out of `@internal`). The attribute, enum, and
-> exception rows are public API.
+> **Stability.** `CausalLogStore` and `ColdArchiveDriver` were promoted to
+> public in v0.17.0 (#349), stable for two minors since their v0.15.0
+> introduction. Both are **read/query-seam extension points only** — see the
+> [Streaming Substrate Driver Guide](streaming-substrate-driver-guide.md) for
+> exactly what a custom implementation is (and is not) consumed by; in
+> particular, compaction stays coupled to the concrete database
+> implementations and is out of scope for a custom driver in this release.
+> `TieredStreamEventStore` remains `@internal` and schema-coupled — it is
+> documented here for orientation only.
 
 | Surface | Purpose | Primary documentation |
 | --- | --- | --- |
-| `CausalLogStore` | Database-only contract extending `StreamEventStore` — the append-only causal log. Adds `appendVoidEdge()`, `voidNodeAttempt()`, `latestAttemptEpochBelow()`, `isSealed()`, and `sealRollup()`. Voiding a sealed target throws `SealedCausalWindowException`; voiding an unknown target throws `UnknownCausalTargetException`. Implemented by `DatabaseCausalLogStore` (the database `StreamEventStore` binding now resolves this subclass). **`@internal`** — provisional, not yet semver-stable. (v0.15.0+) | [Lifecycle Events](events.md#causal-void-edges-282-289) |
-| `ColdArchiveDriver` | Contract for the cold tier — addressable-by-coordinate cold storage with an atomic base-pointer swap (`graduate()`) and hot reclaim (`reclaim()`), and separate snapshot (resume) + raw-event (audit) retention paths. Default `DatabaseColdArchiveDriver` backs it with the `swarm_cold_archives` table; resume reads use `openStrict` (decrypt-or-throw, the #212 convention). **`@internal`** — provisional, not yet semver-stable. (v0.15.0+) | [Operator Runbook: Streaming Substrate](operator-runbook-streaming-substrate.md) |
+| `CausalLogStore` | Database-only contract extending `StreamEventStore` — the append-only causal log. Adds `appendVoidEdge()`, `voidNodeAttempt()`, `latestAttemptEpochBelow()`, `isSealed()`, and `sealRollup()`. Voiding a sealed target throws `SealedCausalWindowException`; voiding an unknown target throws `UnknownCausalTargetException`. Implemented by `DatabaseCausalLogStore` (the database `StreamEventStore` binding now resolves this subclass). Read/query-seam extension point — not consumed by compaction. (v0.15.0+, public since v0.17.0) | [Streaming Substrate Driver Guide](streaming-substrate-driver-guide.md), [Lifecycle Events](events.md#causal-void-edges-282-289) |
+| `ColdArchiveDriver` | Read-only contract for the cold tier — addressable-by-coordinate cold storage (`basePointer()`, `readEvents()`, `readSnapshot()`, `forget()`), with separate snapshot (resume) + raw-event (audit) retention paths. Graduation (`graduate()`/`reclaim()`, the atomic base-pointer CAS swap) is internal to the compactor and is not part of this interface. Default `DatabaseColdArchiveDriver` backs it with the `swarm_cold_archives` table; resume reads use `openStrict` (decrypt-or-throw, the #212 convention). Read/query-seam extension point — not consumed by compaction. (v0.15.0+, public since v0.17.0) | [Streaming Substrate Driver Guide](streaming-substrate-driver-guide.md), [Operator Runbook: Streaming Substrate](operator-runbook-streaming-substrate.md) |
 | `TieredStreamEventStore` | Transparent `StreamEventStore` decorator that yields cold events below the base pointer then hot events at/above it, with a half-open seam guarantee (no gap, no duplicate). A consumer reading `events()` after compaction sees the complete history. **`@internal`** — provisional, not yet semver-stable. (v0.15.0+) | [Operator Runbook: Streaming Substrate](operator-runbook-streaming-substrate.md) |
 | `GrowthPolicy` | Enum used by `#[ContextGrowthPolicy]` and `swarm.context_growth.policy`. Cumulative severity ladder: `Ignore` → `Warn` → `DegradeToCold` (the default) → `Backpressure` → `Refuse`. Each rung includes the behaviour of every lower one. (v0.15.0+) | [Streaming Substrate Author Guide](streaming-substrate-author-guide.md#context-growth-policy) |
 | `ContextBudgetExceededException` | Thrown by the `Refuse` rung and by the operator hard-cap breach. Extends `SwarmException`; re-dispatchable on durable runs. (v0.15.0+) | [Streaming Substrate Author Guide](streaming-substrate-author-guide.md#context-growth-policy) |

--- a/docs/streaming-substrate-driver-guide.md
+++ b/docs/streaming-substrate-driver-guide.md
@@ -1,0 +1,108 @@
+# Streaming Substrate Driver Guide
+
+`CausalLogStore` and `ColdArchiveDriver` (both public since v0.17.0, #349) are
+the extension points for a custom storage backend behind the streaming
+substrate's hot/cold tiering. This guide is for **driver authors** — package
+maintainers implementing a custom persistence backend — not application
+authors declaring swarms (see the
+[Streaming Substrate Author Guide](streaming-substrate-author-guide.md) for
+that audience).
+
+Read this before implementing either contract: both are narrower than they
+might look, and the gap between "public contract" and "full custom driver" is
+the thing this guide exists to make explicit.
+
+## What's actually pluggable
+
+Both contracts cover the **read/query seam** only:
+
+- `CausalLogStore` (extends `StreamEventStore`) is read by durable per-node
+  streaming's void-on-resume path and by hierarchical stream causal-log
+  resolution.
+- `ColdArchiveDriver` is read by `TieredStreamEventStore`, which stitches cold
+  events below the base pointer with hot events at/above it.
+
+Bind your implementation the same way any contract is bound, in your service
+provider:
+
+```php
+$this->app->singleton(CausalLogStore::class, MyCausalLogStore::class);
+$this->app->singleton(ColdArchiveDriver::class, MyColdArchiveDriver::class);
+```
+
+## What's NOT pluggable (yet)
+
+**Compaction does not consume your implementation.** `SwarmCompactor`
+constructs `DatabaseCausalLogStore` and `DatabaseColdArchiveDriver`
+concretely — not through the container, not through the interface. Rebinding
+`CausalLogStore::class` / `ColdArchiveDriver::class` to your own
+implementation has no effect on compaction: hot storage for your driver's
+runs is never graduated to cold, and there is no error or warning telling you
+so. If you need bounded hot-table growth today, your driver needs its own
+retention story outside compaction (or you keep hot storage on the database
+driver and use a custom `ColdArchiveDriver` only for the cold read path).
+
+**`#[DurableStreaming]` per-node streaming requires the concrete database
+implementation.** `DispatchValidator::ensureDurableStreamingInfrastructure()`
+checks `instanceof DatabaseCausalLogStore` and throws a `SwarmException` if
+that check fails — a swarm opted into `#[DurableStreaming]` with a custom
+`CausalLogStore` bound will fail loud at dispatch, not silently degrade. This
+is deliberate: fail loud is the safe direction here, but it does mean a
+custom driver cannot back this feature today.
+
+**`ColdArchiveDriver::readSnapshot()` has no production caller yet.** It's
+part of the contract (a forthcoming snapshot-based resume feature reads it),
+and it's exercised directly by tests, but nothing in the framework calls it
+today. Implement it to the documented semantics below, but don't expect
+end-to-end verification against a real resume flow until that feature lands.
+
+## Semantics your implementation must honor
+
+### `ColdArchiveDriver::readSnapshot()` — decrypt-or-throw
+
+`readSnapshot()` returns the raw (possibly sealed/encrypted) string — it does
+not decrypt. The convention (mirroring `DatabaseColdArchiveDriver`) is:
+
+- Return `null` only when nothing has been graduated yet for the run.
+- A driver/network failure throws — never returns `null` to mean "something
+  went wrong."
+- Decryption and the wrong/rotated-key fail-loud path (`openStrict()` +
+  `DecryptException` → `SwarmException`) are the **caller's** responsibility,
+  not `readSnapshot()`'s. If you write a convenience wrapper analogous to
+  `DatabaseColdArchiveDriver::readSnapshotStrict()`, it must fail loud on a
+  bad key, never silently return `null` or garbage.
+
+### `ColdArchiveDriver::basePointer()` — the hot/cold boundary contract
+
+The base pointer is an **atomicity guarantee to readers**, not just a number:
+a reader observing a non-zero base pointer is guaranteed that all events with
+id below it are durably available via `readEvents()`, and that the snapshot
+(if any) was written before the pointer advanced. Your implementation only
+needs to serve reads correctly against whatever your own write path
+guarantees — the atomic swap itself is the internal compactor's obligation,
+not yours, since `graduate()`/`reclaim()` aren't part of this interface.
+
+### `CausalLogStore` — database-only by design
+
+`CausalLogStore` extends `StreamEventStore` with void-edge operations
+(`appendVoidEdge()`, `sealRollup()`, `voidNodeAttempt()`, `isSealed()`,
+`latestAttemptEpochBelow()`) that need indexed UUID lookup and row-level
+locking. If your backend can't provide that, implement the base
+`StreamEventStore` contract instead (already public) and skip
+`CausalLogStore` — a non-`CausalLogStore` `StreamEventStore` binding is a
+supported, first-class configuration; it just doesn't get the causal
+void-edge / durable-per-node-streaming features.
+
+## Summary
+
+| Capability | Custom `CausalLogStore`/`ColdArchiveDriver`? |
+| --- | --- |
+| Hierarchical stream read / causal-log resolution | Yes |
+| Hot/cold read stitching (`TieredStreamEventStore`) | Yes |
+| Compaction (graduation to cold, hot reclaim) | No — concrete-class-coupled |
+| `#[DurableStreaming]` per-node streaming | No — fails loud at dispatch |
+| Snapshot-based resume (`readSnapshot()`) | Contract-ready, no production caller yet |
+
+If your use case needs compaction or `#[DurableStreaming]` support for a
+custom backend, that's follow-on work, not something this promotion covers —
+open an issue describing your backend and the gap.

--- a/src/Contracts/CausalLogStore.php
+++ b/src/Contracts/CausalLogStore.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Contracts;
 
+use BuiltByBerry\LaravelSwarm\Compaction\SwarmCompactor;
 use BuiltByBerry\LaravelSwarm\Exceptions\SealedCausalWindowException;
 use BuiltByBerry\LaravelSwarm\Exceptions\UnknownCausalTargetException;
 use BuiltByBerry\LaravelSwarm\Persistence\DatabaseCausalLogStore;
@@ -22,10 +23,16 @@ use BuiltByBerry\LaravelSwarm\Streaming\Events\CausalVoidEdgeType;
  * a non-database persistence driver must fail loud (see
  * {@see DatabaseCausalLogStore}).
  *
- * @internal This contract is schema-coupled to {@see DatabaseCausalLogStore} (its
- * sole implementation) and evolves with the substrate; it is not a consumer
- * extension point. Consumers wanting a custom persistence backend implement the
- * public {@see StreamEventStore} instead.
+ * Public since v0.17.0 (#349), stable for two minors since its v0.15.0
+ * introduction. This is a **read/query-seam extension point**: a custom
+ * implementation is consumed by the runtime read paths (durable per-node
+ * streaming's void-on-resume, hierarchical stream causal-log resolution). It is
+ * NOT consumed by compaction — {@see SwarmCompactor}
+ * depends on the concrete {@see DatabaseCausalLogStore} directly, so a custom
+ * implementation's runs are never compacted. `#[DurableStreaming]` per-node
+ * streaming additionally requires the concrete database implementation and
+ * fails loud otherwise (see `DispatchValidator::ensureDurableStreamingInfrastructure`).
+ * See `docs/streaming-substrate-driver-guide.md` for the full driver-author story.
  */
 interface CausalLogStore extends StreamEventStore
 {

--- a/src/Contracts/ColdArchiveDriver.php
+++ b/src/Contracts/ColdArchiveDriver.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Contracts;
 
+use BuiltByBerry\LaravelSwarm\Compaction\SwarmCompactor;
 use BuiltByBerry\LaravelSwarm\Exceptions\SwarmException;
+use BuiltByBerry\LaravelSwarm\Persistence\DatabaseColdArchiveDriver;
+use BuiltByBerry\LaravelSwarm\Persistence\TieredStreamEventStore;
 use BuiltByBerry\LaravelSwarm\Streaming\Events\SwarmStreamEvent;
 
 /**
@@ -16,13 +19,26 @@ use BuiltByBerry\LaravelSwarm\Streaming\Events\SwarmStreamEvent;
  * expressed here — the contract documents the atomicity requirement so any
  * future compactor implementation can be verified against it.
  *
- * Atomic swap requirement: the compactor MUST advance the base pointer with a
- * single-pointer CAS swap (old-or-new, never half). A reader that observes a
- * non-zero base pointer is guaranteed that all events with id < that value are
- * durably available via readEvents(), and that the snapshot (if any) was written
- * before the pointer was advanced.
+ * Atomic swap requirement: the compactor (internal) MUST advance the base
+ * pointer with a single-pointer CAS swap (old-or-new, never half). A reader
+ * that observes a non-zero base pointer is guaranteed that all events with id
+ * < that value are durably available via readEvents(), and that the snapshot
+ * (if any) was written before the pointer was advanced. This obligation binds
+ * the internal compactor, not implementers of this contract.
  *
- * @internal
+ * Public since v0.17.0 (#349), stable for two minors since its v0.15.0
+ * introduction. This is a **read-only extension point** — it has no write
+ * methods (graduate/reclaim are internal to the compactor and are not part of
+ * this interface). A custom implementation is consumed by {@see
+ * TieredStreamEventStore}'s read seam, but NOT by compaction: {@see
+ * SwarmCompactor} depends on the concrete {@see DatabaseColdArchiveDriver}
+ * directly, so a custom implementation's runs are never graduated to cold
+ * storage (no error — hot storage simply grows unbounded for those runs).
+ * `readSnapshot()` is reserved for a forthcoming snapshot-based resume feature
+ * and has no production caller yet. Any custom `readSnapshot()` implementation
+ * must honor the same decrypt-or-throw semantics as
+ * {@see DatabaseColdArchiveDriver::readSnapshotStrict()}.
+ * See `docs/streaming-substrate-driver-guide.md` for the full driver-author story.
  */
 interface ColdArchiveDriver
 {


### PR DESCRIPTION
## Summary

- Promotes `CausalLogStore` and `ColdArchiveDriver` from `@internal` to public, now stable for two minors since their v0.15.0 introduction (clears the bar set at the v0.16.0 `@internal` survey).
- Scoped by a pre-implementation design gate to a **read/query-seam extension point**: compaction (graduation to cold, hot reclaim) and `#[DurableStreaming]` per-node streaming both stay coupled to the concrete `DatabaseCausalLogStore`/`DatabaseColdArchiveDriver` classes — disclosed explicitly in a new [driver guide](docs/streaming-substrate-driver-guide.md) rather than glossed over.
- Fixes a stale `docs/public-surface.md` claim that `ColdArchiveDriver` exposed `graduate()`/`reclaim()` — those are compactor-internal and were never part of the interface.
- Updates `docs/internal-audit-1.0.md` (deferred → promoted), `CHANGELOG.md`, and `UPGRADING.md` (change-review follow-up, added after the initial review).

No behavior change, no migration, no breaking API.

## Linked issue

Closes #349

## Verification

- `vendor/bin/pint --test` — passed
- `composer analyse` — no errors
- `composer test` (full suite) — 1899 passed
- Design gate recorded in `.claude/design-state.json`
- Multi-expert change review: `approve-with-followups` → 1 medium finding (UPGRADING.md gap), addressed and verified before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)