### PR TITLE
feat(durable,audit): public display read seams for companions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ Public display-read seams for ecosystem companions. Adds separate, additive, rea
 
 ### Added
 
-_To be filled in during release wrap-up._
+- **`InspectsDurableRuns` — public read-only durable inspection contract.** The supported, container-bound seam for companion packages and external readers to DISPLAY a durable run's assembled state (`find()`, `inspect()`, `inspectByLabels()`), returning a display-decrypted `DurableRunDetail`. It is the read-only counterpart to `SwarmOperator` (control): resolve it with `app(InspectsDurableRuns::class)` instead of binding the `@internal` `DurableSwarmManager`/`DurableRunInspector` or the `@internal` `SwarmPersistenceCipher`. Every sealed field is opened through the evidence path that honors `swarm.persistence.decrypt_failure_policy` and **degrades per row** — an undecryptable value becomes `null` with an explicit `*_available: false` flag rather than throwing or leaking `sw0:` ciphertext, so one poison row never aborts the batch or 500s a display surface. The operational resume reads on `DurableRunStore` are untouched and still decrypt strictly (fail loud on a rotated `APP_KEY`).
+- **`ReadableAuditOutbox` — public read-only audit-outbox health contract.** The non-mutating counterpart to `AuditOutbox::drain()` (which reserves and consumes rows): `pending()`, `deadLettered()`, `healthSummary()`, and `isAvailable()` for outbox-health surfaces. Every read is a pure SELECT that never writes `reserved_at` and never deletes, so it coexists with a concurrent `swarm:relay --type=audit` drainer instead of stealing its rows. Sealed `payload`/`last_error` are display-decrypted with the same per-row degrade. Bound to the database outbox when the persistence driver supports it and a no-op (reporting an empty, unavailable outbox) otherwise.
+- **`DurableRunDetail::hierarchicalNodeOutputs`.** The assembled durable read model now includes hierarchical node outputs (display-decrypted, per-row `output_available` flag), completing cross-topology parity with parallel branches and child runs on the inspection surface.
 
 ### Changed
 
-_To be filled in during release wrap-up._
+- **`DurableRunInspector` now implements the public `InspectsDurableRuns` contract** (the class stays `@internal`; consumers bind the contract). Its branch, child-run, and hierarchical-node-output display reads now degrade per row via a new `SwarmPersistenceCipher::openForDisplay()` helper rather than surfacing raw ciphertext under the `legacy` policy or throwing under the `throw` policy.
 
 ## v0.18.0 - 2026-07-07
 

--- a/docs/public-surface.md
+++ b/docs/public-surface.md
@@ -28,6 +28,7 @@ adding a new public API.
 | `DurablePauseResult` / `DurableResumeResult` / `DurableCancelResult` | Lifecycle result value objects returned by the `SwarmOperator` control verbs. Each carries the effective status as a typed `DurableLifecycleStatus` enum — `Paused` vs `PauseScheduled`, `Cancelled` vs `CancelScheduled`, `Resumed` vs `Waiting` (with `waitingBoundaryDispatched`) — plus `isImmediate()`/`isWaiting()` convenience methods and `toArray()`. They never hide whether the run actually transitioned. (v0.16.0+) | [Durable Execution](durable-execution.md#operator-control-contract) |
 | `DurableLifecycleStatus` | Backed enum of the effective status a control verb transitioned a run into. Cases: `Paused` (`paused`), `PauseScheduled` (`pause_scheduled`), `Cancelled` (`cancelled`), `CancelScheduled` (`cancel_scheduled`), `Resumed` (`resumed`), `Waiting` (`waiting`). Backs the three lifecycle result objects so the status is a typed public value, not a raw string. (v0.16.0+) | [Durable Execution](durable-execution.md#operator-control-contract) |
 | `DurableSignalResult` | Result of a signal delivery — `accepted`, `duplicate`, recorded `status`, and the stored signal. Returned by `SwarmOperator::signal()` and `DurableSwarmResponse::signal()`. | [Durable Waits And Signals](durable-waits-and-signals.md), [Durable Webhooks](durable-webhooks.md) |
+| `DurableRunDetail` | Display-decrypted read model returned by `InspectsDurableRuns::inspect()` — `run`, `history`, `labels`, `details`, `waits`, `signals`, `progress`, `children`, `branches`, and `hierarchicalNodeOutputs`, plus `toArray()`. Sealed fields carry a companion `*_available` flag; an undecryptable field is `null` rather than throwing or leaking ciphertext. (v0.19.0+) | [Durable Execution](durable-execution.md#read-only-inspection) |
 | `RunContext` | Explicit run input, run ID, data, metadata, artifacts, labels, and details. Implements `ArrayAccess` — `$context['key']` reads and writes directly through to the `SwarmMemory` Run scope (v0.9.0+). `withConversationId()` binds the run to a conversation (read back with `conversationId()`), making `MemoryScope::Conversation` addressable for snapshot gathering and the `Recall`/`Remember` tools; the id threads through every execution path via run metadata (v0.12.0+). | [Structured Input](structured-input.md), [Persistence And History](persistence-and-history.md), [Swarm Memory](memory.md#runcontext-write-through), [Conversation-scoped memory](memory.md#conversation-scoped-memory) |
 | `SwarmHistory` | Query persisted history and replay stored stream events. | [Persistence And History](persistence-and-history.md), [Run Inspector](../examples/run-inspector/README.md) |
 | `AuditDrainResult` | Result of an `AuditOutbox::drain()` invocation — `replayed`, `dead_lettered`, `failed`, `claimed`, `reclaimed`. (v0.5.0+) | [Audit Evidence Contract](audit-evidence-contract.md#audit-outbox) |
@@ -87,12 +88,42 @@ the consuming application's responsibility. Verbs fail loud (throw
 | `SwarmOperator::signal()` | Deliver a named signal (idempotent per `idempotencyKey`); returns a `DurableSignalResult`. | [Durable Waits And Signals](durable-waits-and-signals.md), [Durable Webhooks](durable-webhooks.md) |
 | `SwarmOperator::recover()` | Redispatch recoverable runs, branches, waits, retries, and child reconciliations; returns the redispatched run ids. Lease-guarded and idempotent. | [Durable Execution](durable-execution.md#operator-control-contract), [Maintenance](maintenance.md#scheduling) |
 
+## Read-Only Inspection Contracts (v0.19.0+)
+
+The public, container-bound read-only seams companion packages and external
+readers (a Filament panel, an MCP server, a custom dashboard) use to DISPLAY
+durable and audit data. They are the read-only counterparts to `SwarmOperator`:
+resolve them with `app(...)`, never bind the `@internal` engine types or the
+`@internal` `SwarmPersistenceCipher`.
+
+Every sealed field these seams return is **display-decrypted**: it honors
+`swarm.persistence.decrypt_failure_policy` and degrades per row — a value that
+cannot be decrypted becomes `null` with an explicit `*_available: false` flag
+rather than throwing or leaking `sw0:` ciphertext. One undecryptable row never
+aborts the batch and never 500s a display surface. This is the opposite of the
+operational resume reads on `DurableRunStore`, which decrypt strictly and fail
+loud on a rotated `APP_KEY`.
+
+| Surface | Purpose | Primary documentation |
+| --- | --- | --- |
+| `InspectsDurableRuns::find()` | The durable run row for a run, or `null`. Never decrypts. | [Durable Execution](durable-execution.md#read-only-inspection) |
+| `InspectsDurableRuns::inspect()` | Assemble the full display-decrypted `DurableRunDetail` — run, history, labels, details, waits, signals, progress, child runs, parallel branches, and hierarchical node outputs. Throws on an unknown run. | [Durable Execution](durable-execution.md#read-only-inspection) |
+| `InspectsDurableRuns::inspectByLabels()` | Inspect every run carrying the given labels. | [Durable Execution](durable-execution.md#read-only-inspection) |
+| `ReadableAuditOutbox::pending()` / `deadLettered()` | List outbox rows by status, newest first, display-decrypted. Pure SELECT — never reserves or deletes, so it coexists with a concurrent `swarm:relay --type=audit` drainer. | [Audit Evidence Contract](audit-evidence-contract.md#audit-outbox) |
+| `ReadableAuditOutbox::healthSummary()` | Non-mutating counts by status, reserved-in-flight count, and oldest-pending timestamp. | [Audit Evidence Contract](audit-evidence-contract.md#audit-outbox) |
+| `ReadableAuditOutbox::isAvailable()` | Whether the outbox is backed by a working store (false in cache mode / when the table is missing). | [Audit Evidence Contract](audit-evidence-contract.md#audit-outbox) |
+
+The audit outbox seams cover the retry BUFFER only. The full audit TRAIL is
+served by an application's own `ReadableSwarmAuditSink`; core's default sink
+stores nothing, so a trail surface requires the app to bind a readable sink.
+
 ## Durable Manager Operations
 
 The `DurableSwarmManager` and `DurableRunInspector` are `@internal` engine
-types, not a supported contract. For control use the `SwarmOperator` contract
-above; for reads use `SwarmHistory` / `RunHistoryStore`. The rows below describe
-engine behavior for orientation only.
+types, not a supported contract — consumers bind the public `SwarmOperator`
+(control) and `InspectsDurableRuns` (read) contracts above, which they
+implement. For reads also see `SwarmHistory` / `RunHistoryStore`. The rows below
+describe engine behavior for orientation only.
 
 | Surface | Purpose | Primary documentation |
 | --- | --- | --- |
@@ -178,6 +209,7 @@ engine behavior for orientation only.
 | `SinkFailureHandler` | Decide how to react when an audit sink throws. | [Audit Evidence Contract](audit-evidence-contract.md#sink-failure-handler) |
 | `SinkFailureDecision` | Enum of sink failure outcomes (`Swallow`, `RetryInline`, `Halt`, `Queue`, `DeadLetter`). `Queue` and `DeadLetter` added in v0.5.0 alongside the audit outbox. | [Audit Evidence Contract](audit-evidence-contract.md#sink-failure-handler) |
 | `AuditOutbox` | Persisted retry surface for audit evidence that failed to emit. Drained by `swarm:relay --type=audit`. (v0.5.0+) | [Audit Evidence Contract](audit-evidence-contract.md#audit-outbox) |
+| `ReadableAuditOutbox` | Non-mutating, display-decrypted read-only view of the audit outbox for health surfaces (`pending()`, `deadLettered()`, `healthSummary()`, `isAvailable()`). Pure SELECT — coexists with the drainer, never consumes rows. The read counterpart to `AuditOutbox::drain()`. (v0.19.0+) | [Audit Evidence Contract](audit-evidence-contract.md#audit-outbox) |
 | `Enums\RelayLane` | Enum naming the outbox lane a `swarm:relay` invocation drains. Cases: `Durable` (`durable`) and `Audit` (`audit`); the `Audit` value is the `swarm:relay --type=audit` keyword. Extensible for future lanes. (v0.16.0+) | [Audit Evidence Contract](audit-evidence-contract.md#audit-outbox) |
 | `Enums\DurableDispatchType` | Enum of the durable-run dispatch kinds persisted in the `swarm_durable_outbox` `dispatch_type` column and accepted by `swarm:relay --type=…`. Cases: `Step` (`step`), `Branch` (`branch`), `QueuedResume` (`queued_resume`). The string values are a persisted contract and never change. (v0.16.0+) | [Audit Evidence Contract](audit-evidence-contract.md#audit-outbox) |
 | `Enums\OutboxDispatchType` | **Deprecated since v0.16.0** — split into `RelayLane` (the lane) + `DurableDispatchType` (the durable dispatch kind) because its `Audit` case never reached the durable dispatcher. Retained unchanged for backward compatibility; scheduled for removal in a future major release. See [Upgrading to v0.16.0](../UPGRADING.md#upgrading-to-v0160). | [Audit Evidence Contract](audit-evidence-contract.md#audit-outbox) |

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,6 +15,7 @@ parameters:
         -
             identifier: property.notFound
             paths:
+                - src/Persistence/DatabaseAuditOutbox.php
                 - src/Persistence/DatabaseDurableOutbox.php
                 - src/Persistence/DatabaseDurableRunStore.php
                 - src/Persistence/DatabaseRunHistoryStore.php

--- a/src/Audit/NoOpAuditOutbox.php
+++ b/src/Audit/NoOpAuditOutbox.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BuiltByBerry\LaravelSwarm\Audit;
 
 use BuiltByBerry\LaravelSwarm\Contracts\AuditOutbox;
+use BuiltByBerry\LaravelSwarm\Contracts\ReadableAuditOutbox;
 use BuiltByBerry\LaravelSwarm\Exceptions\SwarmException;
 use BuiltByBerry\LaravelSwarm\Responses\AuditDrainResult;
 
@@ -14,11 +15,13 @@ use BuiltByBerry\LaravelSwarm\Responses\AuditDrainResult;
  *
  * enqueue() silently discards. drain() reports zero work. isAvailable()
  * returns false so the dispatcher knows to degrade Queue/DeadLetter
- * decisions to log-and-swallow rather than calling enqueue here.
+ * decisions to log-and-swallow rather than calling enqueue here. The
+ * {@see ReadableAuditOutbox} health reads report an empty, unavailable
+ * outbox so a display consumer renders a clean "unavailable" empty state.
  *
  * @internal
  */
-class NoOpAuditOutbox implements AuditOutbox
+class NoOpAuditOutbox implements AuditOutbox, ReadableAuditOutbox
 {
     public function enqueue(string $category, array $payload, bool $deadLetter = false): void {}
 
@@ -30,6 +33,27 @@ class NoOpAuditOutbox implements AuditOutbox
     public function isAvailable(): bool
     {
         return false;
+    }
+
+    public function pending(int $limit = 100): array
+    {
+        return [];
+    }
+
+    public function deadLettered(int $limit = 100): array
+    {
+        return [];
+    }
+
+    public function healthSummary(): array
+    {
+        return [
+            'available' => false,
+            'pending' => 0,
+            'dead_letter' => 0,
+            'reserved' => 0,
+            'oldest_pending_at' => null,
+        ];
     }
 
     public function assertReady(): void

--- a/src/Contracts/InspectsDurableRuns.php
+++ b/src/Contracts/InspectsDurableRuns.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Contracts;
+
+use BuiltByBerry\LaravelSwarm\Responses\DurableRunDetail;
+
+/**
+ * Public, read-only inspection seam over a durable run's persisted state, for
+ * companion packages and external readers that DISPLAY run data (a Filament
+ * panel, an MCP server, a custom dashboard).
+ *
+ * This is the supported way to read assembled durable-run detail from outside
+ * core. It is the read-only counterpart to {@see SwarmOperator} (which owns the
+ * write/control verbs — pause/resume/cancel/signal/recover): a free, read-only
+ * consumer binds THIS contract and never the control surface.
+ *
+ * ## Display-decrypt contract
+ *
+ * Every read here is DISPLAY-decrypted: sealed fields are opened through the
+ * evidence path that honors `swarm.persistence.decrypt_failure_policy`, and —
+ * unlike the operational resume reads on {@see DurableRunStore} (which decrypt
+ * strictly and throw on a wrong/rotated `APP_KEY`) — a field that cannot be
+ * decrypted here degrades to `null` with an explicit availability flag rather
+ * than throwing. One undecryptable row never aborts the batch and never 500s a
+ * display surface. See {@see DurableRunDetail} for the per-row shape.
+ *
+ * Consumers MUST bind this contract, never the `@internal` concrete inspector
+ * or the `@internal` `SwarmPersistenceCipher`. The default binding resolves the
+ * shipped database-backed inspector.
+ */
+interface InspectsDurableRuns
+{
+    /**
+     * The durable run row for a run, or null when unknown. Never decrypts (the
+     * run row carries no sealed input/output), so it never degrades.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function find(string $runId): ?array;
+
+    /**
+     * Assemble the full display-decrypted detail for a run: the run row, its run
+     * history, labels, details, waits, signals, progress, child runs, parallel
+     * branches, and hierarchical node outputs. Throws when the run is unknown.
+     */
+    public function inspect(string $runId): DurableRunDetail;
+
+    /**
+     * Inspect every run currently carrying the given labels, newest bound first.
+     *
+     * @param  array<string, bool|int|float|string|null>  $labels
+     * @return array<int, DurableRunDetail>
+     */
+    public function inspectByLabels(array $labels, int $limit = 50): array;
+}

--- a/src/Contracts/ReadableAuditOutbox.php
+++ b/src/Contracts/ReadableAuditOutbox.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Contracts;
+
+/**
+ * Public, read-only health seam over the audit outbox — the persisted retry
+ * buffer that holds audit evidence which failed to emit through the bound
+ * {@see SwarmAuditSink}.
+ *
+ * This is the non-mutating counterpart to {@see AuditOutbox::drain()}, which
+ * RESERVES and CONSUMES rows for re-delivery. A display consumer (a Filament
+ * outbox-health card, an MCP audit reader) that called drain() would destroy
+ * audit evidence out from under the real `swarm:relay --type=audit` drainer.
+ * Every read here is a pure SELECT: it never writes `reserved_at`, never
+ * deletes, and never contends with a concurrent drainer.
+ *
+ * ## Display-decrypt contract
+ *
+ * Outbox `payload` and `last_error` are sealed at rest. They are read here
+ * through the evidence path that honors `swarm.persistence.decrypt_failure_policy`
+ * and degrades per row: a value that cannot be decrypted becomes `null` with an
+ * explicit availability flag rather than throwing or leaking `sw0:` ciphertext.
+ * One poison row never aborts the batch and never 500s a health surface.
+ *
+ * Consumers MUST bind this contract, never the `@internal` concrete outbox or
+ * the `@internal` `SwarmPersistenceCipher`. The default binding resolves the
+ * database-backed outbox when the persistence driver supports it, and a no-op
+ * (reporting an empty, unavailable outbox) otherwise — mirroring how
+ * {@see AuditOutbox} itself is bound.
+ *
+ * This contract governs the outbox RETRY BUFFER only. The full audit TRAIL —
+ * every evidence record a run emitted — is served by an application's own
+ * {@see ReadableSwarmAuditSink} implementation; core's default sink stores
+ * nothing, so a trail surface requires the app to bind a readable sink.
+ */
+interface ReadableAuditOutbox
+{
+    /**
+     * Whether the outbox is backed by a working store. False in cache
+     * persistence mode and when the `swarm_audit_outbox` table is missing;
+     * a display surface should render an "outbox unavailable" empty state.
+     */
+    public function isAvailable(): bool;
+
+    /**
+     * Rows still pending re-delivery, newest first, display-decrypted per row.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function pending(int $limit = 100): array;
+
+    /**
+     * Rows that exhausted `swarm.audit.outbox.max_attempts` and moved to the
+     * dead-letter status, newest first, display-decrypted per row.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function deadLettered(int $limit = 100): array;
+
+    /**
+     * A non-mutating health summary: row counts by status, the number of rows
+     * currently reserved by a drainer, and the oldest pending timestamp. No
+     * decryption — counts and timestamps only.
+     *
+     * @return array{available: bool, pending: int, dead_letter: int, reserved: int, oldest_pending_at: ?string}
+     */
+    public function healthSummary(): array;
+}

--- a/src/Persistence/DatabaseAuditOutbox.php
+++ b/src/Persistence/DatabaseAuditOutbox.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BuiltByBerry\LaravelSwarm\Persistence;
 
 use BuiltByBerry\LaravelSwarm\Contracts\AuditOutbox;
+use BuiltByBerry\LaravelSwarm\Contracts\ReadableAuditOutbox;
 use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
 use BuiltByBerry\LaravelSwarm\Exceptions\SwarmException;
 use BuiltByBerry\LaravelSwarm\Responses\AuditDrainResult;
@@ -29,7 +30,7 @@ use Throwable;
  *
  * @internal
  */
-class DatabaseAuditOutbox implements AuditOutbox
+class DatabaseAuditOutbox implements AuditOutbox, ReadableAuditOutbox
 {
     use SafeReporting;
 
@@ -312,6 +313,115 @@ class DatabaseAuditOutbox implements AuditOutbox
                 .'switch to a different failure policy.'
             );
         }
+    }
+
+    public function pending(int $limit = 100): array
+    {
+        return $this->readRows('pending', $limit);
+    }
+
+    public function deadLettered(int $limit = 100): array
+    {
+        return $this->readRows('dead_letter', $limit);
+    }
+
+    public function healthSummary(): array
+    {
+        if (! $this->isAvailable()) {
+            return [
+                'available' => false,
+                'pending' => 0,
+                'dead_letter' => 0,
+                'reserved' => 0,
+                'oldest_pending_at' => null,
+            ];
+        }
+
+        $reservationTimeoutSeconds = (int) $this->config->get('swarm.durable.relay.reservation_timeout_seconds', 60);
+        $freshThreshold = Carbon::now('UTC')->subSeconds($reservationTimeoutSeconds);
+
+        $pending = (int) $this->table()->where('status', 'pending')->count();
+        $deadLetter = (int) $this->table()->where('status', 'dead_letter')->count();
+        $reserved = (int) $this->table()
+            ->where('status', 'pending')
+            ->whereNotNull('reserved_at')
+            ->where('reserved_at', '>=', $freshThreshold)
+            ->count();
+        $oldestPendingAt = $this->table()
+            ->where('status', 'pending')
+            ->min('created_at');
+
+        return [
+            'available' => true,
+            'pending' => $pending,
+            'dead_letter' => $deadLetter,
+            'reserved' => $reserved,
+            'oldest_pending_at' => $oldestPendingAt !== null ? (string) $oldestPendingAt : null,
+        ];
+    }
+
+    /**
+     * Pure-SELECT read of outbox rows by status, newest first, display-decrypted
+     * per row. Never writes `reserved_at` and never deletes, so it coexists with a
+     * concurrent `swarm:relay --type=audit` drainer instead of stealing its rows
+     * (record 632).
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function readRows(string $status, int $limit): array
+    {
+        if (! $this->isAvailable()) {
+            return [];
+        }
+
+        return $this->table()
+            ->where('status', $status)
+            ->orderByDesc('id')
+            ->limit(max(1, $limit))
+            ->get()
+            ->map(fn (object $record): array => $this->mapRow($record))
+            ->all();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function mapRow(object $record): array
+    {
+        [$lastError, $lastErrorAvailable] = $this->cipher->openForDisplay(
+            $record->last_error === null ? null : (string) $record->last_error,
+        );
+
+        [$rawPayload, $payloadAvailable] = $this->cipher->openForDisplay(
+            $record->payload === null ? null : (string) $record->payload,
+        );
+
+        $payload = null;
+
+        if ($payloadAvailable && is_string($rawPayload)) {
+            $decoded = json_decode($rawPayload, true);
+            if (is_array($decoded)) {
+                $payload = $decoded;
+            } else {
+                $payloadAvailable = false;
+            }
+        }
+
+        return [
+            'id' => (int) $record->id,
+            'category' => $record->category,
+            'run_id' => $record->run_id,
+            'status' => $record->status,
+            'attempts' => (int) $record->attempts,
+            'last_error' => $lastError,
+            'last_error_available' => $lastErrorAvailable,
+            'payload' => $payload,
+            'payload_available' => $payloadAvailable,
+            'reserved_at' => $record->reserved_at ?? null,
+            'last_attempted_at' => $record->last_attempted_at ?? null,
+            'created_at' => $record->created_at,
+            'updated_at' => $record->updated_at,
+        ];
     }
 
     protected function table(): Builder

--- a/src/Persistence/DatabaseDurableRunStore.php
+++ b/src/Persistence/DatabaseDurableRunStore.php
@@ -499,6 +499,40 @@ class DatabaseDurableRunStore implements DurableRunStore
             ->all();
     }
 
+    /**
+     * Evidence/display hierarchical node-output read (concrete-only, used by
+     * DurableRunInspector): returns EVERY node output persisted for a run,
+     * per-row display-decrypted. Where the operational {@see hierarchicalNodeOutputsFor()}
+     * decrypts strictly (throws on a rotated key, because a resume folds the
+     * output into a downstream prompt) and takes an explicit node-id list, this
+     * degrades an undecryptable output to null + `output_available=false` and
+     * lists the whole run, so a display surface never 500s. Intentionally NOT on
+     * the DurableRunStore contract — reached through {@see InspectsDurableRuns}.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function hierarchicalNodeOutputsForInspection(string $runId): array
+    {
+        return $this->nodeOutputTable()
+            ->where('run_id', $runId)
+            ->orderBy('id')
+            ->get()
+            ->map(function (object $record): array {
+                [$output, $available] = $this->cipher->openForDisplay($record->output === null ? null : (string) $record->output);
+
+                return [
+                    'run_id' => $record->run_id,
+                    'node_id' => $record->node_id,
+                    'output' => $output,
+                    'output_available' => $available,
+                    'expires_at' => $record->expires_at ?? null,
+                    'created_at' => $record->created_at ?? null,
+                    'updated_at' => $record->updated_at ?? null,
+                ];
+            })
+            ->all();
+    }
+
     public function storeHierarchicalNodeOutput(string $runId, string $nodeId, string $output, int $ttlSeconds): void
     {
         $timestamp = Carbon::now('UTC');
@@ -635,16 +669,19 @@ class DatabaseDurableRunStore implements DurableRunStore
     }
 
     /**
-     * Evidence/display branch read (concrete-only, used by DurableRunInspector): honors
-     * swarm.persistence.decrypt_failure_policy — the policy-aware twin of the now-strict
-     * operational branchesFor(). Intentionally not on the DurableRunStore contract.
+     * Evidence/display branch read (concrete-only, used by DurableRunInspector): the
+     * per-row-degrading display twin of the now-strict operational branchesFor().
+     * Each branch's input/output decrypt via {@see openForDisplay()} and carry an
+     * `*_available` flag, so an undecryptable row degrades to null rather than
+     * throwing or leaking ciphertext (record 632). Intentionally not on the
+     * DurableRunStore contract — reached through {@see InspectsDurableRuns}.
      *
      * @return array<int, array<string, mixed>>
      */
     public function branchesForInspection(string $runId, ?string $parentNodeId = null): array
     {
         return $this->branchRowsFor($runId, $parentNodeId)
-            ->map(fn (object $record): array => $this->mapBranch($record, strict: false))
+            ->map(fn (object $record): array => $this->mapBranchForDisplay($record))
             ->all();
     }
 
@@ -1917,16 +1954,19 @@ class DatabaseDurableRunStore implements DurableRunStore
     }
 
     /**
-     * Evidence/display child-run read (concrete-only, used by DurableRunInspector): honors
-     * swarm.persistence.decrypt_failure_policy — the policy-aware twin of the now-strict
-     * operational childRuns(). Intentionally not on the DurableRunStore contract.
+     * Evidence/display child-run read (concrete-only, used by DurableRunInspector): the
+     * per-row-degrading display twin of the operational childRuns(). Each child's
+     * context input/output decrypt via the display helpers and carry an `*_available`
+     * flag, so an undecryptable child degrades to null rather than throwing or leaking
+     * ciphertext (record 632). Intentionally not on the DurableRunStore contract —
+     * reached through {@see InspectsDurableRuns}.
      *
      * @return array<int, array<string, mixed>>
      */
     public function childRunsForInspection(string $runId): array
     {
         return $this->childRunRowsFor($runId)
-            ->map(fn (object $record): array => $this->mapChildRun($record, strict: false))
+            ->map(fn (object $record): array => $this->mapChildRunForDisplay($record))
             ->all();
     }
 
@@ -2650,9 +2690,65 @@ class DatabaseDurableRunStore implements DurableRunStore
     }
 
     /**
+     * Display-safe decrypt of a child run's nested context payload: opens the
+     * top-level input key through the policy-aware path, then masks it to null
+     * with availability=false if it threw or came back still-sealed. Never throws.
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array{0: array<string, mixed>, 1: bool}
+     */
+    private function openChildContextForDisplay(array $payload): array
+    {
+        try {
+            $opened = $this->cipher->openContextTopLevelInput($payload);
+        } catch (DecryptException) {
+            $payload['input'] = null;
+
+            return [$payload, false];
+        }
+
+        $input = $opened['input'] ?? null;
+
+        if (is_string($input) && str_starts_with($input, SwarmPersistenceCipher::PREFIX)) {
+            $opened['input'] = null;
+
+            return [$opened, false];
+        }
+
+        return [$opened, true];
+    }
+
+    /**
+     * Policy-aware, per-row-degrading display twin of {@see mapBranch()}. Carries
+     * the same non-sealed fields, but `input`/`output` decrypt via
+     * {@see SwarmPersistenceCipher::openForDisplay()} and each gains an
+     * `*_available` flag so a consumer can render "unavailable" for a row that
+     * failed to decrypt without losing the rest of the batch.
+     *
      * @return array<string, mixed>
      */
-    protected function mapBranch(object $record, bool $strict = true): array
+    protected function mapBranchForDisplay(object $record): array
+    {
+        $branch = $this->mapBranchBaseFields($record);
+
+        [$input, $inputAvailable] = $this->cipher->openForDisplay($record->input === null ? null : (string) $record->input);
+        [$output, $outputAvailable] = $this->cipher->openForDisplay($record->output === null ? null : (string) $record->output);
+
+        $branch['input'] = $input;
+        $branch['input_available'] = $inputAvailable;
+        $branch['output'] = $output;
+        $branch['output_available'] = $outputAvailable;
+
+        return $branch;
+    }
+
+    /**
+     * The non-sealed branch fields shared by {@see mapBranch()} and
+     * {@see mapBranchForDisplay()} — everything except `input`/`output`.
+     *
+     * @return array<string, mixed>
+     */
+    private function mapBranchBaseFields(object $record): array
     {
         return [
             'run_id' => $record->run_id,
@@ -2662,19 +2758,6 @@ class DatabaseDurableRunStore implements DurableRunStore
             'agent_class' => $record->agent_class,
             'parent_node_id' => $record->parent_node_id,
             'status' => $record->status,
-            // Branch input + output are operational resume state: the input is the
-            // re-dispatch prompt and the output is folded into the parallel-join
-            // prompt. On the operational ($strict) path they must decrypt-or-throw
-            // so a wrong/rotated APP_KEY fails the resume loudly (#212) rather than
-            // feeding null/ciphertext downstream; the inspection path keeps open().
-            'input' => $strict
-                ? $this->openStrictOrFail((string) $record->input, 'branch input', (string) $record->run_id, "branch [{$record->branch_id}]")
-                : $this->cipher->open((string) $record->input),
-            'output' => $record->output === null
-                ? null
-                : ($strict
-                    ? $this->openStrictOrFail((string) $record->output, 'branch output', (string) $record->run_id, "branch [{$record->branch_id}]")
-                    : $this->cipher->open((string) $record->output)),
             'usage' => $this->decodeJson($record->usage ?? null, []),
             'metadata' => $this->decodeJson($record->metadata ?? null, []),
             'failure' => $this->decodeJson($record->failure ?? null, null),
@@ -2695,6 +2778,30 @@ class DatabaseDurableRunStore implements DurableRunStore
             'created_at' => $record->created_at,
             'updated_at' => $record->updated_at,
         ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function mapBranch(object $record, bool $strict = true): array
+    {
+        $branch = $this->mapBranchBaseFields($record);
+
+        // Branch input + output are operational resume state: the input is the
+        // re-dispatch prompt and the output is folded into the parallel-join
+        // prompt. On the operational ($strict) path they must decrypt-or-throw
+        // so a wrong/rotated APP_KEY fails the resume loudly (#212) rather than
+        // feeding null/ciphertext downstream; the inspection path keeps open().
+        $branch['input'] = $strict
+            ? $this->openStrictOrFail((string) $record->input, 'branch input', (string) $record->run_id, "branch [{$record->branch_id}]")
+            : $this->cipher->open((string) $record->input);
+        $branch['output'] = $record->output === null
+            ? null
+            : ($strict
+                ? $this->openStrictOrFail((string) $record->output, 'branch output', (string) $record->run_id, "branch [{$record->branch_id}]")
+                : $this->cipher->open((string) $record->output));
+
+        return $branch;
     }
 
     /**
@@ -2782,25 +2889,65 @@ class DatabaseDurableRunStore implements DurableRunStore
      */
     protected function mapChildRun(object $record, bool $strict = true): array
     {
+        $child = $this->mapChildRunBaseFields($record);
+
+        // context_payload is operational child-resume input (RunContext::fromPayload
+        // on re-dispatch), so the operational ($strict) path decrypts-or-throws (#212).
+        $child['context_payload'] = $this->openChildContextOrFail(
+            $this->decodeJson($record->context_payload ?? null, []),
+            $strict,
+            (string) $record->child_run_id,
+        );
+        // Child output is read ONLY by the inspector (evidence) — no operational
+        // caller consumes it (the terminal output reaches the parent via the
+        // in-flight event argument, not this DB read). So it stays policy-aware on
+        // every path; making it strict would add a failure mode with no benefit.
+        // This asymmetry with branch output is deliberate — do not "fix" it.
+        $child['output'] = $record->output !== null ? $this->cipher->open((string) $record->output) : null;
+
+        return $child;
+    }
+
+    /**
+     * Policy-aware, per-row-degrading display twin of {@see mapChildRun()}: the
+     * nested context input and the child output decrypt via the display helpers
+     * ({@see openChildContextForDisplay()} / {@see openForDisplay()}) and each
+     * gains an `*_available` flag, so one undecryptable child never aborts the
+     * batch or 500s a display surface (record 632).
+     *
+     * @return array<string, mixed>
+     */
+    protected function mapChildRunForDisplay(object $record): array
+    {
+        $child = $this->mapChildRunBaseFields($record);
+
+        [$context, $contextAvailable] = $this->openChildContextForDisplay(
+            $this->decodeJson($record->context_payload ?? null, []),
+        );
+        [$output, $outputAvailable] = $this->cipher->openForDisplay($record->output === null ? null : (string) $record->output);
+
+        $child['context_payload'] = $context;
+        $child['context_available'] = $contextAvailable;
+        $child['output'] = $output;
+        $child['output_available'] = $outputAvailable;
+
+        return $child;
+    }
+
+    /**
+     * The non-sealed child-run fields shared by {@see mapChildRun()} and
+     * {@see mapChildRunForDisplay()} — everything except `context_payload`/`output`.
+     *
+     * @return array<string, mixed>
+     */
+    private function mapChildRunBaseFields(object $record): array
+    {
         return [
             'parent_run_id' => $record->parent_run_id,
             'child_run_id' => $record->child_run_id,
             'child_swarm_class' => $record->child_swarm_class,
             'wait_name' => $record->wait_name,
-            // context_payload is operational child-resume input (RunContext::fromPayload
-            // on re-dispatch), so the operational ($strict) path decrypts-or-throws (#212).
-            'context_payload' => $this->openChildContextOrFail(
-                $this->decodeJson($record->context_payload ?? null, []),
-                $strict,
-                (string) $record->child_run_id,
-            ),
             'status' => $record->status,
-            // Child output is read ONLY by the inspector (evidence) — no operational
-            // caller consumes it (the terminal output reaches the parent via the
-            // in-flight event argument, not this DB read). So it stays policy-aware on
-            // every path; making it strict would add a failure mode with no benefit.
-            // This asymmetry with branch output (above) is deliberate — do not "fix" it.
-            'output' => $record->output !== null ? $this->cipher->open((string) $record->output) : null,
             'failure' => $this->decodeJson($record->failure ?? null, null),
             'dispatched_at' => $record->dispatched_at ?? null,
             'terminal_event_dispatched_at' => $record->terminal_event_dispatched_at ?? null,

--- a/src/Persistence/DatabaseDurableRunStore.php
+++ b/src/Persistence/DatabaseDurableRunStore.php
@@ -2690,32 +2690,28 @@ class DatabaseDurableRunStore implements DurableRunStore
     }
 
     /**
-     * Display-safe decrypt of a child run's nested context payload: opens the
-     * top-level input key through the policy-aware path, then masks it to null
-     * with availability=false if it threw or came back still-sealed. Never throws.
+     * Display-safe decrypt of a child run's nested context payload. The only
+     * sealed member is the top-level `input` key ({@see SwarmPersistenceCipher::sealContextTopLevelInput()});
+     * it is opened through {@see SwarmPersistenceCipher::openForDisplay()} so an
+     * undecryptable input degrades to null + availability=false regardless of
+     * policy — never throwing, never leaking ciphertext. A payload with no sealed
+     * input is available by definition.
      *
      * @param  array<string, mixed>  $payload
      * @return array{0: array<string, mixed>, 1: bool}
      */
     private function openChildContextForDisplay(array $payload): array
     {
-        try {
-            $opened = $this->cipher->openContextTopLevelInput($payload);
-        } catch (DecryptException) {
-            $payload['input'] = null;
+        $rawInput = $payload['input'] ?? null;
 
-            return [$payload, false];
+        if (! is_string($rawInput)) {
+            return [$payload, true];
         }
 
-        $input = $opened['input'] ?? null;
+        [$plain, $available] = $this->cipher->openForDisplay($rawInput);
+        $payload['input'] = $plain;
 
-        if (is_string($input) && str_starts_with($input, SwarmPersistenceCipher::PREFIX)) {
-            $opened['input'] = null;
-
-            return [$opened, false];
-        }
-
-        return [$opened, true];
+        return [$payload, $available];
     }
 
     /**

--- a/src/Persistence/SwarmPersistenceCipher.php
+++ b/src/Persistence/SwarmPersistenceCipher.php
@@ -137,6 +137,41 @@ class SwarmPersistenceCipher
     }
 
     /**
+     * Display-safe decrypt for a read-only inspection/display consumer. Where
+     * {@see open()} can THROW under `decrypt_failure_policy=throw` and surfaces
+     * raw `sw0:` ciphertext under the `legacy` policy, this NEVER throws and NEVER
+     * leaks ciphertext: an undecryptable value degrades to `null` alongside an
+     * explicit availability=false flag. A display consumer that maps many rows
+     * uses this so one poison row can neither abort the batch nor 500 the page,
+     * and never has to re-implement the 3-way policy itself (record 632). The
+     * operational resume path keeps {@see openStrict()} — this is for evidence and
+     * display reads only.
+     *
+     * @return array{0: ?string, 1: bool} [plaintext or null, decrypted-cleanly]
+     */
+    public function openForDisplay(?string $value): array
+    {
+        if ($value === null || $value === '' || ! str_starts_with($value, self::PREFIX)) {
+            return [$value, true];
+        }
+
+        try {
+            $plain = $this->open($value);
+        } catch (DecryptException) {
+            // decrypt_failure_policy=throw — degrade rather than propagate.
+            return [null, false];
+        }
+
+        // null_with_log returns null and legacy returns the raw sw0: ciphertext on
+        // a decrypt failure; a still-sealed value was never actually decrypted.
+        if ($plain === null || str_starts_with($plain, self::PREFIX)) {
+            return [null, false];
+        }
+
+        return [$plain, true];
+    }
+
+    /**
      * @param  array<string, mixed>  $row
      * @return array<string, mixed>
      */

--- a/src/Responses/DurableRunDetail.php
+++ b/src/Responses/DurableRunDetail.php
@@ -16,6 +16,7 @@ class DurableRunDetail
      * @param  array<int, array<string, mixed>>  $progress
      * @param  array<int, array<string, mixed>>  $children
      * @param  array<int, array<string, mixed>>  $branches
+     * @param  array<int, array<string, mixed>>  $hierarchicalNodeOutputs
      */
     public function __construct(
         public readonly string $runId,
@@ -28,6 +29,7 @@ class DurableRunDetail
         public readonly array $progress = [],
         public readonly array $children = [],
         public readonly array $branches = [],
+        public readonly array $hierarchicalNodeOutputs = [],
     ) {}
 
     /**
@@ -46,6 +48,7 @@ class DurableRunDetail
             'progress' => $this->progress,
             'children' => $this->children,
             'branches' => $this->branches,
+            'hierarchical_node_outputs' => $this->hierarchicalNodeOutputs,
         ];
     }
 }

--- a/src/Runners/Durable/DurableRunInspector.php
+++ b/src/Runners/Durable/DurableRunInspector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Runners\Durable;
 
+use BuiltByBerry\LaravelSwarm\Contracts\InspectsDurableRuns;
 use BuiltByBerry\LaravelSwarm\Events\SwarmProgressRecorded;
 use BuiltByBerry\LaravelSwarm\Exceptions\SwarmException;
 use BuiltByBerry\LaravelSwarm\Persistence\DatabaseDurableRunStore;
@@ -12,15 +13,18 @@ use BuiltByBerry\LaravelSwarm\Responses\DurableRunDetail;
 use Illuminate\Contracts\Events\Dispatcher;
 
 /**
- * @internal
+ * @internal The class is internal; consumers bind the public {@see InspectsDurableRuns}
+ * contract, which this implements.
  *
  * Depends on the concrete {@see DatabaseDurableRunStore} (not the DurableRunStore
  * contract) because the evidence/display reads it needs — branchesForInspection() /
- * childRunsForInspection(), the policy-aware twins of the now-strict operational
- * branchesFor()/childRuns() — are intentionally NOT on the public contract. The
- * inspector reads the shipped database durable tables, so this coupling is by design.
+ * childRunsForInspection() / hierarchicalNodeOutputsForInspection(), the
+ * per-row-degrading display twins of the now-strict operational
+ * branchesFor()/childRuns()/hierarchicalNodeOutputsFor() — are intentionally NOT on
+ * the public store contract. The inspector reads the shipped database durable tables,
+ * so this coupling is by design.
  */
-class DurableRunInspector
+class DurableRunInspector implements InspectsDurableRuns
 {
     public function __construct(
         protected DatabaseDurableRunStore $durableRuns,
@@ -57,6 +61,7 @@ class DurableRunInspector
             progress: $this->durableRuns->progress($runId),
             children: $this->durableRuns->childRunsForInspection($runId),
             branches: $this->durableRuns->branchesForInspection($runId),
+            hierarchicalNodeOutputs: $this->durableRuns->hierarchicalNodeOutputsForInspection($runId),
         );
     }
 

--- a/src/SwarmServiceProvider.php
+++ b/src/SwarmServiceProvider.php
@@ -51,9 +51,11 @@ use BuiltByBerry\LaravelSwarm\Contracts\ContextStore;
 use BuiltByBerry\LaravelSwarm\Contracts\ConversationRunResolver;
 use BuiltByBerry\LaravelSwarm\Contracts\DurableOutbox;
 use BuiltByBerry\LaravelSwarm\Contracts\DurableRunStore;
+use BuiltByBerry\LaravelSwarm\Contracts\InspectsDurableRuns;
 use BuiltByBerry\LaravelSwarm\Contracts\MemoryCapturePolicy;
 use BuiltByBerry\LaravelSwarm\Contracts\MemoryPropagationPolicy;
 use BuiltByBerry\LaravelSwarm\Contracts\MemoryStore;
+use BuiltByBerry\LaravelSwarm\Contracts\ReadableAuditOutbox;
 use BuiltByBerry\LaravelSwarm\Contracts\RunHistoryStore;
 use BuiltByBerry\LaravelSwarm\Contracts\SinkFailureHandler;
 use BuiltByBerry\LaravelSwarm\Contracts\SnapshotsMemory;
@@ -105,6 +107,7 @@ use BuiltByBerry\LaravelSwarm\Runners\Durable\DurableNodeStreamRecorder;
 use BuiltByBerry\LaravelSwarm\Runners\Durable\DurablePayloadCapture;
 use BuiltByBerry\LaravelSwarm\Runners\Durable\DurableRecoveryCoordinator;
 use BuiltByBerry\LaravelSwarm\Runners\Durable\DurableRunContext;
+use BuiltByBerry\LaravelSwarm\Runners\Durable\DurableRunInspector;
 use BuiltByBerry\LaravelSwarm\Runners\Durable\DurableRunTerminalHandler;
 use BuiltByBerry\LaravelSwarm\Runners\Durable\DurableSequentialStepAdvancer;
 use BuiltByBerry\LaravelSwarm\Runners\Durable\DurableStepAdvancer;
@@ -202,6 +205,15 @@ class SwarmServiceProvider extends ServiceProvider
             return $driver === 'database'
                 ? $app->make(DatabaseAuditOutbox::class)
                 : $app->make(NoOpAuditOutbox::class);
+        });
+        // Public read-only outbox-health seam for companions/external readers. The
+        // bound AuditOutbox instance (database or no-op) already implements it, so
+        // resolve the same instance rather than a second copy.
+        $this->app->singleton(ReadableAuditOutbox::class, function (Application $app): ReadableAuditOutbox {
+            $outbox = $app->make(AuditOutbox::class);
+            assert($outbox instanceof ReadableAuditOutbox);
+
+            return $outbox;
         });
         $this->app->singleton(SwarmAuditDispatcher::class, function (Application $app): SwarmAuditDispatcher {
             return new SwarmAuditDispatcher(
@@ -303,6 +315,11 @@ class SwarmServiceProvider extends ServiceProvider
         // Public operator control contract (#329). A thin, stateless adapter over
         // the @internal manager; safe as a shared singleton under Octane.
         $this->app->singleton(SwarmOperator::class, DurableSwarmOperator::class);
+        // Public read-only durable-inspection contract for companions/external
+        // readers. Read-only counterpart to SwarmOperator: display-decrypted,
+        // per-row-degrading reads (record 632), never the control verbs. Backed by
+        // the database inspector (durable state is DB-only).
+        $this->app->singleton(InspectsDurableRuns::class, DurableRunInspector::class);
         $this->app->singleton(DurableRunStore::class, DatabaseDurableRunStore::class);
         $this->app->singleton(DurableOutbox::class, DatabaseDurableOutbox::class);
 

--- a/tests/Feature/DatabasePersistenceTest.php
+++ b/tests/Feature/DatabasePersistenceTest.php
@@ -20,7 +20,6 @@ use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\FakeEditor;
 use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\FakeResearcher;
 use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\FakeWriter;
 use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\FakeSequentialSwarm;
-use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
@@ -1629,7 +1628,7 @@ test('childRunForChild fails loud with SwarmException on an undecryptable contex
         ->toThrow(SwarmException::class, 'verify APP_KEY');
 });
 
-test('inspector branch read honors decrypt_failure_policy on an undecryptable input (#212)', function (string $policy, $assert) {
+test('inspector branch read degrades an undecryptable input per row under every policy (record 632)', function (string $policy) {
     config()->set('swarm.persistence.encrypt_at_rest', true);
     config()->set('swarm.persistence.decrypt_failure_policy', $policy);
     $store = freshDurableRunStore();
@@ -1638,20 +1637,16 @@ test('inspector branch read honors decrypt_failure_policy on an undecryptable in
     insertDurableRunRow($runId);
     insertDurableBranchRow($runId, 'parallel:researcher', undecryptableSealedValue());
 
-    $assert($store, $runId);
-})->with([
-    'null_with_log returns null' => ['null_with_log', function (DatabaseDurableRunStore $store, string $runId) {
-        expect($store->branchesForInspection($runId)[0]['input'])->toBeNull();
-    }],
-    'legacy surfaces ciphertext' => ['legacy', function (DatabaseDurableRunStore $store, string $runId) {
-        expect($store->branchesForInspection($runId)[0]['input'])->toStartWith('sw0:');
-    }],
-    'throw rethrows the raw DecryptException' => ['throw', function (DatabaseDurableRunStore $store, string $runId) {
-        expect(fn () => $store->branchesForInspection($runId))->toThrow(DecryptException::class);
-    }],
-]);
+    // The display read degrades per row whatever the operator policy: it never
+    // throws (unlike open() under `throw`) and never leaks the sw0: ciphertext
+    // (unlike open() under `legacy`) — the field is null + input_available=false.
+    $branch = $store->branchesForInspection($runId)[0];
 
-test('inspector child read honors null_with_log policy on an undecryptable context payload (#212)', function () {
+    expect($branch['input'])->toBeNull()
+        ->and($branch['input_available'])->toBeFalse();
+})->with(['null_with_log', 'legacy', 'throw']);
+
+test('inspector child read degrades an undecryptable context payload per row (record 632)', function () {
     config()->set('swarm.persistence.encrypt_at_rest', true);
     config()->set('swarm.persistence.decrypt_failure_policy', 'null_with_log');
     $store = freshDurableRunStore();
@@ -1661,7 +1656,10 @@ test('inspector child read honors null_with_log policy on an undecryptable conte
     insertDurableRunRow($parentRunId);
     insertDurableChildRunRow($parentRunId, $childRunId, json_encode(['input' => undecryptableSealedValue()]));
 
-    expect($store->childRunsForInspection($parentRunId)[0]['context_payload']['input'])->toBeNull();
+    $child = $store->childRunsForInspection($parentRunId)[0];
+
+    expect($child['context_payload']['input'])->toBeNull()
+        ->and($child['context_available'])->toBeFalse();
 });
 
 test('strict durable reads round-trip a value that legitimately starts with the sealed prefix (#212)', function () {
@@ -1700,11 +1698,15 @@ test('strict and inspection reads on the same store instance do not interfere (#
     insertDurableRunRow($runId);
     insertDurableBranchRow($runId, 'parallel:researcher', undecryptableSealedValue());
 
-    // Strict op throws; the subsequent policy-aware inspection read on the SAME instance
-    // still surfaces ciphertext under the legacy policy — the strict path never mutated
-    // policy resolution (no shared mutable state).
+    // Strict op throws; the subsequent display inspection read on the SAME instance
+    // DEGRADES (null + input_available=false, never the sw0: ciphertext even under
+    // the legacy policy) — the strict path never mutated policy resolution and the
+    // two paths stay divergent (no shared mutable state).
     expect(fn () => $store->findBranch($runId, 'parallel:researcher'))->toThrow(SwarmException::class, 'verify APP_KEY');
-    expect($store->branchesForInspection($runId)[0]['input'])->toStartWith('sw0:');
+
+    $branch = $store->branchesForInspection($runId)[0];
+    expect($branch['input'])->toBeNull()
+        ->and($branch['input_available'])->toBeFalse();
 });
 
 test('contextStore find fails loud with SwarmException on an undecryptable resume input (#212)', function () {

--- a/tests/Feature/Persistence/DisplayReadSeamsTest.php
+++ b/tests/Feature/Persistence/DisplayReadSeamsTest.php
@@ -23,7 +23,7 @@ use Psr\Log\NullLogger;
  */
 
 /** A sealed sw0: value encrypted under a foreign key — undecryptable here. */
-function poisonCiphertext(string $plaintext = 'unreadable'): string
+function displaySeamsPoison(string $plaintext = 'unreadable'): string
 {
     $foreign = new SwarmPersistenceCipher(
         new Repository(['swarm.persistence.encrypt_at_rest' => true, 'swarm.persistence.driver' => 'database']),
@@ -34,7 +34,7 @@ function poisonCiphertext(string $plaintext = 'unreadable'): string
     return (string) $foreign->seal($plaintext);
 }
 
-function seedDurableRun(string $runId): void
+function displaySeamsSeedRun(string $runId): void
 {
     $now = now('UTC');
 
@@ -81,7 +81,7 @@ function seedDurableRun(string $runId): void
     ]);
 }
 
-function useDatabasePersistence(): void
+function displaySeamsUseDatabase(): void
 {
     config()->set('swarm.persistence.driver', 'database');
     config()->set('swarm.persistence.encrypt_at_rest', true);
@@ -97,7 +97,7 @@ test('ReadableAuditOutbox binds the database outbox in database mode and the no-
 
     expect(app(ReadableAuditOutbox::class))->toBeInstanceOf(NoOpAuditOutbox::class);
 
-    useDatabasePersistence();
+    displaySeamsUseDatabase();
 
     expect(app(ReadableAuditOutbox::class))->toBeInstanceOf(DatabaseAuditOutbox::class)
         // Same instance as the AuditOutbox binding, not a second copy.
@@ -128,7 +128,7 @@ test('no-op outbox health reports an empty, unavailable outbox', function () {
 });
 
 test('outbox health reads display-decrypt rows and never consume them', function () {
-    useDatabasePersistence();
+    displaySeamsUseDatabase();
 
     /** @var DatabaseAuditOutbox $outbox */
     $outbox = app(ReadableAuditOutbox::class);
@@ -165,7 +165,7 @@ test('outbox health reads display-decrypt rows and never consume them', function
 });
 
 test('outbox health degrades a poison row instead of throwing under the throw policy', function () {
-    useDatabasePersistence();
+    displaySeamsUseDatabase();
     config()->set('swarm.persistence.decrypt_failure_policy', 'throw');
 
     /** @var DatabaseAuditOutbox $outbox */
@@ -176,7 +176,7 @@ test('outbox health degrades a poison row instead of throwing under the throw po
 
     // Corrupt the newest row's sealed payload to a foreign-key blob.
     $poisonId = DB::table('swarm_audit_outbox')->where('run_id', 'bad')->value('id');
-    DB::table('swarm_audit_outbox')->where('id', $poisonId)->update(['payload' => poisonCiphertext()]);
+    DB::table('swarm_audit_outbox')->where('id', $poisonId)->update(['payload' => displaySeamsPoison()]);
 
     $pending = collect($outbox->pending())->keyBy('run_id');
 
@@ -187,13 +187,13 @@ test('outbox health degrades a poison row instead of throwing under the throw po
 });
 
 test('hierarchical node output display read degrades a poison node without aborting the batch', function () {
-    useDatabasePersistence();
+    displaySeamsUseDatabase();
     config()->set('swarm.persistence.decrypt_failure_policy', 'throw');
 
     /** @var DatabaseDurableRunStore $store */
     $store = app(DatabaseDurableRunStore::class);
     $runId = 'hier-display-1';
-    seedDurableRun($runId);
+    displaySeamsSeedRun($runId);
 
     // A cleanly sealed node output under the app key.
     $store->storeHierarchicalNodeOutput($runId, 'node-a', 'output A', 3600);
@@ -203,7 +203,7 @@ test('hierarchical node output display read degrades a poison node without abort
     DB::table('swarm_durable_node_outputs')->insert([
         'run_id' => $runId,
         'node_id' => 'node-b',
-        'output' => poisonCiphertext('output B'),
+        'output' => displaySeamsPoison('output B'),
         'expires_at' => $now->copy()->addHour(),
         'created_at' => $now,
         'updated_at' => $now,

--- a/tests/Feature/Persistence/DisplayReadSeamsTest.php
+++ b/tests/Feature/Persistence/DisplayReadSeamsTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Audit\NoOpAuditOutbox;
+use BuiltByBerry\LaravelSwarm\Contracts\AuditOutbox;
+use BuiltByBerry\LaravelSwarm\Contracts\InspectsDurableRuns;
+use BuiltByBerry\LaravelSwarm\Contracts\ReadableAuditOutbox;
+use BuiltByBerry\LaravelSwarm\Persistence\DatabaseAuditOutbox;
+use BuiltByBerry\LaravelSwarm\Persistence\DatabaseDurableRunStore;
+use BuiltByBerry\LaravelSwarm\Persistence\SwarmPersistenceCipher;
+use BuiltByBerry\LaravelSwarm\Runners\Durable\DurableRunInspector;
+use Illuminate\Config\Repository;
+use Illuminate\Encryption\Encrypter;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Psr\Log\NullLogger;
+
+/*
+ * Part A of Phase 2 (laravel-swarm-filament): the public display read seams core
+ * exposes so a companion can inspect durable + audit data without binding the
+ * internal cipher or the strict-operational reads. Records 629/630/632.
+ */
+
+/** A sealed sw0: value encrypted under a foreign key — undecryptable here. */
+function poisonCiphertext(string $plaintext = 'unreadable'): string
+{
+    $foreign = new SwarmPersistenceCipher(
+        new Repository(['swarm.persistence.encrypt_at_rest' => true, 'swarm.persistence.driver' => 'database']),
+        new Encrypter(random_bytes(32), 'aes-256-cbc'),
+        new NullLogger,
+    );
+
+    return (string) $foreign->seal($plaintext);
+}
+
+function seedDurableRun(string $runId): void
+{
+    $now = now('UTC');
+
+    DB::table('swarm_durable_runs')->insert([
+        'run_id' => $runId,
+        'swarm_class' => 'ExampleSwarm',
+        'topology' => 'hierarchical',
+        'execution_mode' => 'durable',
+        'coordination_profile' => 'step_durable',
+        'status' => 'pending',
+        'next_step_index' => 0,
+        'current_step_index' => null,
+        'total_steps' => 1,
+        'route_cursor' => null,
+        'route_start_node_id' => null,
+        'current_node_id' => null,
+        'completed_node_ids' => json_encode([]),
+        'timeout_at' => $now->copy()->addHour(),
+        'step_timeout_seconds' => 300,
+        'attempts' => 0,
+        'lease_acquired_at' => null,
+        'execution_token' => null,
+        'leased_until' => null,
+        'recovery_count' => 0,
+        'last_recovered_at' => null,
+        'pause_requested_at' => null,
+        'paused_at' => null,
+        'resumed_at' => null,
+        'cancel_requested_at' => null,
+        'cancelled_at' => null,
+        'timed_out_at' => null,
+        'wait_reason' => null,
+        'waiting_since' => null,
+        'wait_timeout_at' => null,
+        'last_progress_at' => null,
+        'retry_attempt' => 0,
+        'next_retry_at' => null,
+        'parent_run_id' => null,
+        'queue_connection' => null,
+        'queue_name' => null,
+        'finished_at' => null,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+}
+
+function useDatabasePersistence(): void
+{
+    config()->set('swarm.persistence.driver', 'database');
+    config()->set('swarm.persistence.encrypt_at_rest', true);
+    app()->forgetInstance(AuditOutbox::class);
+    app()->forgetInstance(ReadableAuditOutbox::class);
+    Artisan::call('migrate:fresh', ['--database' => 'testing']);
+}
+
+test('ReadableAuditOutbox binds the database outbox in database mode and the no-op otherwise', function () {
+    config()->set('swarm.persistence.driver', 'cache');
+    app()->forgetInstance(AuditOutbox::class);
+    app()->forgetInstance(ReadableAuditOutbox::class);
+
+    expect(app(ReadableAuditOutbox::class))->toBeInstanceOf(NoOpAuditOutbox::class);
+
+    useDatabasePersistence();
+
+    expect(app(ReadableAuditOutbox::class))->toBeInstanceOf(DatabaseAuditOutbox::class)
+        // Same instance as the AuditOutbox binding, not a second copy.
+        ->and(app(ReadableAuditOutbox::class))->toBe(app(AuditOutbox::class));
+});
+
+test('InspectsDurableRuns resolves the read-only durable inspector', function () {
+    expect(app(InspectsDurableRuns::class))->toBeInstanceOf(DurableRunInspector::class);
+});
+
+test('no-op outbox health reports an empty, unavailable outbox', function () {
+    config()->set('swarm.persistence.driver', 'cache');
+    app()->forgetInstance(AuditOutbox::class);
+    app()->forgetInstance(ReadableAuditOutbox::class);
+
+    $outbox = app(ReadableAuditOutbox::class);
+
+    expect($outbox->isAvailable())->toBeFalse()
+        ->and($outbox->pending())->toBe([])
+        ->and($outbox->deadLettered())->toBe([])
+        ->and($outbox->healthSummary())->toBe([
+            'available' => false,
+            'pending' => 0,
+            'dead_letter' => 0,
+            'reserved' => 0,
+            'oldest_pending_at' => null,
+        ]);
+});
+
+test('outbox health reads display-decrypt rows and never consume them', function () {
+    useDatabasePersistence();
+
+    /** @var DatabaseAuditOutbox $outbox */
+    $outbox = app(ReadableAuditOutbox::class);
+
+    $outbox->enqueue('run.started', ['run_id' => 'run-1', 'detail' => 'first']);
+    $outbox->enqueue('step.completed', ['run_id' => 'run-2', 'detail' => 'second']);
+    $outbox->enqueue('run.failed', ['run_id' => 'run-3'], deadLetter: true);
+
+    $pending = $outbox->pending();
+    $deadLettered = $outbox->deadLettered();
+
+    // Newest first; payload display-decrypted back into an array.
+    expect($pending)->toHaveCount(2)
+        ->and($pending[0]['category'])->toBe('step.completed')
+        ->and($pending[0]['run_id'])->toBe('run-2')
+        ->and($pending[0]['status'])->toBe('pending')
+        ->and($pending[0]['attempts'])->toBe(0)
+        ->and($pending[0]['payload_available'])->toBeTrue()
+        ->and($pending[0]['payload']['detail'])->toBe('second')
+        ->and($deadLettered)->toHaveCount(1)
+        ->and($deadLettered[0]['category'])->toBe('run.failed');
+
+    expect($outbox->healthSummary())->toMatchArray([
+        'available' => true,
+        'pending' => 2,
+        'dead_letter' => 1,
+        'reserved' => 0,
+    ]);
+    expect($outbox->healthSummary()['oldest_pending_at'])->not->toBeNull();
+
+    // A pure SELECT never reserves or deletes — the drainer's rows are untouched.
+    expect(DB::table('swarm_audit_outbox')->count())->toBe(3)
+        ->and(DB::table('swarm_audit_outbox')->whereNotNull('reserved_at')->count())->toBe(0);
+});
+
+test('outbox health degrades a poison row instead of throwing under the throw policy', function () {
+    useDatabasePersistence();
+    config()->set('swarm.persistence.decrypt_failure_policy', 'throw');
+
+    /** @var DatabaseAuditOutbox $outbox */
+    $outbox = app(ReadableAuditOutbox::class);
+
+    $outbox->enqueue('run.started', ['run_id' => 'good', 'detail' => 'readable']);
+    $outbox->enqueue('run.started', ['run_id' => 'bad', 'detail' => 'unreadable']);
+
+    // Corrupt the newest row's sealed payload to a foreign-key blob.
+    $poisonId = DB::table('swarm_audit_outbox')->where('run_id', 'bad')->value('id');
+    DB::table('swarm_audit_outbox')->where('id', $poisonId)->update(['payload' => poisonCiphertext()]);
+
+    $pending = collect($outbox->pending())->keyBy('run_id');
+
+    expect($pending['good']['payload_available'])->toBeTrue()
+        ->and($pending['good']['payload']['detail'])->toBe('readable')
+        ->and($pending['bad']['payload_available'])->toBeFalse()
+        ->and($pending['bad']['payload'])->toBeNull();
+});
+
+test('hierarchical node output display read degrades a poison node without aborting the batch', function () {
+    useDatabasePersistence();
+    config()->set('swarm.persistence.decrypt_failure_policy', 'throw');
+
+    /** @var DatabaseDurableRunStore $store */
+    $store = app(DatabaseDurableRunStore::class);
+    $runId = 'hier-display-1';
+    seedDurableRun($runId);
+
+    // A cleanly sealed node output under the app key.
+    $store->storeHierarchicalNodeOutput($runId, 'node-a', 'output A', 3600);
+
+    // A poison node output sealed under a foreign key.
+    $now = now('UTC');
+    DB::table('swarm_durable_node_outputs')->insert([
+        'run_id' => $runId,
+        'node_id' => 'node-b',
+        'output' => poisonCiphertext('output B'),
+        'expires_at' => $now->copy()->addHour(),
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    $outputs = collect($store->hierarchicalNodeOutputsForInspection($runId))->keyBy('node_id');
+
+    expect($outputs)->toHaveCount(2)
+        ->and($outputs['node-a']['output'])->toBe('output A')
+        ->and($outputs['node-a']['output_available'])->toBeTrue()
+        ->and($outputs['node-b']['output'])->toBeNull()
+        ->and($outputs['node-b']['output_available'])->toBeFalse();
+});

--- a/tests/Unit/Persistence/SwarmPersistenceCipherTest.php
+++ b/tests/Unit/Persistence/SwarmPersistenceCipherTest.php
@@ -246,3 +246,48 @@ test('openContextTopLevelInputStrict throws on an undecryptable input regardless
 
     expect(fn () => $opener->openContextTopLevelInputStrict($row))->toThrow(DecryptException::class);
 })->with(['null_with_log', 'legacy', 'throw']);
+
+test('openForDisplay passes plaintext, null, and empty through as available', function () {
+    $cipher = makeCipher(true, 'database');
+
+    expect($cipher->openForDisplay('no prefix here'))->toBe(['no prefix here', true])
+        ->and($cipher->openForDisplay(null))->toBe([null, true])
+        ->and($cipher->openForDisplay(''))->toBe(['', true]);
+});
+
+test('openForDisplay round-trips a sealed value under the correct key', function () {
+    $cipher = makeCipher(true, 'database');
+
+    $sealed = $cipher->seal('secret prompt');
+
+    expect($cipher->openForDisplay($sealed))->toBe(['secret prompt', true]);
+});
+
+test('openForDisplay degrades a rotated-key value to null+unavailable under null_with_log', function () {
+    $sealed = makeCipher(true, 'database')->seal('secret prompt');
+    $opener = makeCipher(true, 'database', null, 'null_with_log');
+
+    // Different random key => decrypt fails; display read degrades, never throws.
+    expect($opener->openForDisplay($sealed))->toBe([null, false]);
+});
+
+test('openForDisplay masks a rotated-key value and never leaks ciphertext under legacy', function () {
+    $sealed = makeCipher(true, 'database')->seal('secret prompt');
+    $opener = makeCipher(true, 'database', null, 'legacy');
+
+    // legacy policy would surface the raw sw0: ciphertext via open(); openForDisplay
+    // must NOT leak it — it degrades to null+unavailable.
+    [$value, $available] = $opener->openForDisplay($sealed);
+
+    // null (not the stored sw0: ciphertext) proves it did not leak the ciphertext.
+    expect($available)->toBeFalse()
+        ->and($value)->toBeNull();
+});
+
+test('openForDisplay never throws under the throw policy and degrades instead', function () {
+    $sealed = makeCipher(true, 'database')->seal('secret prompt');
+    $opener = makeCipher(true, 'database', null, 'throw');
+
+    // open() under throw would raise DecryptException; openForDisplay swallows it.
+    expect($opener->openForDisplay($sealed))->toBe([null, false]);
+});


### PR DESCRIPTION
Part A of Phase 2 (`laravel-swarm-filament`). Adds the public, read-only display seams core must expose before the Filament companion can bind them — without touching the `@internal` cipher or the strict-operational resume reads.

Targets `release/v0.19.0`.

## What

- **`InspectsDurableRuns`** — public read-only durable inspection contract (read-only counterpart to `SwarmOperator`). Assembles a display-decrypted `DurableRunDetail` via `find()` / `inspect()` / `inspectByLabels()`. `DurableRunInspector` now implements it (class stays `@internal`; consumers bind the contract). `DurableRunDetail` gains `hierarchicalNodeOutputs` for cross-topology parity with branches + child runs.
- **`ReadableAuditOutbox`** — public read-only outbox-health contract, the non-mutating counterpart to `AuditOutbox::drain()`. `pending()` / `deadLettered()` / `healthSummary()` / `isAvailable()` are pure SELECTs that never reserve or delete, so they coexist with a concurrent `swarm:relay --type=audit` drainer. Implemented by `DatabaseAuditOutbox` + `NoOpAuditOutbox`. **Resolves #630.**
- **`SwarmPersistenceCipher::openForDisplay()`** — centralized per-row degrade: never throws (even under `decrypt_failure_policy=throw`), never leaks `sw0:` ciphertext (even under `legacy`); an undecryptable field becomes `null` with an explicit `*_available: false` flag. The durable branch/child/hierarchical display reads route through it. **Operational strict/consuming reads are untouched** — display and operational paths stay separate.

## Design gate

Design-gated before implementation (verdict: proceed-to-implement, 1 high / 3 medium / 1 low). Invariant: *a companion can DISPLAY durable + audit data through a public seam that honors `decrypt_failure_policy` and never mutates, while operational reads stay strict and consuming; the two paths never collapse.* Canon recorded as channel records 629/630/632.

## Verification

- New: `SwarmPersistenceCipher::openForDisplay` unit tests (all 3 policies + rotated key: never throws, never leaks ciphertext) and `DisplayReadSeamsTest` (bindings, non-consuming outbox reads, poison-row-among-good degrade for outbox + hierarchical outputs, no-op outbox health).
- `composer analyse` (phpstan L7) clean · `pint --test` clean · 226 existing durable/audit/provider tests green (no regressions).
- Semver-minor: additive contracts only; no existing interface widened; no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)