### PR TITLE
chore(release): v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## v0.17.0 - unreleased
+## v0.17.0 - 2026-07-06
 
-Phase-0 surface-settle: Pulse extract + contract prune + driver-surface promotions — settle the core public surface before the adoption packages (Filament/MCP/driver-family) bind it.
+Phase-0 surface-settle: extract Pulse (and the shared test harness it needed) into companion packages, and promote the streaming substrate's driver contracts to public — settling the core public surface before the adoption packages (Filament/MCP/driver-family) bind it. An audit of the Contracts namespace for pruning candidates (#350) found the work already done in v0.12.0 and was closed without further changes.
 
 ### Removed
 
@@ -14,7 +14,7 @@ Phase-0 surface-settle: Pulse extract + contract prune + driver-surface promotio
 
 ### Changed
 
-_To be filled in during release wrap-up._
+- **Shared `swarm:install*` test harness extracted to `builtbyberry/laravel-swarm-installer-testkit` (#355).** `InstallerTestCase`, `InstallerRunResult`, and `DoubleRunResult` moved out of this repo's `tests/Installer/` into a new standalone package (v0.1.0) so companion packages — starting with `laravel-swarm-pulse`, which had duplicated roughly 250 lines of the harness — can share it instead of each carrying their own copy. This repo's own installer tests now extend a thin `SwarmInstallerTestCase` that supplies the swarm-specific service-provider list on top of the shared base class. Dev-only: added to `require-dev`, no public API or runtime behavior change.
 
 ## v0.16.1 - 2026-07-03
 

--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ Swarm carries `laravel/ai` `ToolCall` / `ToolResult` objects through the stream 
 
 - **Authors:** [Streaming Substrate Author Guide](docs/streaming-substrate-author-guide.md) — dynamic streaming, the causal-log fold, rollup nodes, the context-growth policy.
 - **Operators:** [Streaming Substrate Operator Runbook](docs/operator-runbook-streaming-substrate.md) — hot/cold tiering, scheduling `swarm:compact`, retention, recovery and quarantine.
+- **Driver authors (v0.17.0):** `CausalLogStore` and `ColdArchiveDriver` are now public contracts for a custom persistence backend's read/query seam. See the [Streaming Substrate Driver Guide](docs/streaming-substrate-driver-guide.md) for exactly what's pluggable today (hot/cold read stitching, causal-log resolution) and what isn't yet (compaction, `#[DurableStreaming]` per-node streaming).
 
 ## Durable Execution
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -282,6 +282,8 @@ stability settings while Laravel AI remains pre-stable.
 
 See [Pulse](docs/pulse.md) for the full install flow.
 
+**Shared `swarm:install*` test harness extracted to `builtbyberry/laravel-swarm-installer-testkit` (#355) — no required action.** Dev-only change to this repo's own test suite (`require-dev`), with no public API or runtime behavior change. Only relevant if you were extending or importing `BuiltByBerry\LaravelSwarm\Tests\Installer\InstallerTestCase` directly from outside this repo (not a supported pattern — `tests/` is `autoload-dev`, never part of the public surface); that base class now lives in the new package under `BuiltByBerry\LaravelSwarmInstallerTestkit\InstallerTestCase`.
+
 ## Upgrading to v0.16.1
 
 **No required action.** v0.16.1 is a core hardening pass with no migration, no config change, and no breaking API — `swarm:compact` discovery is now a bounded SQL query instead of an unbounded in-memory pluck (#339), `DatabaseAuditOutbox::drain()` batches its retry/dead-letter writes with a per-row fallback (no observable change to `AuditDrainResult`'s shape or the audit trail), and two documentation lines (`AGENTS.md`'s `laravel/ai` version, `CONTRIBUTING.md`'s hook setup step) were corrected.

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "0.16.x-dev"
+            "dev-main": "0.17.x-dev"
         },
         "laravel": {
             "providers": [


### PR DESCRIPTION
## Summary

Release wrap for v0.17.0 (Phase-0 surface-settle). All four components are merged (`driver-surface-promotion` #353, `pulse-extraction` #354/#356, `installer-testkit-extraction` #357/#358; `contract-prune` #350 closed without merge — already done in v0.12.0). A full multi-expert review of the release branch's diff against `main` came back clean (approve, 0 findings) — no separate review-followups PR was needed.

This PR:
- Fills in `CHANGELOG.md`'s v0.17.0 entry: dates it, adds a `### Changed` entry for the installer-testkit extraction, corrects the theme summary to reflect that contract-prune shipped no code.
- Adds a v0.17.0 UPGRADING.md note for the installer-testkit extraction (no required action, dev-only).
- Bumps `composer.json`'s `extra.branch-alias.dev-main` from the stale `0.16.x-dev` to `0.17.x-dev`.
- Adds a README "Driver authors (v0.17.0)" pointer to the new Streaming Substrate Driver Guide, alongside the existing Authors/Operators bullets.

**Breaking change roll-up:** Pulse integration extraction (#351) is the only breaking change this release — `BuiltByBerry\LaravelSwarm\Pulse\*` is removed; consumers who use Pulse must `composer require builtbyberry/laravel-swarm-pulse`. Full migration steps in UPGRADING.md.

**Deploy safety:** No migrations, no runtime behavior change to any code path a consumer application executes. Safe to release as a normal minor.

Next: readiness-followups phase (`swarm-release-readiness`), then mark-ready-for-tag.

## Test plan
- [x] `composer lint` (pint) — clean
- [x] `composer analyse` (phpstan) — clean
- [x] `composer test` (full suite) — 1859/1859 passing