### PR TITLE
chore(release): v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.19.0 - unreleased
+## v0.19.0 - 2026-07-08
 
 Public display-read seams for ecosystem companions. Adds separate, additive, read-only contracts so a companion (starting with `laravel-swarm-filament`) can DISPLAY durable-run branch/child/hierarchical-node data and audit-outbox health through supported public seams that honor `swarm.persistence.decrypt_failure_policy` — without binding to the `@internal` cipher or the strict-operational resume reads. Operational strict/consuming methods are untouched; the display and operational paths stay separate by construction.
 

--- a/README.md
+++ b/README.md
@@ -413,6 +413,18 @@ $result->isImmediate();  // false when a mid-step run pauses at its next checkpo
 
 The control verbs return rich result objects (`DurablePauseResult` / `DurableResumeResult` / `DurableCancelResult`, backed by the `DurableLifecycleStatus` enum) that report the **effective** transition — whether the run paused/cancelled immediately or is scheduled to at its next step boundary. The contract is **control-only** (operational reads stay on `SwarmHistory` / `RunHistoryStore`), **authorization-agnostic** (gate the call in your own app), and **fails loud** on an unknown run. The `$response->pause()` / `resume()` / `cancel()` handle methods shown above delegate to it. See [Durable Execution — operator control contract](docs/durable-execution.md#operator-control-contract).
 
+### Read-only inspection contracts (v0.19.0)
+
+The read-only counterpart to `SwarmOperator`, for companion packages and external readers (a Filament panel, an MCP server, a dashboard) that need to **display** run data. Resolve the contract instead of reaching into the `@internal` cipher or manager:
+
+```php
+use BuiltByBerry\LaravelSwarm\Contracts\InspectsDurableRuns;
+
+app(InspectsDurableRuns::class)->inspect($runId); // display-decrypted DurableRunDetail
+```
+
+Three seams ship: **`InspectsDurableRuns`** (durable run, branches, child runs, hierarchical node outputs), **`ReadableRunHistoryStore`** (run + step detail and the runs list), and **`ReadableAuditOutbox`** (non-mutating outbox-health reads). Every sealed field is **display-decrypted per row** — it honors `swarm.persistence.decrypt_failure_policy` and degrades an undecryptable field to `null` with an `*_available: false` flag rather than throwing or leaking ciphertext, so one bad row never 500s a page. The operational reads (`RunHistoryStore::find`, `AuditOutbox::drain`, durable resume) are untouched and still fail loud. See [Public Surface — read-only inspection contracts](docs/public-surface.md#read-only-inspection-contracts-v0190).
+
 ## Memory (v0.9.0+)
 
 Swarm Memory is a first-class, scoped, snapshot-replayable memory subsystem. It gives agents and application code a place to read and write structured values that persist across steps, survive queue boundaries, and can be replayed deterministically from a frozen snapshot on a crash-resume.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -269,6 +269,10 @@ This package’s `composer.json` uses `"minimum-stability": "dev"` with
 still prefers tagged releases. Your application may need compatible Composer
 stability settings while Laravel AI remains pre-stable.
 
+## Upgrading to v0.19.0
+
+**No required action — additive.** This release adds three public, read-only display seams for companion packages and external readers — `InspectsDurableRuns` (durable-run inspection), `ReadableRunHistoryStore` (run + step history), and `ReadableAuditOutbox` (audit-outbox health) — plus a `SwarmPersistenceCipher::openForDisplay()` helper. They are new interfaces, container-bound alongside the existing stores; no existing contract is widened, and there is no migration, config, or schema change. Every operational read (durable resume, guardrail, `RunHistoryStore::find()`, `AuditOutbox::drain()`) is untouched and still decrypts strictly / fails loud. If you are building an observability surface, bind these contracts instead of the `@internal` cipher or manager; otherwise nothing changes. See the [CHANGELOG](CHANGELOG.md#v0190---2026-07-08) and [Public Surface](docs/public-surface.md#read-only-inspection-contracts-v0190) for details.
+
 ## Upgrading to v0.18.0
 
 **No required action — additive.** This release adds the `make:swarm:blueprint` generator and four new curated blueprint trees (`triage`, `extraction`, `memory`, `streaming`) to the starter corpus. It is purely additive — a new Artisan command plus new stub files, with no migration, config, schema, or breaking API change. `swarm:install:examples`' behavior and file output are unchanged (it now also skips the package-side `blueprint.json` metadata alongside `README.md`). If you want the new scaffolder, run `php artisan make:swarm:blueprint <Name> --template=<slug>`; otherwise nothing changes. See the [CHANGELOG](CHANGELOG.md#v0180---2026-07-07) and [Generators](docs/generators.md#make-swarm-blueprint) for details.

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "0.18.x-dev"
+            "dev-main": "0.19.x-dev"
         },
         "laravel": {
             "providers": [


### PR DESCRIPTION
Phase 2 of `/release-wrap` — deterministic release hygiene for v0.19.0.

- **CHANGELOG** — finalized the v0.19.0 date (2026-07-08); Added/Changed sections were filled on the topic branches (#395/#396) and carried over.
- **UPGRADING** — added the `## Upgrading to v0.19.0` block: **no required action, additive** (three new read-only contracts, no widened interface, no migration/config/schema change).
- **branch-alias** — bumped `dev-main` to `0.19.x-dev`.
- **README** — added a "Read-only inspection contracts (v0.19.0)" subsection under Durable Execution, as the read-only counterpart to the operator control contract.

## Roll-up
- **Breaking:** none. **Deploy safety:** additive; no migration, no config, no schema. Semver-minor.
- Next: Phase 3 (readiness review) → mark-ready-for-tag → tag `v0.19.0` on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)