### PR TITLE
docs(tests): fix stale InstallerTestCase reference in Pest.php comment

### DIFF
--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -10,7 +10,7 @@ use BuiltByBerry\LaravelSwarm\Tests\TestCase;
 pest()->extend(TestCase::class)->in('Feature', 'Unit');
 pest()->extend(ProcessConcurrencyTestCase::class)->in('ProcessConcurrency');
 
-// Installer tests bind their own base case via `uses(InstallerTestCase::class)`
+// Installer tests bind their own base case via `uses(SwarmInstallerTestCase::class)`
 // inside each file so each test gets an isolated host-app skeleton — see
 // tests/Installer/README.md.
 


### PR DESCRIPTION
## Summary
- Follow-up from the post-merge multi-expert review of #357 (F1, low severity)
- `tests/Pest.php`'s installer-test comment still named `InstallerTestCase` after #357 renamed every `uses()` call to `SwarmInstallerTestCase`

## Test plan
- [x] `composer lint` (pint) — clean
- [x] `composer analyse` (phpstan) — clean
- [x] Comment-only change, no test behavior affected