### PR TITLE
feat(generators): make:swarm:blueprint + unified blueprint corpus (#378)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Ecosystem epic #254 Phase 1 — blueprint templates. Adds a name-parameterized `
 
 ### Changed
 
-- **Shared blueprint-corpus machinery extracted from `swarm:install:examples` (#378).** The tree-walking, namespace-placeholder rewriting, and host-root-namespace resolution that `swarm:install:examples` used are now shared with `make:swarm:blueprint` via the `InteractsWithBlueprintCorpus` and `ResolvesHostRootNamespace` concerns, so the two commands stay in lockstep. `swarm:install:examples`' behavior and output are unchanged — it continues to land example trees verbatim and skips the package-side `README.md` and (new) `blueprint.json` metadata.
+- **Shared blueprint-corpus machinery extracted from `swarm:install:examples` (#378).** The tree-walking, namespace-placeholder rewriting, and host-root-namespace resolution that `swarm:install:examples` used are now shared with `make:swarm:blueprint` via the `InteractsWithBlueprintCorpus` and `ResolvesHostRootNamespace` concerns, so the two commands stay in lockstep. `swarm:install:examples`' file output is unchanged — it continues to land example trees verbatim and skips the package-side `README.md` and (new) `blueprint.json` metadata. Its interactive picker now prefers the tree's `blueprint.json` summary as the single source of truth for the one-line description (falling back to the README's first line for any tree without a manifest).
 
 ## v0.17.4 - 2026-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ Ecosystem epic #254 Phase 1 — blueprint templates. Adds a name-parameterized `
 
 ### Added
 
-_To be filled in during release wrap-up._
+- **`make:swarm:blueprint` — scaffold a complete, runnable swarm from a curated blueprint (#378).** Where `make:swarm:swarm` scaffolds an empty swarm shell for a topology, `make:swarm:blueprint <Name> --template=<slug>` scaffolds a whole working use-case — the swarm class, its agents, and a runnable console command — renamed and namespaced as your own. It draws from the same curated corpus under `stubs/examples/` that `swarm:install:examples` lands, but where the installer copies a tree **verbatim** (fixed-name reference to read), this copies it **renamed** (a starting point to edit). Omit `--template` in an interactive terminal to pick from a list; the swarm name can be prompted too. Ships three blueprints to start — `pipeline` (sequential), `research` (parallel fan-out), and `approval` (durable, human-in-the-loop) — with more to follow. The generator fails loud rather than overwrite existing app files (pass `--force` to overwrite) or generate uncompilable code (reserved names are rejected). Each blueprint declares its canonical class/command names in a per-tree `blueprint.json` manifest; agent class names are preserved on rename by design.
 
 ### Changed
 
-_To be filled in during release wrap-up._
+- **Shared blueprint-corpus machinery extracted from `swarm:install:examples` (#378).** The tree-walking, namespace-placeholder rewriting, and host-root-namespace resolution that `swarm:install:examples` used are now shared with `make:swarm:blueprint` via the `InteractsWithBlueprintCorpus` and `ResolvesHostRootNamespace` concerns, so the two commands stay in lockstep. `swarm:install:examples`' behavior and output are unchanged — it continues to land example trees verbatim and skips the package-side `README.md` and (new) `blueprint.json` metadata.
 
 ## v0.17.4 - 2026-07-06
 

--- a/src/Commands/Concerns/InteractsWithBlueprintCorpus.php
+++ b/src/Commands/Concerns/InteractsWithBlueprintCorpus.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Commands\Concerns;
+
+use FilesystemIterator;
+use Illuminate\Filesystem\Filesystem;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * Shared machinery for the two commands that consume the bundled corpus of
+ * curated swarm trees under `stubs/examples/`:
+ *
+ *  - `swarm:install:examples` lands a tree **verbatim** (fixed-name reference
+ *    material to read), rewriting only the `{{ rootNamespace }}` placeholder.
+ *  - `make:swarm:blueprint` lands the same tree **renamed** (a starting point
+ *    to edit), additionally rewriting the tree's canonical class/command names
+ *    to the developer's chosen name via the per-tree `blueprint.json` manifest.
+ *
+ * Keeping the low-level file-walking, namespace resolution, and placeholder
+ * rewriting in one place guarantees the two commands stay in lockstep — in
+ * particular that a blueprint scaffolds the exact same bytes `install:examples`
+ * lands, modulo the rename map.
+ *
+ * Files that are package-side reference material and must never reach the host
+ * app tree — the per-tree `README.md` and `blueprint.json` — are enumerated in
+ * {@see self::CORPUS_META_FILES} and skipped by both commands.
+ *
+ * Every method here is container-independent (no `$this->laravel`), so the
+ * concern is unit-testable in isolation. Resolving the host root namespace —
+ * the one step that needs the application instance — lives in the companion
+ * {@see ResolvesHostRootNamespace} trait.
+ */
+trait InteractsWithBlueprintCorpus
+{
+    /**
+     * Tree-root files that document/describe a corpus entry for the package's
+     * own tooling and must not be copied into the host app.
+     *
+     * @var list<string>
+     */
+    private const CORPUS_META_FILES = ['README.md', 'blueprint.json'];
+
+    /**
+     * Absolute path to the package's bundled corpus of curated swarm trees.
+     */
+    protected function corpusRoot(): string
+    {
+        return dirname(__DIR__, 3).DIRECTORY_SEPARATOR.'stubs'.DIRECTORY_SEPARATOR.'examples';
+    }
+
+    /**
+     * Read a tree's `blueprint.json` manifest, or `null` when the tree does not
+     * declare one (it is then installable verbatim but not scaffoldable as a
+     * named blueprint).
+     *
+     * @return array{slug: string, title: string, topology: string, summary: string, tokens: array{namespaceSegment: string, swarmClass: string, commandClass: string, commandSignature: string}}|null
+     */
+    protected function readBlueprintManifest(Filesystem $files, string $treeDir): ?array
+    {
+        $manifestPath = $treeDir.DIRECTORY_SEPARATOR.'blueprint.json';
+
+        if (! $files->exists($manifestPath)) {
+            return null;
+        }
+
+        try {
+            /** @var array<string, mixed> $decoded */
+            $decoded = json_decode((string) $files->get($manifestPath), true, flags: JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return null;
+        }
+
+        $tokens = $decoded['tokens'] ?? null;
+
+        if (! is_array($tokens)) {
+            return null;
+        }
+
+        foreach (['namespaceSegment', 'swarmClass', 'commandClass', 'commandSignature'] as $required) {
+            if (! isset($tokens[$required]) || ! is_string($tokens[$required]) || $tokens[$required] === '') {
+                return null;
+            }
+        }
+
+        foreach (['slug', 'title', 'topology'] as $required) {
+            if (! isset($decoded[$required]) || ! is_string($decoded[$required]) || $decoded[$required] === '') {
+                return null;
+            }
+        }
+
+        return [
+            'slug' => $decoded['slug'],
+            'title' => $decoded['title'],
+            'topology' => $decoded['topology'],
+            'summary' => is_string($decoded['summary'] ?? null) ? $decoded['summary'] : $decoded['title'],
+            'tokens' => [
+                'namespaceSegment' => $tokens['namespaceSegment'],
+                'swarmClass' => $tokens['swarmClass'],
+                'commandClass' => $tokens['commandClass'],
+                'commandSignature' => $tokens['commandSignature'],
+            ],
+        ];
+    }
+
+    /**
+     * Enumerate every file under a tree directory, returning the absolute source
+     * path and the destination path *relative to the host app's base directory*
+     * (i.e. preserving `app/Ai/Swarms/...` shape). The package-side meta files
+     * ({@see self::CORPUS_META_FILES}) are excluded.
+     *
+     * @return list<array{absolute: string, relative: string}>
+     */
+    protected function collectCopyPairs(string $treeSourceRoot): array
+    {
+        $pairs = [];
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator(
+                $treeSourceRoot,
+                FilesystemIterator::SKIP_DOTS,
+            ),
+            RecursiveIteratorIterator::LEAVES_ONLY,
+        );
+
+        $prefixLength = strlen($treeSourceRoot) + 1;
+
+        foreach ($iterator as $info) {
+            /** @var \SplFileInfo $info */
+            if (! $info->isFile()) {
+                continue;
+            }
+
+            $absolute = $info->getPathname();
+            $relative = str_replace(DIRECTORY_SEPARATOR, '/', substr($absolute, $prefixLength));
+
+            if (in_array($relative, self::CORPUS_META_FILES, true)) {
+                continue;
+            }
+
+            $pairs[] = [
+                'absolute' => $absolute,
+                'relative' => $relative,
+            ];
+        }
+
+        return $pairs;
+    }
+
+    /**
+     * Rewrite the package's two supported namespace placeholders to the host
+     * app's PSR-4 root.
+     *
+     * Both `{{ rootNamespace }}` (canonical) and `{{ namespace }}` (legacy alias
+     * for compatibility with the AC wording in #90) are accepted, with arbitrary
+     * whitespace inside the braces, so hand-edited or future stubs stay
+     * compatible.
+     */
+    protected function rewriteNamespacePlaceholders(string $contents, string $rootNamespace): string
+    {
+        $contents = (string) preg_replace(
+            '/\{\{\s*rootNamespace\s*\}\}/',
+            $rootNamespace,
+            $contents,
+        );
+
+        $contents = (string) preg_replace(
+            '/\{\{\s*namespace\s*\}\}/',
+            $rootNamespace,
+            $contents,
+        );
+
+        return $contents;
+    }
+}

--- a/src/Commands/Concerns/ResolvesHostRootNamespace.php
+++ b/src/Commands/Concerns/ResolvesHostRootNamespace.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Commands\Concerns;
+
+use Illuminate\Filesystem\Filesystem;
+
+/**
+ * Resolve the host application's PSR-4 root namespace from its `composer.json`.
+ *
+ * Kept separate from {@see InteractsWithBlueprintCorpus} because this one step
+ * needs the command's `$this->laravel` application instance to locate the host
+ * app root — everything else in the corpus concern is container-independent and
+ * unit-testable on its own. Intended for use on an `Illuminate\Console\Command`.
+ */
+trait ResolvesHostRootNamespace
+{
+    /**
+     * Read the host app's PSR-4 root namespace from `composer.json`. Falls back
+     * to `App` if the file is missing, malformed, or uses a layout that cannot
+     * be interpreted unambiguously (the same default Laravel itself uses).
+     */
+    protected function resolveRootNamespace(Filesystem $files): string
+    {
+        $composerPath = $this->laravel->basePath('composer.json');
+
+        if (! $files->exists($composerPath)) {
+            return 'App';
+        }
+
+        try {
+            /** @var array<string, mixed> $composer */
+            $composer = json_decode((string) $files->get($composerPath), true, flags: JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return 'App';
+        }
+
+        $psr4 = $composer['autoload']['psr-4'] ?? null;
+
+        if (! is_array($psr4) || $psr4 === []) {
+            return 'App';
+        }
+
+        // Prefer a mapping pointed at app/ (the Laravel convention). If none
+        // match, fall back to the first declared mapping, then to App.
+        foreach ($psr4 as $namespace => $path) {
+            if (is_string($path) && rtrim($path, '/\\') === 'app') {
+                return rtrim((string) $namespace, '\\');
+            }
+        }
+
+        $first = array_key_first($psr4);
+
+        return is_string($first) ? rtrim($first, '\\') : 'App';
+    }
+}

--- a/src/Commands/Install/InstallExamplesCommand.php
+++ b/src/Commands/Install/InstallExamplesCommand.php
@@ -119,9 +119,16 @@ final class InstallExamplesCommand extends Command
             }
 
             $name = $entry->getFilename();
+
+            // Prefer the tree's blueprint.json summary as the single tooling
+            // source of truth; fall back to the README's first line for any
+            // tree that doesn't (yet) carry a manifest.
+            $manifest = $this->readBlueprintManifest($files, $entry->getPathname());
+            $description = $manifest['summary'] ?? $this->readDescription($files, $entry->getPathname());
+
             $entries[$name] = [
                 'name' => $name,
-                'description' => $this->readDescription($files, $entry->getPathname()),
+                'description' => $description,
                 'runner' => $this->detectRunnerCommandName($files, $entry->getPathname()),
             ];
         }

--- a/src/Commands/Install/InstallExamplesCommand.php
+++ b/src/Commands/Install/InstallExamplesCommand.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Commands\Install;
 
+use BuiltByBerry\LaravelSwarm\Commands\Concerns\InteractsWithBlueprintCorpus;
+use BuiltByBerry\LaravelSwarm\Commands\Concerns\ResolvesHostRootNamespace;
 use FilesystemIterator;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 use function Laravel\Prompts\multiselect;
@@ -20,9 +20,9 @@ use function Laravel\Prompts\multiselect;
  * `app/Ai/Swarms/<Name>/`, `app/Ai/Agents/<Name>/`, and
  * `app/Console/Commands/SwarmExample<Name>Command.php` trees, with
  * `{{ rootNamespace }}` placeholders the installer rewrites to the host app's
- * PSR-4 root (usually `App\`). The per-example `README.md` files are
- * deliberately not copied — they exist as reference material in the package's
- * own tree, not as noise inside the user's `app/` directory.
+ * PSR-4 root (usually `App\`). The per-tree `README.md` and `blueprint.json`
+ * files are deliberately not copied — they are package-side reference and
+ * tooling metadata, not something that belongs in the user's `app/` directory.
  *
  * Auto-discovery in Laravel 11+ scans `app/Console/Commands/` on every boot,
  * so the copied runner commands register automatically — the installer does
@@ -31,6 +31,9 @@ use function Laravel\Prompts\multiselect;
 #[AsCommand(name: 'swarm:install:examples')]
 final class InstallExamplesCommand extends Command
 {
+    use InteractsWithBlueprintCorpus;
+    use ResolvesHostRootNamespace;
+
     /** @var string */
     protected $signature = 'swarm:install:examples
         {--example=* : Install one specific example by directory name (repeatable)}
@@ -42,7 +45,7 @@ final class InstallExamplesCommand extends Command
 
     public function handle(Filesystem $files): int
     {
-        $sourceRoot = $this->stubsRoot();
+        $sourceRoot = $this->corpusRoot();
 
         if (! $files->isDirectory($sourceRoot)) {
             $this->components->error("Cannot locate starter examples at [{$sourceRoot}].");
@@ -97,14 +100,6 @@ final class InstallExamplesCommand extends Command
         $this->printPostInstallHints($installed, $skipped, $available);
 
         return self::SUCCESS;
-    }
-
-    /**
-     * Absolute path to the package's bundled starter examples.
-     */
-    private function stubsRoot(): string
-    {
-        return dirname(__DIR__, 3).DIRECTORY_SEPARATOR.'stubs'.DIRECTORY_SEPARATOR.'examples';
     }
 
     /**
@@ -266,46 +261,6 @@ final class InstallExamplesCommand extends Command
     }
 
     /**
-     * Read the host app's PSR-4 root namespace from `composer.json`. Falls
-     * back to `App` if the file is missing, malformed, or uses a layout the
-     * installer cannot interpret unambiguously (the same default Laravel
-     * itself uses).
-     */
-    private function resolveRootNamespace(Filesystem $files): string
-    {
-        $composerPath = $this->laravel->basePath('composer.json');
-
-        if (! $files->exists($composerPath)) {
-            return 'App';
-        }
-
-        try {
-            /** @var array<string, mixed> $composer */
-            $composer = json_decode((string) $files->get($composerPath), true, flags: JSON_THROW_ON_ERROR);
-        } catch (\JsonException) {
-            return 'App';
-        }
-
-        $psr4 = $composer['autoload']['psr-4'] ?? null;
-
-        if (! is_array($psr4) || $psr4 === []) {
-            return 'App';
-        }
-
-        // Prefer a mapping pointed at app/ (the Laravel convention). If none
-        // match, fall back to the first declared mapping, then to App.
-        foreach ($psr4 as $namespace => $path) {
-            if (is_string($path) && rtrim($path, '/\\') === 'app') {
-                return rtrim((string) $namespace, '\\');
-            }
-        }
-
-        $first = array_key_first($psr4);
-
-        return is_string($first) ? rtrim($first, '\\') : 'App';
-    }
-
-    /**
      * Copy one example tree into the host app, rewriting namespace
      * placeholders along the way. Returns:
      *
@@ -327,14 +282,9 @@ final class InstallExamplesCommand extends Command
         string $rootNamespace,
         bool $force,
     ): string {
+        // collectCopyPairs already excludes package-side meta files (README.md,
+        // blueprint.json) — the host app receives only the runnable tree.
         $pairs = $this->collectCopyPairs($exampleSourceRoot);
-
-        // The README is reference material that belongs in the package, not
-        // in the user's app/ tree. Skip it explicitly.
-        $pairs = array_values(array_filter(
-            $pairs,
-            static fn (array $pair): bool => $pair['relative'] !== 'README.md',
-        ));
 
         $existing = [];
         foreach ($pairs as $pair) {
@@ -368,72 +318,6 @@ final class InstallExamplesCommand extends Command
         $this->components->info("Installed example [{$exampleName}].");
 
         return 'installed';
-    }
-
-    /**
-     * Enumerate every file under the example source directory, returning the
-     * absolute source path and the destination path *relative to the host
-     * app's base directory* (i.e. preserving `app/Ai/Swarms/...` shape).
-     *
-     * @return list<array{absolute: string, relative: string}>
-     */
-    private function collectCopyPairs(string $exampleSourceRoot): array
-    {
-        $pairs = [];
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator(
-                $exampleSourceRoot,
-                FilesystemIterator::SKIP_DOTS,
-            ),
-            RecursiveIteratorIterator::LEAVES_ONLY,
-        );
-
-        $prefixLength = strlen($exampleSourceRoot) + 1;
-
-        foreach ($iterator as $info) {
-            /** @var \SplFileInfo $info */
-            if (! $info->isFile()) {
-                continue;
-            }
-
-            $absolute = $info->getPathname();
-            $relative = str_replace(DIRECTORY_SEPARATOR, '/', substr($absolute, $prefixLength));
-
-            $pairs[] = [
-                'absolute' => $absolute,
-                'relative' => $relative,
-            ];
-        }
-
-        return $pairs;
-    }
-
-    /**
-     * Rewrite the package's two supported namespace placeholders to the
-     * host app's PSR-4 root.
-     *
-     * Both `{{ rootNamespace }}` (canonical) and `{{ namespace }}` (legacy
-     * alias for compatibility with the AC wording in #90) are accepted, with
-     * arbitrary whitespace inside the braces, so hand-edited or future stubs
-     * stay compatible.
-     */
-    private function rewriteNamespacePlaceholders(string $contents, string $rootNamespace): string
-    {
-        $replacement = $rootNamespace;
-
-        $contents = (string) preg_replace(
-            '/\{\{\s*rootNamespace\s*\}\}/',
-            $replacement,
-            $contents,
-        );
-
-        $contents = (string) preg_replace(
-            '/\{\{\s*namespace\s*\}\}/',
-            $replacement,
-            $contents,
-        );
-
-        return $contents;
     }
 
     /**

--- a/src/Commands/MakeSwarmBlueprintCommand.php
+++ b/src/Commands/MakeSwarmBlueprintCommand.php
@@ -244,7 +244,8 @@ class MakeSwarmBlueprintCommand extends Command
 
         $options = [];
         foreach ($blueprints as $slug => $entry) {
-            $options[$slug] = $entry['manifest']['title'].' — '.$entry['manifest']['summary'];
+            $manifest = $entry['manifest'];
+            $options[$slug] = $manifest['title'].' ('.$manifest['topology'].') — '.$manifest['summary'];
         }
 
         /** @var string $chosen */

--- a/src/Commands/MakeSwarmBlueprintCommand.php
+++ b/src/Commands/MakeSwarmBlueprintCommand.php
@@ -1,0 +1,364 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Commands;
+
+use BuiltByBerry\LaravelSwarm\Commands\Concerns\InteractsWithBlueprintCorpus;
+use BuiltByBerry\LaravelSwarm\Commands\Concerns\ResolvesHostRootNamespace;
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\text;
+
+/**
+ * Scaffold a complete, runnable swarm from a curated blueprint — renamed to the
+ * developer's chosen name.
+ *
+ * Where `make:swarm:swarm` scaffolds a single empty swarm shell for a topology,
+ * this scaffolds a whole working use-case: the swarm class, its agents, and a
+ * runnable console command, wired together and ready to run. It draws from the
+ * same curated corpus under `stubs/examples/` that `swarm:install:examples`
+ * lands — but where the installer copies a tree **verbatim** (fixed-name
+ * reference material to read), this copies it **renamed** (a starting point to
+ * make your own).
+ *
+ * Each blueprint declares its canonical class/command names in a per-tree
+ * `blueprint.json` manifest; the rename substitutes those tokens for names
+ * derived from the developer's argument. Descriptive agent class names are
+ * deliberately preserved — a single swarm name cannot sensibly rename three
+ * distinct scout agents, and keeping them keeps the generated code readable.
+ *
+ * Companion commands: `make:swarm:swarm` (empty shell), `make:swarm:agent`
+ * (a single agent). See `docs/generators.md`.
+ *
+ * Programmatic callers (an umbrella command, a test, `Artisan::call`) should
+ * pass `--no-interaction` — like every other prompting command in the package,
+ * the interactive picker/name prompts only fire when the input is interactive.
+ */
+#[AsCommand(name: 'make:swarm:blueprint')]
+class MakeSwarmBlueprintCommand extends Command
+{
+    use InteractsWithBlueprintCorpus;
+    use ResolvesHostRootNamespace;
+
+    /**
+     * Names that are PHP reserved words (illegal as a class name) or collide
+     * with a core type the generated swarm imports (`Swarm`, `Agent`) — either
+     * would produce a file that does not compile. Compared case-insensitively.
+     *
+     * @var list<string>
+     */
+    private const RESERVED_NAMES = [
+        'abstract', 'and', 'array', 'as', 'break', 'callable', 'case', 'catch',
+        'class', 'clone', 'const', 'continue', 'declare', 'default', 'do', 'echo',
+        'else', 'elseif', 'empty', 'enddeclare', 'endfor', 'endforeach', 'endif',
+        'endswitch', 'endwhile', 'enum', 'eval', 'exit', 'extends', 'final',
+        'finally', 'fn', 'for', 'foreach', 'function', 'global', 'goto', 'if',
+        'implements', 'include', 'instanceof', 'insteadof', 'interface', 'isset',
+        'list', 'match', 'namespace', 'new', 'or', 'print', 'private', 'protected',
+        'public', 'readonly', 'require', 'return', 'static', 'switch', 'throw',
+        'trait', 'try', 'unset', 'use', 'var', 'while', 'xor', 'yield',
+        'int', 'float', 'bool', 'string', 'true', 'false', 'null', 'void',
+        'iterable', 'object', 'mixed', 'never', 'self', 'parent',
+        'swarm', 'agent',
+    ];
+
+    /** @var string */
+    protected $signature = 'make:swarm:blueprint
+        {name? : The name for your swarm (StudlyCase, e.g. SupportTriage)}
+        {--template= : The blueprint to scaffold from (slug — omit to pick interactively)}
+        {--without-command : Do not scaffold the runnable console command}
+        {--force : Overwrite files that already exist in the host app}';
+
+    /** @var string */
+    protected $description = 'Scaffold a complete, runnable swarm from a curated blueprint, renamed as your own.';
+
+    public function handle(Filesystem $files): int
+    {
+        $blueprints = $this->discoverBlueprints($files);
+
+        if ($blueprints === []) {
+            $this->components->error('No blueprints are available in the package.');
+
+            return self::FAILURE;
+        }
+
+        $slug = $this->resolveTemplate($blueprints);
+
+        if ($slug === null) {
+            return self::FAILURE;
+        }
+
+        $name = $this->resolveName();
+
+        if ($name === null) {
+            return self::FAILURE;
+        }
+
+        ['manifest' => $manifest, 'dir' => $treeDir] = $blueprints[$slug];
+
+        $renames = $this->buildRenameMap($manifest['tokens'], $name);
+
+        $includeCommand = ! (bool) $this->option('without-command');
+        if ($includeCommand && $this->wantsInteraction()) {
+            $includeCommand = confirm(
+                label: 'Scaffold the runnable console command too?',
+                default: true,
+                hint: 'A `php artisan` command that runs your swarm end-to-end.',
+            );
+        }
+
+        $pairs = $this->collectCopyPairs($treeDir);
+
+        if (! $includeCommand) {
+            $pairs = array_values(array_filter(
+                $pairs,
+                static fn (array $pair): bool => ! str_starts_with($pair['relative'], 'app/Console/Commands/'),
+            ));
+        }
+
+        $rootNamespace = $this->resolveRootNamespace($files);
+        $force = (bool) $this->option('force');
+
+        $plan = [];
+        $collisions = [];
+        foreach ($pairs as $pair) {
+            $relative = strtr($pair['relative'], $renames);
+            $dest = $this->laravel->basePath($relative);
+
+            if ($files->exists($dest) && ! $force) {
+                $collisions[] = $relative;
+            }
+
+            $plan[] = ['absolute' => $pair['absolute'], 'relative' => $relative, 'dest' => $dest];
+        }
+
+        // Fail loud on collision — a scaffold never silently overwrites app code.
+        if ($collisions !== []) {
+            $this->components->error(
+                'Refusing to overwrite '.count($collisions).' existing file(s): '
+                .implode(', ', $collisions).'. Re-run with --force to overwrite.'
+            );
+
+            return self::FAILURE;
+        }
+
+        foreach ($plan as $item) {
+            $files->ensureDirectoryExists(dirname($item['dest']));
+
+            $contents = (string) $files->get($item['absolute']);
+            $contents = $this->rewriteNamespacePlaceholders($contents, $rootNamespace);
+            $contents = strtr($contents, $renames);
+
+            $files->put($item['dest'], $contents);
+        }
+
+        $this->reportScaffold($name, $slug, $plan, $includeCommand);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Discover every corpus tree that declares a `blueprint.json` manifest,
+     * keyed by slug in stable sorted order. Trees without a manifest are
+     * installable verbatim via `swarm:install:examples` but are not offered as
+     * named blueprints here.
+     *
+     * @return array<string, array{manifest: array{slug: string, title: string, topology: string, summary: string, tokens: array{namespaceSegment: string, swarmClass: string, commandClass: string, commandSignature: string}}, dir: string}>
+     */
+    private function discoverBlueprints(Filesystem $files): array
+    {
+        $root = $this->corpusRoot();
+
+        if (! $files->isDirectory($root)) {
+            return [];
+        }
+
+        $blueprints = [];
+        foreach ($files->directories($root) as $treeDir) {
+            $manifest = $this->readBlueprintManifest($files, $treeDir);
+
+            if ($manifest === null) {
+                // A tree with a present-but-invalid manifest would otherwise
+                // vanish from --template silently, misreporting as "unknown
+                // blueprint" downstream. Surface it as an actionable warning.
+                if ($files->exists($treeDir.DIRECTORY_SEPARATOR.'blueprint.json')) {
+                    $this->components->warn(
+                        'Ignoring malformed blueprint manifest in ['.basename($treeDir).'].'
+                    );
+                }
+
+                continue;
+            }
+
+            if (isset($blueprints[$manifest['slug']])) {
+                $this->components->warn(
+                    "Duplicate blueprint slug [{$manifest['slug']}] — the last tree discovered wins."
+                );
+            }
+
+            $blueprints[$manifest['slug']] = ['manifest' => $manifest, 'dir' => $treeDir];
+        }
+
+        ksort($blueprints);
+
+        return $blueprints;
+    }
+
+    /**
+     * Resolve which blueprint to scaffold: the `--template` slug, an interactive
+     * pick, or a hard failure in non-interactive mode. Returns `null` on any
+     * failure already reported to the console.
+     *
+     * @param  array<string, array{manifest: array{slug: string, title: string, topology: string, summary: string, tokens: array<string, string>}, dir: string}>  $blueprints
+     */
+    private function resolveTemplate(array $blueprints): ?string
+    {
+        $requested = $this->option('template');
+
+        if (is_string($requested) && $requested !== '') {
+            if (! isset($blueprints[$requested])) {
+                $this->components->error(
+                    "Unknown blueprint [{$requested}]. Available: ".implode(', ', array_keys($blueprints)).'.'
+                );
+
+                return null;
+            }
+
+            return $requested;
+        }
+
+        if (! $this->wantsInteraction()) {
+            $this->components->error(
+                'In non-interactive mode you must pass --template=<slug>. '
+                .'Available: '.implode(', ', array_keys($blueprints)).'.'
+            );
+
+            return null;
+        }
+
+        $options = [];
+        foreach ($blueprints as $slug => $entry) {
+            $options[$slug] = $entry['manifest']['title'].' — '.$entry['manifest']['summary'];
+        }
+
+        /** @var string $chosen */
+        $chosen = select(
+            label: 'Which blueprint should we scaffold?',
+            options: $options,
+            hint: 'Each is a complete, runnable swarm you can rename and edit.',
+        );
+
+        return $chosen;
+    }
+
+    /**
+     * Resolve the swarm name from the argument or an interactive prompt, and
+     * validate it studlies into a legal class name. Returns the StudlyCase name
+     * or `null` on a reported failure.
+     */
+    private function resolveName(): ?string
+    {
+        $raw = $this->argument('name');
+        $raw = is_string($raw) ? trim($raw) : '';
+
+        if ($raw === '' && $this->wantsInteraction()) {
+            $raw = text(
+                label: 'What should we name your swarm?',
+                placeholder: 'SupportTriage',
+                hint: 'StudlyCase — this becomes your swarm class and namespace.',
+            );
+            $raw = trim($raw);
+        }
+
+        if ($raw === '') {
+            $this->components->error('A swarm name is required (pass it as the first argument).');
+
+            return null;
+        }
+
+        $name = Str::studly($raw);
+
+        if (preg_match('/^[A-Za-z][A-Za-z0-9]*$/', $name) !== 1) {
+            $this->components->error(
+                "[{$raw}] is not a valid swarm name. Use letters and numbers only (e.g. SupportTriage)."
+            );
+
+            return null;
+        }
+
+        if (in_array(strtolower($name), self::RESERVED_NAMES, true)) {
+            $this->components->error(
+                "[{$name}] is a reserved name and would generate a class that does not compile. Choose another name."
+            );
+
+            return null;
+        }
+
+        return $name;
+    }
+
+    /**
+     * Build the token → replacement map for a blueprint's canonical names.
+     * Applied via {@see strtr()} to both file contents and destination paths.
+     * strtr matches the longest key at each position and never rescans a
+     * replacement — independent of this array's insertion order — so the
+     * substring overlap between `namespaceSegment` (e.g. `ParallelResearchFanout`)
+     * and `swarmClass` (e.g. `ResearchFanout`) can never cause a partial
+     * mis-replacement.
+     *
+     * @param  array{namespaceSegment: string, swarmClass: string, commandClass: string, commandSignature: string}  $tokens
+     * @return array<string, string>
+     */
+    private function buildRenameMap(array $tokens, string $name): array
+    {
+        $kebab = Str::kebab($name);
+
+        return [
+            $tokens['commandClass'] => $name.'Command',
+            $tokens['namespaceSegment'] => $name,
+            $tokens['swarmClass'] => $name,
+            $tokens['commandSignature'] => 'swarm:run:'.$kebab,
+        ];
+    }
+
+    /**
+     * Whether the command may prompt the user (interactive TTY and not
+     * `--no-interaction`).
+     */
+    private function wantsInteraction(): bool
+    {
+        return $this->input->isInteractive() && $this->option('no-interaction') !== true;
+    }
+
+    /**
+     * Print what was scaffolded and how to run it.
+     *
+     * @param  list<array{absolute: string, relative: string, dest: string}>  $plan
+     */
+    private function reportScaffold(string $name, string $slug, array $plan, bool $includeCommand): void
+    {
+        $this->components->info("Scaffolded [{$name}] from the [{$slug}] blueprint.");
+
+        $this->components->bulletList(array_map(
+            static fn (array $item): string => $item['relative'],
+            $plan,
+        ));
+
+        if ($includeCommand) {
+            $signature = 'swarm:run:'.Str::kebab($name);
+            $this->newLine();
+            $this->components->info('Run it end-to-end:');
+            $this->components->bulletList(["php artisan {$signature}"]);
+            $this->components->info('Artisan auto-discovery registers the new command on the next boot.');
+        }
+
+        $this->newLine();
+        $this->components->info('Next: open the generated files, swap the ScriptedAgent stubs for real agents, and edit the docblocks.');
+    }
+}

--- a/src/SwarmServiceProvider.php
+++ b/src/SwarmServiceProvider.php
@@ -18,6 +18,7 @@ use BuiltByBerry\LaravelSwarm\Commands\Install\InstallExamplesCommand;
 use BuiltByBerry\LaravelSwarm\Commands\Install\InstallMemoryCommand;
 use BuiltByBerry\LaravelSwarm\Commands\MakeMemoryToolCommand;
 use BuiltByBerry\LaravelSwarm\Commands\MakeSwarmAgentCommand;
+use BuiltByBerry\LaravelSwarm\Commands\MakeSwarmBlueprintCommand;
 use BuiltByBerry\LaravelSwarm\Commands\MakeSwarmCommand;
 use BuiltByBerry\LaravelSwarm\Commands\MakeSwarmSwarmCommand;
 use BuiltByBerry\LaravelSwarm\Commands\SwarmAuditReconcileCommand;
@@ -460,6 +461,7 @@ class SwarmServiceProvider extends ServiceProvider
                 MakeSwarmCommand::class,
                 MakeSwarmSwarmCommand::class,
                 MakeSwarmAgentCommand::class,
+                MakeSwarmBlueprintCommand::class,
                 MakeMemoryToolCommand::class,
                 SwarmHealthCommand::class,
                 SwarmPruneCommand::class,

--- a/stubs/examples/durable-approval-workflow/blueprint.json
+++ b/stubs/examples/durable-approval-workflow/blueprint.json
@@ -1,0 +1,12 @@
+{
+    "slug": "approval",
+    "title": "Durable approval workflow",
+    "topology": "sequential",
+    "summary": "A durable run that pauses for human approval, then resumes from a checkpoint.",
+    "tokens": {
+        "namespaceSegment": "DurableApprovalWorkflow",
+        "swarmClass": "PolicyApprovalSwarm",
+        "commandClass": "SwarmExampleApprovalWorkflowCommand",
+        "commandSignature": "swarm:example:approval-workflow"
+    }
+}

--- a/stubs/examples/parallel-research-fanout/blueprint.json
+++ b/stubs/examples/parallel-research-fanout/blueprint.json
@@ -1,0 +1,12 @@
+{
+    "slug": "research",
+    "title": "Parallel research fan-out",
+    "topology": "parallel",
+    "summary": "Dispatch one prompt to multiple agents at once, then merge their results into a single response.",
+    "tokens": {
+        "namespaceSegment": "ParallelResearchFanout",
+        "swarmClass": "ResearchFanout",
+        "commandClass": "SwarmExampleResearchFanoutCommand",
+        "commandSignature": "swarm:example:research-fanout"
+    }
+}

--- a/stubs/examples/sequential-blog-pipeline/blueprint.json
+++ b/stubs/examples/sequential-blog-pipeline/blueprint.json
@@ -1,0 +1,12 @@
+{
+    "slug": "pipeline",
+    "title": "Sequential pipeline",
+    "topology": "sequential",
+    "summary": "Chain agents in order so each one refines the previous step's output.",
+    "tokens": {
+        "namespaceSegment": "SequentialBlogPipeline",
+        "swarmClass": "BlogPipeline",
+        "commandClass": "SwarmExampleBlogPipelineCommand",
+        "commandSignature": "swarm:example:blog-pipeline"
+    }
+}

--- a/tests/Feature/BlueprintCorpusManifestTest.php
+++ b/tests/Feature/BlueprintCorpusManifestTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use BuiltByBerry\LaravelSwarm\Commands\Concerns\InteractsWithBlueprintCorpus;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
 
 /**
  * Exercises the manifest-parsing seam of the shared corpus concern directly, so
@@ -102,6 +103,41 @@ test('a manifest missing a required token returns null', function () {
     ], JSON_THROW_ON_ERROR));
 
     expect(manifestProbe()->read(new Filesystem, $this->tmp))->toBeNull();
+});
+
+test('every shipped blueprint manifest topology matches its swarm attribute', function () {
+    // Guards against drift between the hand-declared manifest `topology` and the
+    // authoritative #[Topology] attribute on the swarm class it describes.
+    $corpus = dirname(__DIR__, 2).'/stubs/examples';
+    $files = new Filesystem;
+
+    $checked = 0;
+    foreach ($files->directories($corpus) as $treeDir) {
+        if (! $files->exists($treeDir.'/blueprint.json')) {
+            continue;
+        }
+
+        $manifest = json_decode((string) $files->get($treeDir.'/blueprint.json'), true, flags: JSON_THROW_ON_ERROR);
+        $tokens = $manifest['tokens'];
+        $swarmFile = $treeDir.'/app/Ai/Swarms/'.$tokens['namespaceSegment'].'/'.$tokens['swarmClass'].'.php';
+
+        expect($files->exists($swarmFile))->toBeTrue("swarm class missing for [{$manifest['slug']}]");
+
+        // A swarm without an explicit #[Topology] attribute relies on the
+        // framework default, which is Sequential.
+        $effective = preg_match('/TopologyEnum::(\w+)/', (string) $files->get($swarmFile), $m) === 1
+            ? $m[1]
+            : 'Sequential';
+
+        expect($effective)->toBe(
+            Str::studly($manifest['topology']),
+            "manifest topology [{$manifest['topology']}] does not match the #[Topology] on [{$tokens['swarmClass']}]"
+        );
+
+        $checked++;
+    }
+
+    expect($checked)->toBeGreaterThan(0);
 });
 
 test('a manifest missing a required top-level field returns null', function () {

--- a/tests/Feature/BlueprintCorpusManifestTest.php
+++ b/tests/Feature/BlueprintCorpusManifestTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Commands\Concerns\InteractsWithBlueprintCorpus;
+use Illuminate\Filesystem\Filesystem;
+
+/**
+ * Exercises the manifest-parsing seam of the shared corpus concern directly, so
+ * the malformed-manifest paths are covered without planting a broken fixture in
+ * the real `stubs/examples/` corpus (which install:examples / the renderer walk).
+ */
+function manifestProbe(): object
+{
+    return new class
+    {
+        use InteractsWithBlueprintCorpus;
+
+        /** @return array<string, mixed>|null */
+        public function read(Filesystem $files, string $dir): ?array
+        {
+            return $this->readBlueprintManifest($files, $dir);
+        }
+    };
+}
+
+function writeManifest(string $dir, string $contents): void
+{
+    if (! is_dir($dir)) {
+        mkdir($dir, 0777, true);
+    }
+    file_put_contents($dir.'/blueprint.json', $contents);
+}
+
+beforeEach(function () {
+    $this->tmp = sys_get_temp_dir().'/laravel-swarm-manifest-test/'.bin2hex(random_bytes(4));
+    mkdir($this->tmp, 0777, true);
+});
+
+afterEach(function () {
+    (new Filesystem)->deleteDirectory($this->tmp);
+});
+
+test('a well-formed manifest parses into the expected shape', function () {
+    writeManifest($this->tmp, json_encode([
+        'slug' => 'demo',
+        'title' => 'Demo',
+        'topology' => 'sequential',
+        'summary' => 'A demo.',
+        'tokens' => [
+            'namespaceSegment' => 'DemoTree',
+            'swarmClass' => 'DemoSwarm',
+            'commandClass' => 'SwarmExampleDemoCommand',
+            'commandSignature' => 'swarm:example:demo',
+        ],
+    ], JSON_THROW_ON_ERROR));
+
+    $manifest = manifestProbe()->read(new Filesystem, $this->tmp);
+
+    expect($manifest)->not->toBeNull()
+        ->and($manifest['slug'])->toBe('demo')
+        ->and($manifest['tokens']['swarmClass'])->toBe('DemoSwarm');
+});
+
+test('a summary defaults to the title when omitted', function () {
+    writeManifest($this->tmp, json_encode([
+        'slug' => 'demo',
+        'title' => 'Demo Title',
+        'topology' => 'sequential',
+        'tokens' => [
+            'namespaceSegment' => 'DemoTree',
+            'swarmClass' => 'DemoSwarm',
+            'commandClass' => 'SwarmExampleDemoCommand',
+            'commandSignature' => 'swarm:example:demo',
+        ],
+    ], JSON_THROW_ON_ERROR));
+
+    expect(manifestProbe()->read(new Filesystem, $this->tmp)['summary'])->toBe('Demo Title');
+});
+
+test('an absent manifest returns null', function () {
+    expect(manifestProbe()->read(new Filesystem, $this->tmp))->toBeNull();
+});
+
+test('malformed JSON returns null', function () {
+    writeManifest($this->tmp, '{ this is not json ]');
+
+    expect(manifestProbe()->read(new Filesystem, $this->tmp))->toBeNull();
+});
+
+test('a manifest missing a required token returns null', function () {
+    writeManifest($this->tmp, json_encode([
+        'slug' => 'demo',
+        'title' => 'Demo',
+        'topology' => 'sequential',
+        'tokens' => [
+            'namespaceSegment' => 'DemoTree',
+            // swarmClass omitted
+            'commandClass' => 'SwarmExampleDemoCommand',
+            'commandSignature' => 'swarm:example:demo',
+        ],
+    ], JSON_THROW_ON_ERROR));
+
+    expect(manifestProbe()->read(new Filesystem, $this->tmp))->toBeNull();
+});
+
+test('a manifest missing a required top-level field returns null', function () {
+    writeManifest($this->tmp, json_encode([
+        // slug omitted
+        'title' => 'Demo',
+        'topology' => 'sequential',
+        'tokens' => [
+            'namespaceSegment' => 'DemoTree',
+            'swarmClass' => 'DemoSwarm',
+            'commandClass' => 'SwarmExampleDemoCommand',
+            'commandSignature' => 'swarm:example:demo',
+        ],
+    ], JSON_THROW_ON_ERROR));
+
+    expect(manifestProbe()->read(new Filesystem, $this->tmp))->toBeNull();
+});

--- a/tests/Feature/MakeSwarmBlueprintCommandTest.php
+++ b/tests/Feature/MakeSwarmBlueprintCommandTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+
+/**
+ * Clean every path a scaffold may have written into the testbench app.
+ */
+function cleanBlueprintScaffold(string $name): void
+{
+    File::deleteDirectory(app_path("Ai/Swarms/{$name}"));
+    File::deleteDirectory(app_path("Ai/Agents/{$name}"));
+    File::delete(app_path("Console/Commands/{$name}Command.php"));
+}
+
+afterEach(function () {
+    foreach (['SupportTriage', 'ForcedName', 'SkipCommand'] as $name) {
+        cleanBlueprintScaffold($name);
+    }
+    // Sweep anything install:examples landed during the regression test.
+    foreach (glob(app_path('Ai/Swarms/*'), GLOB_ONLYDIR) ?: [] as $dir) {
+        File::deleteDirectory($dir);
+    }
+    foreach (glob(app_path('Ai/Agents/*'), GLOB_ONLYDIR) ?: [] as $dir) {
+        File::deleteDirectory($dir);
+    }
+    foreach (glob(app_path('Console/Commands/*.php')) ?: [] as $file) {
+        File::delete($file);
+    }
+});
+
+test('make:swarm:blueprint scaffolds a renamed swarm, agents, and command', function () {
+    $exit = Artisan::call('make:swarm:blueprint', ['name' => 'SupportTriage', '--template' => 'research',
+        '--no-interaction' => true,
+    ]);
+
+    expect($exit)->toBe(0);
+
+    $swarm = app_path('Ai/Swarms/SupportTriage/SupportTriage.php');
+    $agent = app_path('Ai/Agents/SupportTriage/MarketScout.php');
+    $command = app_path('Console/Commands/SupportTriageCommand.php');
+
+    expect(File::exists($swarm))->toBeTrue()
+        ->and(File::exists($agent))->toBeTrue()
+        ->and(File::exists($command))->toBeTrue();
+
+    $swarmContents = File::get($swarm);
+    expect($swarmContents)
+        ->toContain('namespace App\Ai\Swarms\SupportTriage;')
+        ->toContain('class SupportTriage implements Swarm')
+        ->toContain('use App\Ai\Agents\SupportTriage\MarketScout;')
+        ->not->toContain('ResearchFanout')
+        ->not->toContain('ParallelResearchFanout')
+        ->not->toContain('{{ rootNamespace }}');
+
+    // Agent class names are deliberately preserved; only the namespace segment is renamed.
+    expect(File::get($agent))
+        ->toContain('namespace App\Ai\Agents\SupportTriage;')
+        ->toContain('class MarketScout');
+});
+
+test('make:swarm:blueprint renames the console command and its signature', function () {
+    Artisan::call('make:swarm:blueprint', ['name' => 'SupportTriage', '--template' => 'research',
+        '--no-interaction' => true,
+    ]);
+
+    $command = File::get(app_path('Console/Commands/SupportTriageCommand.php'));
+
+    expect($command)
+        ->toContain('class SupportTriageCommand extends Command')
+        ->toContain("#[AsCommand(name: 'swarm:run:support-triage')]")
+        ->toContain('swarm:run:support-triage {topic')
+        ->toContain('SupportTriage::make()')
+        ->not->toContain('SwarmExampleResearchFanoutCommand')
+        ->not->toContain('swarm:example:research-fanout');
+});
+
+test('--without-command skips the runnable command but still scaffolds the swarm', function () {
+    $exit = Artisan::call('make:swarm:blueprint', [
+        'name' => 'SkipCommand',
+        '--template' => 'research',
+        '--without-command' => true,
+        '--no-interaction' => true,
+    ]);
+
+    expect($exit)->toBe(0)
+        ->and(File::exists(app_path('Ai/Swarms/SkipCommand/SkipCommand.php')))->toBeTrue()
+        ->and(File::exists(app_path('Console/Commands/SkipCommandCommand.php')))->toBeFalse();
+});
+
+test('make:swarm:blueprint refuses to overwrite existing files without --force', function () {
+    Artisan::call('make:swarm:blueprint', ['name' => 'ForcedName', '--template' => 'research',
+        '--no-interaction' => true,
+    ]);
+
+    $exit = Artisan::call('make:swarm:blueprint', ['name' => 'ForcedName', '--template' => 'research',
+        '--no-interaction' => true,
+    ]);
+
+    expect($exit)->toBe(1)
+        ->and(Artisan::output())->toContain('Refusing to overwrite');
+});
+
+test('--force overwrites an existing scaffold', function () {
+    Artisan::call('make:swarm:blueprint', ['name' => 'ForcedName', '--template' => 'research',
+        '--no-interaction' => true,
+    ]);
+
+    $exit = Artisan::call('make:swarm:blueprint', [
+        'name' => 'ForcedName',
+        '--template' => 'research',
+        '--force' => true,
+        '--no-interaction' => true,
+    ]);
+
+    expect($exit)->toBe(0);
+});
+
+test('non-interactive mode requires --template', function () {
+    $exit = Artisan::call('make:swarm:blueprint', ['name' => 'SupportTriage',
+        '--no-interaction' => true,
+    ]);
+
+    expect($exit)->toBe(1)
+        ->and(Artisan::output())
+        ->toContain('you must pass --template')
+        ->toContain('research');
+});
+
+test('an unknown --template is rejected with the available list', function () {
+    $exit = Artisan::call('make:swarm:blueprint', ['name' => 'SupportTriage', '--template' => 'nope',
+        '--no-interaction' => true,
+    ]);
+
+    expect($exit)->toBe(1)
+        ->and(Artisan::output())
+        ->toContain('Unknown blueprint [nope]')
+        ->toContain('research');
+});
+
+test('an invalid swarm name is rejected', function () {
+    $exit = Artisan::call('make:swarm:blueprint', ['name' => '123', '--template' => 'research',
+        '--no-interaction' => true,
+    ]);
+
+    expect($exit)->toBe(1)
+        ->and(Artisan::output())->toContain('not a valid swarm name');
+});
+
+test('every discoverable blueprint scaffolds cleanly', function () {
+    // Guards each shipped blueprint end-to-end, not just the research fixture.
+    foreach (['pipeline', 'research', 'approval'] as $slug) {
+        $exit = Artisan::call('make:swarm:blueprint', ['name' => 'SupportTriage', '--template' => $slug,
+            '--no-interaction' => true,
+        ]);
+
+        expect($exit)->toBe(0, "blueprint [{$slug}] failed to scaffold")
+            ->and(File::exists(app_path('Ai/Swarms/SupportTriage/SupportTriage.php')))->toBeTrue();
+
+        cleanBlueprintScaffold('SupportTriage');
+    }
+});
+
+test('swarm:install:examples never lands the package-side blueprint.json manifest', function () {
+    // Byte-identical invariant: the shared-corpus refactor must not leak the
+    // new manifest into the host app tree — anywhere under app/.
+    Artisan::call('swarm:install:examples', ['--all' => true,
+        '--no-interaction' => true,
+    ]);
+
+    $leaked = collect(File::allFiles(app_path()))
+        ->filter(fn ($file) => $file->getFilename() === 'blueprint.json')
+        ->map(fn ($file) => $file->getPathname())
+        ->values()
+        ->all();
+
+    expect($leaked)->toBe([]);
+});
+
+test('a reserved swarm name is rejected before generating uncompilable code', function () {
+    // `class Swarm implements Swarm` would collide with the imported contract.
+    $exit = Artisan::call('make:swarm:blueprint', ['name' => 'Swarm', '--template' => 'research',
+        '--no-interaction' => true,
+    ]);
+
+    expect($exit)->toBe(1)
+        ->and(Artisan::output())->toContain('reserved name');
+});


### PR DESCRIPTION
Closes #378. Targets `release/v0.18.0` (not `main`).

Phase 1 (ecosystem epic #254) **engine** — the serial prerequisite the four authored blueprints (#379–#382) branch from.

## What this does

Adds `make:swarm:blueprint <Name> --template=<slug>`: scaffolds a complete, runnable swarm (swarm class + agents + console command) **renamed and namespaced as the developer's own**, from the same curated corpus under `stubs/examples/` that `swarm:install:examples` lands. The installer copies a tree **verbatim** (fixed-name reference to read); this copies it **renamed** (a starting point to edit).

## Design highlights

- **One shared engine.** Extracted `InteractsWithBlueprintCorpus` (container-free: tree walk, placeholder rewrite, manifest read) + `ResolvesHostRootNamespace` (the one container-dependent step) from `InstallExamplesCommand`. Both commands consume them, so they can't drift.
- **Byte-identical invariant held.** `swarm:install:examples` output is unchanged — it now skips the package-side `blueprint.json` alongside `README.md`. Guarded by a regression test that scans all of `app/` for leaked manifests.
- **Name substitution via per-tree `blueprint.json` manifest + `strtr()`.** Longest-match-first, no-rescan semantics mean the `namespaceSegment` (`ParallelResearchFanout`) ⊃ `swarmClass` (`ResearchFanout`) substring overlap can never mis-replace. Agent class names are preserved by design (a single swarm name can't rename three distinct scouts).
- **Fails loud.** Refuses to overwrite app files without `--force` (checks the full plan before writing any file — no partial writes); rejects reserved/uncompilable names (e.g. `Swarm`); requires `--template` when non-interactive; warns on malformed / duplicate-slug manifests.

## Blueprints shipped here

`pipeline` (sequential), `research` (parallel fan-out), `approval` (durable) — the three existing example trees, now catalogued. `triage`, `extraction`, `memory`, `streaming` land in #379–#382.

## Review

A pre-implementation gate + an adversarial review ran on the diff. Findings addressed in-branch: reserved-name guard (would have generated `class Swarm implements Swarm`), malformed/duplicate-manifest warnings, broadened leak-guard scan, and the corpus/namespace concern split (keeps the corpus trait container-free + unit-testable).

## Verification

- ✅ Full suite: **1885 passed** (7545 assertions)
- ✅ PHPStan: no errors · Pint: clean
- ✅ New coverage: 10 command tests (happy path, rename, `--without-command`, `--force`, collision, non-interactive guard, unknown/reserved name) + 6 manifest-parsing unit tests + install:examples leak-guard regression

## Acceptance criteria (#378)

- [x] `make:swarm:blueprint <Name> --template=<slug>` scaffolds renamed; agent names preserved
- [x] Copy/tokenize extracted to a shared concern; `install:examples` byte-identical (regression test)
- [x] Catalog registry resolves slug → tree; existing 3 registered
- [x] Interactive picker + name prompt + command toggle; non-interactive fails loud on missing `--template`
- [x] Collision fail-loud; `--help` present
- [x] CHANGELOG entry under v0.18.0
- [x] Tests: feature + installer regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)