### PR TITLE
release: v0.17.3 — Docs cohesion + README refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ If a gap is deferred, it must be recorded as a named follow-up with an owner, no
 - `pestphp/pest` ^4.4 + `pest-plugin-laravel` ^4.1
 - `larastan/larastan` ^3.0
 - `laravel/pint` ^1.0
-- Optional `laravel/pulse` integration
+- Optional Pulse observability via the [`builtbyberry/laravel-swarm-pulse`](https://github.com/builtbyberry/laravel-swarm-pulse) companion package (not a core dependency)
 
 ## Dependency And Upgrade Path
 
@@ -75,7 +75,6 @@ Keep the mental model high-level rather than mirroring every file:
 - `src/Events` — lifecycle events for started, step started/completed, completed, failed, paused, resumed, and cancelled.
 - `src/Jobs` — queued and durable execution jobs.
 - `src/Persistence` — cache and database context, artifact, durable run, run history, and stream replay stores; `SwarmPersistenceCipher` seals designated string columns when database persistence uses encrypter-backed at-rest sealing.
-- `src/Pulse` — optional Pulse recorders, cards, and key helpers.
 - `src/Responses` — sync, queued, durable, streamable, artifact, response, and step DTOs.
 - `src/Streaming` — typed swarm stream events aligned with Laravel AI stream events.
 - `src/Routing` — hierarchical route plan objects and validation.
@@ -134,7 +133,7 @@ Schedule `swarm:prune` for database-backed persistence. Schedule `swarm:recover`
 
 ## Pulse
 
-Laravel Swarm has optional Laravel Pulse support. When Pulse is installed, the package can register `swarm.runs` and `swarm.steps` Livewire cards. Applications enable the `SwarmRuns` and `SwarmStepDurations` recorders in `config/pulse.php`.
+Pulse observability lives in the separate companion package [`builtbyberry/laravel-swarm-pulse`](https://github.com/builtbyberry/laravel-swarm-pulse) (namespace `BuiltByBerry\LaravelSwarmPulse\*`), extracted from core in v0.17.1. Install it to get the `SwarmRuns`, `SwarmStepDurations`, and `SwarmMemoryMetrics` recorders and the `swarm.runs` / `swarm.steps` / `swarm.audit-outbox` / `swarm.memory` dashboard cards, registered by its `swarm:install:pulse` sub-installer. Core is no longer aware of Pulse and no longer depends on `laravel/pulse`; it retains only the shared `swarm.pulse.memory.sample_rate` config knob that the companion's memory-metrics recorder reads. See [docs/pulse.md](docs/pulse.md).
 
 Pulse is aggregate observability. For live per-run operations feeds, listen to Laravel Swarm lifecycle events and broadcast application-owned events.
 
@@ -225,15 +224,15 @@ Releases are session-shaped: a thematic group of work ships as one tagged releas
 
 ## Current State
 
-The package supports sequential, parallel, and hierarchical topologies; synchronous, queued, streamed, and durable execution; cache and database persistence; run history and artifacts; lifecycle events; optional Pulse observability; config, migration, and stub publishing; and a full fake/assertion system.
+The package supports sequential, parallel, and hierarchical topologies; synchronous, queued, streamed, and durable execution; cache and database persistence; run history and artifacts; lifecycle events; optional Pulse observability via a companion package; config, migration, and stub publishing; and a full fake/assertion system.
 
 Streaming covers typed non-text final-agent events (`swarm_text_end`, `swarm_reasoning_delta`, `swarm_reasoning_end`, `swarm_tool_call`, `swarm_tool_result`) with persisted replay support and Laravel AI-style stream-event broadcast helpers.
 
-The test suite includes Feature and Unit coverage across sequential, parallel, hierarchical routing, streaming, queued execution, durable execution, persistence, Pulse integration, commands, fakes, and support objects.
+The test suite includes Feature and Unit coverage across sequential, parallel, hierarchical routing, streaming, queued execution, durable execution, persistence, commands, fakes, and support objects. (Pulse recorder/card tests moved to the companion package with the v0.17.1 extraction.)
 
 ## Known Gaps / Next Work
 
-- Commercial dashboard layer is a separate future repo/product. The package intentionally exposes history, events, artifacts, and Pulse hooks instead of owning a full dashboard API.
+- Commercial dashboard layer is a separate future repo/product. The package intentionally exposes history, events, and artifacts (with Pulse cards available via the [`builtbyberry/laravel-swarm-pulse`](https://github.com/builtbyberry/laravel-swarm-pulse) companion package) instead of owning a full dashboard API.
 
 ## Testing And Quality
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Documentation-only patch. Corrects cross-repo cohesion gaps found in a full docu
 
 ### Documentation
 
-_To be filled in during release wrap-up._
+- **README: table of contents + accuracy pass (#364).** Added a grouped table of contents for the ~35KB README, and grouped the Configuration key reference by concern. Folded in fact-fixes: corrected a non-compiling `#[DurableStreaming]` example (`Runnable` is a trait, applied via `implements Swarm { use Runnable; }`, not `implements Runnable`); documented the `swarm:install:memory` sub-installer and its `--with-memory` flag in the Installation section; and expanded the Configuration reference to cover the previously-undocumented `memory`, `context`, `context_growth`, `compaction`, `guardrails`, `retention`, `history`, and topology-plan config sections.
 
 ## v0.17.2 - 2026-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.17.3 - unreleased
+## v0.17.3 - 2026-07-06
 
 Documentation-only patch. Corrects cross-repo cohesion gaps found in a full documentation review: an editorial refresh plus fact-fixes to the README, and de-staling of `AGENTS.md`'s Pulse references after the v0.17.1 extraction. No code changes. The companion packages `laravel-swarm-pulse` and `laravel-swarm-installer-testkit` received their own doc patches in parallel.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Documentation-only patch. Corrects cross-repo cohesion gaps found in a full docu
 ### Documentation
 
 - **README: table of contents + accuracy pass (#364).** Added a grouped table of contents for the ~35KB README, and grouped the Configuration key reference by concern. Folded in fact-fixes: corrected a non-compiling `#[DurableStreaming]` example (`Runnable` is a trait, applied via `implements Swarm { use Runnable; }`, not `implements Runnable`); documented the `swarm:install:memory` sub-installer and its `--with-memory` flag in the Installation section; and expanded the Configuration reference to cover the previously-undocumented `memory`, `context`, `context_growth`, `compaction`, `guardrails`, `retention`, `history`, and topology-plan config sections.
+- **AGENTS.md: de-stale Pulse references after the v0.17.1 extraction (#365).** Removed the `src/Pulse` entry from the package-shape map (that directory moved to the companion package in v0.17.1), rewrote the `## Pulse` section to point at [`builtbyberry/laravel-swarm-pulse`](https://github.com/builtbyberry/laravel-swarm-pulse) (namespace `BuiltByBerry\LaravelSwarmPulse\*`) and note the shared `swarm.pulse.memory.sample_rate` config seam core retains, and corrected the Tech Stack, Current State, and test-coverage descriptions that still framed Pulse as living in core.
 
 ## v0.17.2 - 2026-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.17.3 - unreleased
+
+Documentation-only patch. Corrects cross-repo cohesion gaps found in a full documentation review: an editorial refresh plus fact-fixes to the README, and de-staling of `AGENTS.md`'s Pulse references after the v0.17.1 extraction. No code changes. The companion packages `laravel-swarm-pulse` and `laravel-swarm-installer-testkit` received their own doc patches in parallel.
+
+### Documentation
+
+_To be filled in during release wrap-up._
+
 ## v0.17.2 - 2026-07-06
 
 Documentation-only release. `v0.17.0` was tagged at the wrong commit — a stale local branch reference caused it to be tagged against the v0.16.1 tree (no Phase-0 changes at all) — and it was published to Packagist before the mistake was caught. Packagist's version-immutability guard correctly refused to let the tag's contents change after publication, so `v0.17.0` has been left as-is: it is identical to `v0.16.1` and **must not be used**. The actual Phase-0 work described below shipped in `v0.17.1`, which remains a valid, correct release — this release only corrects documentation that said "v0.17.0" for changes that actually first shipped in `v0.17.1`, and adds this explanation. No code changes.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Tagged releases are available on [Packagist](https://packagist.org/packages/buil
 
 - [`swarm:install:durable`](docs/durable-execution.md) — scheduler entries (`swarm:relay`, `swarm:recover`, `swarm:prune`), persistence/queue checks, copy-paste worker snippets.
 - [`swarm:install:audit`](docs/audit-evidence-contract.md) — bind a `SwarmAuditSink` (and optional `SwarmAuditSigner` / `ActorResolver` / `CapturePolicy`) inside `AppServiceProvider`.
-- [`swarm:install:memory`](docs/memory.md) — verify the memory tables (offering to run migrations if they are missing), then print the effective persistence driver and replay mode for the [Swarm Memory](docs/memory.md) subsystem.
+- [`swarm:install:memory`](docs/memory.md) — verify the memory tables (offering to run migrations if they are missing), then print the effective persistence driver and replay mode for the Swarm Memory subsystem.
 - [`swarm:install:examples`](docs/examples.md) — copy the runnable starter example pack into `app/Ai/`.
 
 Pulse observability (recorders + dashboard cards) lives in a separate companion package as of v0.17.1 — see [Pulse](docs/pulse.md) for the [`builtbyberry/laravel-swarm-pulse`](https://github.com/builtbyberry/laravel-swarm-pulse) install steps.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ Define a swarm once, return the Laravel AI agents that participate in it, and ru
 - **Upgrading:** [UPGRADING.md](UPGRADING.md)
 - **Contributing:** [CONTRIBUTING.md](CONTRIBUTING.md)
 
+## Contents
+
+- **Getting started** — [Quick Start](#quick-start) · [Requirements](#requirements) · [Installation](#installation) · [Your First Swarm](#your-first-swarm) · [Running A Swarm](#running-a-swarm)
+- **Execution modes** — [Choosing An Execution Mode](#choosing-an-execution-mode) · [Queueing](#queueing-a-swarm) · [Streaming](#streaming-a-swarm) · [Durable Execution](#durable-execution)
+- **Capabilities** — [Memory](#memory-v090) · [Topologies](#topologies)
+- **Production & reference** — [Testing](#testing) · [Configuration](#configuration) · [Production Checklist](#production-checklist) · [Documentation](#documentation) · [Local Development](#local-development)
+
 ## Quick Start
 
 ```bash
@@ -79,6 +86,7 @@ Tagged releases are available on [Packagist](https://packagist.org/packages/buil
 
 - [`swarm:install:durable`](docs/durable-execution.md) — scheduler entries (`swarm:relay`, `swarm:recover`, `swarm:prune`), persistence/queue checks, copy-paste worker snippets.
 - [`swarm:install:audit`](docs/audit-evidence-contract.md) — bind a `SwarmAuditSink` (and optional `SwarmAuditSigner` / `ActorResolver` / `CapturePolicy`) inside `AppServiceProvider`.
+- [`swarm:install:memory`](docs/memory.md) — verify the memory tables (offering to run migrations if they are missing), then print the effective persistence driver and replay mode for the [Swarm Memory](docs/memory.md) subsystem.
 - [`swarm:install:examples`](docs/examples.md) — copy the runnable starter example pack into `app/Ai/`.
 
 Pulse observability (recorders + dashboard cards) lives in a separate companion package as of v0.17.1 — see [Pulse](docs/pulse.md) for the [`builtbyberry/laravel-swarm-pulse`](https://github.com/builtbyberry/laravel-swarm-pulse) install steps.
@@ -89,7 +97,7 @@ For CI and scripted setups, every prompt has a flag override:
 php artisan swarm:install \
     --no-interaction \
     --persistence=database \
-    --with-durable --with-audit --with-examples
+    --with-durable --with-audit --with-memory --with-examples
 ```
 
 Pass `--without-<name>` to skip a sub-installer in non-interactive mode, `--persistence=cache` for cache-only deployments, `--skip-migrate` to defer migrations, or `--force` to overwrite an existing `config/swarm.php`.
@@ -369,9 +377,16 @@ A durable run can stream **each node's events into the causal log** as it execut
 
 ```php
 use BuiltByBerry\LaravelSwarm\Attributes\DurableStreaming;
+use BuiltByBerry\LaravelSwarm\Concerns\Runnable;
+use BuiltByBerry\LaravelSwarm\Contracts\Swarm;
 
 #[DurableStreaming]
-final class ClaimsReview implements Runnable { /* … */ }
+final class ClaimsReview implements Swarm
+{
+    use Runnable;
+
+    // agents() …
+}
 ```
 
 It streams on **every durable topology** — sequential, hierarchical, static_hierarchical, and parallel (including fan-out branches) — with each node's attempt voided-and-retried cleanly on crash-resume (the same append-only causal-log fold the live substrate uses). The hierarchical coordinator streams structural events; token-streaming the coordinator is a follow-up. Declaring the attribute on a topology not yet wired for streaming fails loud at dispatch. An operator kill-switch (`SWARM_DURABLE_STREAMING_ENABLED=false`) pauses emission fleet-wide without a redeploy, safely mid-run. See [Durable Execution — per-node streaming](docs/durable-execution.md#durable-per-node-streaming).
@@ -554,19 +569,14 @@ See [Testing](docs/testing.md) and [Testing Swarms](examples/testing-swarms/READ
 
 Laravel Swarm stores defaults in `config/swarm.php`.
 
-Common settings include:
+Settings are grouped by concern:
 
-- `swarm.topology`
-- `swarm.timeout`
-- `swarm.max_agent_steps`
-- `swarm.persistence.driver`
-- `swarm.capture.*`
-- `swarm.queue.*`
-- `swarm.durable.*`
-- `swarm.streaming.replay.*`
-- `swarm.observability.*`
-- `swarm.audit.*`
-- `swarm.limits.*`
+- **Core** — `swarm.topology`, `swarm.timeout`, `swarm.max_agent_steps`
+- **Persistence & history** — `swarm.persistence.*`, `swarm.capture.*`, `swarm.retention.*`, `swarm.history.*`
+- **Execution modes** — `swarm.queue.*`, `swarm.durable.*`, `swarm.streaming.*`
+- **Memory & context** — `swarm.memory.*`, `swarm.context.*`, `swarm.context_growth.*`, `swarm.compaction.*`
+- **Topology plans** — `swarm.hierarchical.*`, `swarm.static_hierarchical.*`
+- **Governance & observability** — `swarm.guardrails.*`, `swarm.audit.*`, `swarm.observability.*`, `swarm.artifacts.*`, `swarm.limits.*`
 
 Capture defaults are conservative. Prompts, outputs, automatic step artifacts, and rich active-context snapshots are not persisted unless you opt in. When the global persistence driver or a per-store override uses `database`, `swarm.persistence.encrypt_at_rest` defaults to true and seals designated sensitive string columns with Laravel's encrypter.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -269,6 +269,10 @@ This package’s `composer.json` uses `"minimum-stability": "dev"` with
 still prefers tagged releases. Your application may need compatible Composer
 stability settings while Laravel AI remains pre-stable.
 
+## Upgrading to v0.17.3
+
+**No required action — documentation only.** This release restructures the README for scannability (adds a table of contents and groups the configuration-key reference by concern), documents the `swarm:install:memory` sub-installer and its `--with-memory` flag, fixes a non-compiling `#[DurableStreaming]` code example (`Runnable` is a trait, applied via `implements Swarm { use Runnable; }`), and de-stales `AGENTS.md`'s Pulse references after the v0.17.1 companion-package extraction. No code, config, or schema changes. See the [CHANGELOG](CHANGELOG.md#v0173---2026-07-06) for details.
+
 ## Upgrading to v0.17.2
 
 **No required action — documentation only.** `v0.17.0` was tagged at the wrong commit and is identical to `v0.16.1`; it must not be used. The changes below shipped in `v0.17.1`, which remains a correct, valid release — this version only fixes docs that said "v0.17.0" for them and adds this note. See the [CHANGELOG](CHANGELOG.md#v0172---2026-07-06) for what happened.


### PR DESCRIPTION
Release session for v0.17.3 — documentation-only patch.

## Theme

Corrects cross-repo cohesion gaps found in a full documentation review: an editorial refresh + fact-fixes to the README, and de-staling of AGENTS.md's Pulse references after the v0.17.1 extraction. Companion packages received their own doc patches in parallel.

## Session contents

Milestone: https://github.com/builtbyberry/laravel-swarm/milestone/23

Topic PRs (merged into this release branch):
- [x] #367 — docs: README table of contents + installer/config coverage + fact-fixes (closes #364)
- [x] #368 — docs: de-stale AGENTS.md Pulse references (closes #365)
- [x] #370 — chore(release): v0.17.3 wrap (CHANGELOG date, UPGRADING block, review F1 fix)

Companion patches (shipped separately, not in this milestone):
- ✅ builtbyberry/laravel-swarm-pulse#4 — correct extraction version to v0.17.1 + changelog restructure (merged)
- ✅ builtbyberry/laravel-swarm-installer-testkit#2 — backfill v0.1.1 changelog (merged)

## Wrap status

- [x] All topic PRs merged
- [x] Phase 1 — multi-expert review run (approve-with-followups; F1 low, folded into the wrap PR — no separate followups branch)
- [x] Phase 2 — CHANGELOG + UPGRADING filled (`chore/0.17.3-release-wrap` / #370, merged)
- [x] Phase 3 — release-readiness review run (**ship**, 0 findings — no followups needed)
- [x] Ready for merge + tag

## Closes

Closes #364
Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)