### PR TITLE
chore(release): v0.18.0 wrap-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.18.0 - unreleased
+## v0.18.0 - 2026-07-07
 
 Ecosystem epic #254 Phase 1 — blueprint templates. Adds a name-parameterized `make:swarm:blueprint` generator over a unified, tokenized blueprint catalog, so a developer can scaffold a complete, runnable, use-case-shaped swarm (swarm + agents + console command + README) as their own — renamed and namespaced — rather than only reading the fixed-name reference copies that `swarm:install:examples` lands. One tokenized corpus now serves both: `install:examples` lands it verbatim, `make:swarm:blueprint` lands it renamed.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -269,6 +269,10 @@ This package’s `composer.json` uses `"minimum-stability": "dev"` with
 still prefers tagged releases. Your application may need compatible Composer
 stability settings while Laravel AI remains pre-stable.
 
+## Upgrading to v0.18.0
+
+**No required action — additive.** This release adds the `make:swarm:blueprint` generator and four new curated blueprint trees (`triage`, `extraction`, `memory`, `streaming`) to the starter corpus. It is purely additive — a new Artisan command plus new stub files, with no migration, config, schema, or breaking API change. `swarm:install:examples`' behavior and file output are unchanged (it now also skips the package-side `blueprint.json` metadata alongside `README.md`). If you want the new scaffolder, run `php artisan make:swarm:blueprint <Name> --template=<slug>`; otherwise nothing changes. See the [CHANGELOG](CHANGELOG.md#v0180---2026-07-07) and [Generators](docs/generators.md#make-swarm-blueprint) for details.
+
 ## Upgrading to v0.17.4
 
 **No required action — test-only.** This release adds behavior coverage for three public durable-routing capability seams — `ConfiguresDurableRetries`, `RoutesDurableWaits`, and `RoutesDurableBranches` — ahead of the 1.0 surface freeze. No code, config, or schema changes; the contracts themselves are unchanged. See the [CHANGELOG](CHANGELOG.md#v0174---2026-07-06) for details.

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "0.17.x-dev"
+            "dev-main": "0.18.x-dev"
         },
         "laravel": {
             "providers": [


### PR DESCRIPTION
Phase 2 of the v0.18.0 wrap — deterministic release hygiene.

- **CHANGELOG** — `## v0.18.0 - unreleased` → `## v0.18.0 - 2026-07-07`. The Added/Changed/Documentation sections were already filled from the per-PR entries as the components merged.
- **UPGRADING.md** — added a `## Upgrading to v0.18.0` block: **No required action — additive** (new command + stubs, no migration/config/schema/breaking; `install:examples` output unchanged).
- **composer.json** — bumped `extra.branch-alias.dev-main` `0.17.x-dev` → `0.18.x-dev` (lagged one release). `composer.lock` is not tracked, so no lock refresh needed.

**README marquee:** already satisfied — the `make:swarm:blueprint` pointer + catalog link landed in the "Your First Swarm" section via the docs capstone (#390). No further README change needed.

## Breaking-change / deploy-safety roll-up
No breaking changes. No migrations. No deploy-safety concerns — the entire release is additive (a generator + curated stub trees).

After merge → Phase 3 readiness review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)