### PR TITLE
chore(release): v0.17.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## v0.17.4 - unreleased
+## v0.17.4 - 2026-07-06
 
-Durable contract-seam hardening. Closes test-coverage gaps on three public durable-routing capability seams — `ConfiguresDurableRetries`, `RoutesDurableWaits`, and `RoutesDurableBranches` — before the 1.0 surface freeze. Each is the programmatic (contract) alternative to a PHP attribute, and the interface branch was under-tested. No behavior or public-surface changes; test-only hardening.
+Durable contract-seam hardening. Closes test-coverage gaps on three public durable-routing capability seams — `ConfiguresDurableRetries`, `RoutesDurableWaits`, and `RoutesDurableBranches` — before the 1.0 surface freeze. Each is the programmatic (contract) alternative to a PHP attribute, and the interface branch (checked first) was previously the untested path. No behavior, config, schema, or public-surface changes.
 
-### Added
+### Tests
 
-_To be filled in during release wrap-up._
+- **Durable-routing contract-seam coverage (#371, #372, #373).** Added opt-in behavior tests for the three durable-routing capability seams. `ConfiguresDurableRetries` — locks the full `DurableRetryHandler::resolveRetryPolicy` precedence chain (interface-agent > agent-attribute > interface-swarm > swarm-attribute), including the null-return fall-through. `RoutesDurableWaits` — interface-declared waits win over the `#[DurableWait]` attribute and receive the `RunContext`, so declared waits vary per run. `RoutesDurableBranches` — `durableBranchQueue()` routing is stamped onto the branch payload the dispatch reads, with an empty-array return falling back to the run's routing.
 
 ## v0.17.3 - 2026-07-06
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -269,6 +269,10 @@ This package’s `composer.json` uses `"minimum-stability": "dev"` with
 still prefers tagged releases. Your application may need compatible Composer
 stability settings while Laravel AI remains pre-stable.
 
+## Upgrading to v0.17.4
+
+**No required action — test-only.** This release adds behavior coverage for three public durable-routing capability seams — `ConfiguresDurableRetries`, `RoutesDurableWaits`, and `RoutesDurableBranches` — ahead of the 1.0 surface freeze. No code, config, or schema changes; the contracts themselves are unchanged. See the [CHANGELOG](CHANGELOG.md#v0174---2026-07-06) for details.
+
 ## Upgrading to v0.17.3
 
 **No required action — documentation only.** This release restructures the README for scannability (adds a table of contents and groups the configuration-key reference by concern), documents the `swarm:install:memory` sub-installer and its `--with-memory` flag, fixes a non-compiling `#[DurableStreaming]` code example (`Runnable` is a trait, applied via `implements Swarm { use Runnable; }`), and de-stales `AGENTS.md`'s Pulse references after the v0.17.1 companion-package extraction. No code, config, or schema changes. See the [CHANGELOG](CHANGELOG.md#v0173---2026-07-06) for details.


### PR DESCRIPTION
Phase 2 (release-wrap) for v0.17.4.

- **CHANGELOG** — filled the `v0.17.4 - 2026-07-06` entry with a `### Tests` section covering #371/#372/#373.
- **UPGRADING** — added the `v0.17.4` block: **No required action — test-only.**
- **branch-alias** — `extra.branch-alias.dev-main` is already `0.17.x-dev`; no bump needed.
- **README** — skipped: pure internal/test release, no user-facing headline feature.

## Breaking / deploy-safety roll-up
None. Test-only release — no behavior, config, schema, or public-surface changes.

Next: Phase 3 readiness review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)