### PR TITLE
chore(release): v0.17.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.17.3 - unreleased
+## v0.17.3 - 2026-07-06
 
 Documentation-only patch. Corrects cross-repo cohesion gaps found in a full documentation review: an editorial refresh plus fact-fixes to the README, and de-staling of `AGENTS.md`'s Pulse references after the v0.17.1 extraction. No code changes. The companion packages `laravel-swarm-pulse` and `laravel-swarm-installer-testkit` received their own doc patches in parallel.
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Tagged releases are available on [Packagist](https://packagist.org/packages/buil
 
 - [`swarm:install:durable`](docs/durable-execution.md) — scheduler entries (`swarm:relay`, `swarm:recover`, `swarm:prune`), persistence/queue checks, copy-paste worker snippets.
 - [`swarm:install:audit`](docs/audit-evidence-contract.md) — bind a `SwarmAuditSink` (and optional `SwarmAuditSigner` / `ActorResolver` / `CapturePolicy`) inside `AppServiceProvider`.
-- [`swarm:install:memory`](docs/memory.md) — verify the memory tables (offering to run migrations if they are missing), then print the effective persistence driver and replay mode for the [Swarm Memory](docs/memory.md) subsystem.
+- [`swarm:install:memory`](docs/memory.md) — verify the memory tables (offering to run migrations if they are missing), then print the effective persistence driver and replay mode for the Swarm Memory subsystem.
 - [`swarm:install:examples`](docs/examples.md) — copy the runnable starter example pack into `app/Ai/`.
 
 Pulse observability (recorders + dashboard cards) lives in a separate companion package as of v0.17.1 — see [Pulse](docs/pulse.md) for the [`builtbyberry/laravel-swarm-pulse`](https://github.com/builtbyberry/laravel-swarm-pulse) install steps.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -269,6 +269,10 @@ This package’s `composer.json` uses `"minimum-stability": "dev"` with
 still prefers tagged releases. Your application may need compatible Composer
 stability settings while Laravel AI remains pre-stable.
 
+## Upgrading to v0.17.3
+
+**No required action — documentation only.** This release restructures the README for scannability (adds a table of contents and groups the configuration-key reference by concern), documents the `swarm:install:memory` sub-installer and its `--with-memory` flag, fixes a non-compiling `#[DurableStreaming]` code example (`Runnable` is a trait, applied via `implements Swarm { use Runnable; }`), and de-stales `AGENTS.md`'s Pulse references after the v0.17.1 companion-package extraction. No code, config, or schema changes. See the [CHANGELOG](CHANGELOG.md#v0173---2026-07-06) for details.
+
 ## Upgrading to v0.17.2
 
 **No required action — documentation only.** `v0.17.0` was tagged at the wrong commit and is identical to `v0.16.1`; it must not be used. The changes below shipped in `v0.17.1`, which remains a correct, valid release — this version only fixes docs that said "v0.17.0" for them and adds this note. See the [CHANGELOG](CHANGELOG.md#v0172---2026-07-06) for what happened.


### PR DESCRIPTION
Phase 2 (release-wrap) for v0.17.3.

## Changes

- **CHANGELOG** — dated the `v0.17.3` entry (`2026-07-06`); Documentation section already carries the #364 + #365 bullets from the topic PRs.
- **UPGRADING.md** — added a `## Upgrading to v0.17.3` block: **No required action — documentation only.**
- **README** — folded in the one review finding: dropped a redundant `docs/memory.md` link from the `swarm:install:memory` bullet (review **F1**).

## Roll-up

- **Breaking changes:** none — doc-only patch.
- **Branch-alias:** `0.17.x-dev` already matches the release minor; no bump.
- **README marquee:** N/A — this release has no user-facing headline feature (docs-cohesion release).

## Phase status

- [x] Phase 1 — multi-expert review (approve-with-followups; F1 low, fixed here)
- [x] Phase 2 — CHANGELOG + UPGRADING wrap (this PR)
- [ ] Phase 3 — readiness review

🤖 Generated with [Claude Code](https://claude.com/claude-code)