### PR TITLE
chore: v0.19.0 review followups (F1)

### DIFF
--- a/src/Persistence/SwarmPersistenceCipher.php
+++ b/src/Persistence/SwarmPersistenceCipher.php
@@ -162,9 +162,12 @@ class SwarmPersistenceCipher
             return [null, false];
         }
 
-        // null_with_log returns null and legacy returns the raw sw0: ciphertext on
-        // a decrypt failure; a still-sealed value was never actually decrypted.
-        if ($plain === null || str_starts_with($plain, self::PREFIX)) {
+        // A decrypt failure surfaces as null (null_with_log) or the ORIGINAL sealed
+        // value returned verbatim (legacy passes the ciphertext through). Compare
+        // against $value rather than the sw0: prefix so a value that legitimately
+        // decrypts to a `sw0:`-prefixed plaintext (#212) is NOT mistaken for
+        // ciphertext and masked.
+        if ($plain === null || $plain === $value) {
             return [null, false];
         }
 

--- a/tests/Unit/Persistence/SwarmPersistenceCipherTest.php
+++ b/tests/Unit/Persistence/SwarmPersistenceCipherTest.php
@@ -338,3 +338,13 @@ test('openContextTopLevelInputForDisplay reports available for a row with no sea
     expect($available)->toBeTrue()
         ->and($row)->toBe(['data' => ['y' => 2]]);
 });
+
+test('openForDisplay returns a value that legitimately decrypts to a sw0: prefixed plaintext (#212)', function () {
+    $cipher = makeCipher(true, 'database');
+
+    // Real plaintext that happens to start with the sealed sentinel; sealed on
+    // write, it must decrypt back to itself and NOT be masked as ciphertext.
+    $sealed = $cipher->seal('sw0:hello');
+
+    expect($cipher->openForDisplay($sealed))->toBe(['sw0:hello', true]);
+});


### PR DESCRIPTION
Multi-expert review followups for the v0.19.0 release branch (phase 1 of `/release-wrap`).

## F1 · medium · persistence encrypt/decrypt — **fixed**

`SwarmPersistenceCipher::openForDisplay()` detected the legacy-policy ciphertext passthrough by testing whether the *decrypted* plaintext starts with the `sw0:` sentinel. That masked a value which legitimately decrypts to a `sw0:`-prefixed plaintext (the exact shape the `#212` strict-path tests seal and round-trip — `"sw0:input"`, `"sw0:node"`, `"sw0:child"`) as `null` + `available:false` across **every** display twin (branch/child/hierarchical/step/context/audit).

**Fix:** compare the decrypted result against the original `$value` — the sentinel the `legacy` policy actually returns verbatim — instead of the prefix, so a genuine decrypt is never mistaken for ciphertext. Fails safe either way (it masked rather than leaked, which is why no test caught it). Added a unit test sealing `"sw0:hello"` and asserting `openForDisplay` returns `['sw0:hello', true]`.

F2 (cache-mode inspector resolution) and F3 (cache twin shape asymmetry) were **low / informational** — accepted as-is (consistent with existing `swarm:inspect` DB requirement; documented in the contract). No code change.

## Verification
- `pint --test` clean · `composer analyse` (phpstan L7) clean · 93 affected tests green (DisplayReadSeams + DatabasePersistence + cipher), incl. the new #212 display regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)