### PR TITLE
chore: v0.17.4 review followups (F1)

### DIFF
--- a/tests/Unit/DurableCollaboratorsTest.php
+++ b/tests/Unit/DurableCollaboratorsTest.php
@@ -451,7 +451,9 @@ test('RoutesDurableWaits receives the RunContext so declared waits vary by conte
     $alphaWaits = app(DurableRunInspector::class)->inspect($contextAlpha->runId)->waits;
     $betaWaits = app(DurableRunInspector::class)->inspect($contextBeta->runId)->waits;
 
-    expect($alphaWaits[0]['name'])->toBe('wait_alpha')
+    expect($alphaWaits)->toHaveCount(1)
+        ->and($betaWaits)->toHaveCount(1)
+        ->and($alphaWaits[0]['name'])->toBe('wait_alpha')
         ->and($betaWaits[0]['name'])->toBe('wait_beta');
 });
 


### PR DESCRIPTION
Multi-expert change review of `release/v0.17.4` vs `main` (test-only diff) returned a single low finding; fixed here.

**F1 · low · QA** — the `RoutesDurableWaits` context-variance test asserted `waits[0]['name']` without the `->toHaveCount(1)` parity its sibling "enters declared wait once" test has. A regressed entry would have failed on an undefined-key warning rather than a clean count assertion.
- Fix: added `->toHaveCount(1)` to both the alpha and beta wait arrays.

Verified: `tests/Unit/DurableCollaboratorsTest.php` 14 passed / 42 assertions; pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)