### PR TITLE
release: v0.19.1 — Companion packages README section (docs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ now-shipped companions. No code changes; no API impact.
 - **Observability index** points to `laravel-swarm-mcp` as an AI-client
   observation surface.
 - Standardized `.env` code-fence language tags to ` ```env ` across the docs.
+- README polish: consistent heading casing, and a trimmed `Documentation`
+  section that points to the comprehensive docs index rather than maintaining a
+  third partial link list (anchors unchanged).
 
 ## v0.19.0 - 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.19.1 - 2026-07-11
+
+Documentation. Surfaces the shipped companion ecosystem from the core README so
+the two newest companions — the Filament observability panel and the MCP
+observability server — are discoverable alongside Pulse and the vector-memory
+companion, not only on the documentation site. No code changes; no API impact.
+
+### Changed
+
+- **README: new `Companion packages` section.** Consolidates and links the
+  shipped companions — [`laravel-swarm-filament`](https://github.com/builtbyberry/laravel-swarm-filament),
+  [`laravel-swarm-mcp`](https://github.com/builtbyberry/laravel-swarm-mcp),
+  [`laravel-swarm-pulse`](https://github.com/builtbyberry/laravel-swarm-pulse),
+  and [`laravel-swarm-memory-vector`](https://github.com/builtbyberry/laravel-swarm-memory-vector) —
+  and points to the ecosystem map on swarm.builtbyberry.com. Added to the README
+  table of contents.
+
 ## v0.19.0 - 2026-07-08
 
 Public display-read seams for ecosystem companions. Adds separate, additive, read-only contracts so a companion (starting with `laravel-swarm-filament`) can DISPLAY durable-run branch/child/hierarchical-node data and audit-outbox health through supported public seams that honor `swarm.persistence.decrypt_failure_policy` — without binding to the `@internal` cipher or the strict-operational resume reads. Operational strict/consuming methods are untouched; the display and operational paths stay separate by construction.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,29 @@
 
 ## v0.19.1 - 2026-07-11
 
-Documentation. Surfaces the shipped companion ecosystem from the core README so
-the two newest companions — the Filament observability panel and the MCP
-observability server — are discoverable alongside Pulse and the vector-memory
-companion, not only on the documentation site. No code changes; no API impact.
+Documentation cohesiveness pass. Surfaces the shipped companion ecosystem — the
+Filament observability panel and the MCP observability server, alongside Pulse
+and the vector-memory companion — from the core docs, and reconciles the
+mirrored `docs/` index and read-seam contract docs that had drifted behind the
+now-shipped companions. No code changes; no API impact.
 
 ### Changed
 
-- **README: new `Companion packages` section.** Consolidates and links the
-  shipped companions — [`laravel-swarm-filament`](https://github.com/builtbyberry/laravel-swarm-filament),
+- **README + docs index: new `Companion Packages` section.** Consolidates and
+  links the shipped companions — [`laravel-swarm-filament`](https://github.com/builtbyberry/laravel-swarm-filament),
   [`laravel-swarm-mcp`](https://github.com/builtbyberry/laravel-swarm-mcp),
   [`laravel-swarm-pulse`](https://github.com/builtbyberry/laravel-swarm-pulse),
   and [`laravel-swarm-memory-vector`](https://github.com/builtbyberry/laravel-swarm-memory-vector) —
-  and points to the ecosystem map on swarm.builtbyberry.com. Added to the README
-  table of contents.
+  in both `README.md` and the offline `docs/README.md` index (with a ToC entry),
+  so the two are in lockstep.
+- **Read-seam contract docs now link their shipped consumers.** `docs/public-surface.md`
+  and `docs/durable-execution.md` described the read-only inspection seams'
+  consumers as hypothetical ("a Filament panel, an MCP server"); they now link
+  `laravel-swarm-filament` and `laravel-swarm-mcp` as the reference read-only
+  consumers of those seams.
+- **Observability index** points to `laravel-swarm-mcp` as an AI-client
+  observation surface.
+- Standardized `.env` code-fence language tags to ` ```env ` across the docs.
 
 ## v0.19.0 - 2026-07-08
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Define a swarm once, return the Laravel AI agents that participate in it, and ru
 
 ## Contents
 
-- **Getting started** — [Quick Start](#quick-start) · [Requirements](#requirements) · [Installation](#installation) · [Your First Swarm](#your-first-swarm) · [Running A Swarm](#running-a-swarm)
-- **Execution modes** — [Choosing An Execution Mode](#choosing-an-execution-mode) · [Queueing](#queueing-a-swarm) · [Streaming](#streaming-a-swarm) · [Durable Execution](#durable-execution)
+- **Getting started** — [Quick Start](#quick-start) · [Requirements](#requirements) · [Installation](#installation) · [Your First Swarm](#your-first-swarm) · [Running a Swarm](#running-a-swarm)
+- **Execution modes** — [Choosing an Execution Mode](#choosing-an-execution-mode) · [Queueing](#queueing-a-swarm) · [Streaming](#streaming-a-swarm) · [Durable Execution](#durable-execution)
 - **Capabilities** — [Memory](#memory-v090) · [Topologies](#topologies)
 - **Production & reference** — [Testing](#testing) · [Configuration](#configuration) · [Production Checklist](#production-checklist) · [Documentation](#documentation) · [Companion Packages](#companion-packages) · [Local Development](#local-development)
 
@@ -48,7 +48,7 @@ $response = ContentPipeline::make()->prompt('Draft a launch post about Laravel q
 echo $response->output;
 ```
 
-For background execution, streaming, and durable workflows, see [Choosing An Execution Mode](#choosing-an-execution-mode).
+For background execution, streaming, and durable workflows, see [Choosing an Execution Mode](#choosing-an-execution-mode).
 
 ## Requirements
 
@@ -166,7 +166,7 @@ class ContentPipeline implements Swarm
 
 In a sequential swarm, the first agent receives the original task. Each later agent receives the previous agent's output.
 
-## Running A Swarm
+## Running a Swarm
 
 Use `prompt()` when the caller can wait for the full workflow result:
 
@@ -202,7 +202,7 @@ return response()->json($response);
 
 `toArray()` intentionally omits the live `RunContext` so an API response does not accidentally re-emit prompt or input data. Read `$response->context` directly when your application needs the in-process context.
 
-## Choosing An Execution Mode
+## Choosing an Execution Mode
 
 | Method | Returns | Use when |
 | --- | --- | --- |
@@ -220,7 +220,7 @@ return response()->json($response);
 
 `stream()` and the broadcast helpers support sequential swarms only. Use lifecycle events and application-owned broadcasts for queued, durable, parallel, or hierarchical operations feeds.
 
-## Queueing A Swarm
+## Queueing a Swarm
 
 Use `queue()` when the workflow should run in the background:
 
@@ -258,7 +258,7 @@ SWARM_CAPTURE_ACTIVE_CONTEXT=true
 
 You may still leave input, output, and artifact capture disabled for redacted history.
 
-## Streaming A Swarm
+## Streaming a Swarm
 
 Use `stream()` when a browser, CLI, or custom consumer needs live typed events from a sequential swarm:
 
@@ -648,26 +648,16 @@ See [Audit Evidence Contract](docs/audit-evidence-contract.md) for the full refe
 
 The full documentation site is at **[swarm.builtbyberry.com](https://swarm.builtbyberry.com)** — searchable, versioned, and the recommended starting point.
 
-The same content is mirrored in this repository; start with the [in-repo documentation index](docs/README.md) when working offline.
+The same content is mirrored in this repository; the [in-repo documentation index](docs/README.md) is the complete, categorized map when working offline. A few common entry points:
 
-- [Structured Input](docs/structured-input.md)
-- [Streaming](docs/streaming.md)
-- [Hierarchical Routing](docs/hierarchical-routing.md)
-- [Persistence And History](docs/persistence-and-history.md)
-- [Durable Execution](docs/durable-execution.md)
-- [Durable Runtime Architecture](docs/durable-runtime-architecture.md)
-- [Durable Waits And Signals](docs/durable-waits-and-signals.md)
-- [Durable Retries And Progress](docs/durable-retries-and-progress.md)
-- [Durable Child Swarms](docs/durable-child-swarms.md)
-- [Durable Webhooks](docs/durable-webhooks.md)
-- [Observability: Logging And Tracing](docs/observability-logging-tracing.md)
-- [Observability Correlation Contract](docs/observability-correlation-contract.md)
-- [Audit Evidence Contract](docs/audit-evidence-contract.md)
-- [Testing](docs/testing.md)
-- [Pulse](docs/pulse.md)
-- [Maintenance](docs/maintenance.md)
-- [Public Surface Coverage](docs/public-surface.md)
-- [Examples](examples/README.md)
+- [Choosing an Execution Mode](docs/execution-modes.md) — prompt, queue, stream, or durable
+- [Durable Execution](docs/durable-execution.md) — checkpointing, recovery, and operator controls
+- [Swarm Memory](docs/memory.md) — scoped, snapshot-replayable memory
+- [Configuration](docs/configuration.md) — every config key
+- [Public Surface](docs/public-surface.md) — the supported API, events, and read seams
+- [Audit Evidence Contract](docs/audit-evidence-contract.md) — compliance and auditability
+
+For the full set — topologies, guardrails, the durable subsystems, observability, operator runbooks, and examples — see the [documentation index](docs/README.md).
 
 ## Companion Packages
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Define a swarm once, return the Laravel AI agents that participate in it, and ru
 - **Getting started** — [Quick Start](#quick-start) · [Requirements](#requirements) · [Installation](#installation) · [Your First Swarm](#your-first-swarm) · [Running A Swarm](#running-a-swarm)
 - **Execution modes** — [Choosing An Execution Mode](#choosing-an-execution-mode) · [Queueing](#queueing-a-swarm) · [Streaming](#streaming-a-swarm) · [Durable Execution](#durable-execution)
 - **Capabilities** — [Memory](#memory-v090) · [Topologies](#topologies)
-- **Production & reference** — [Testing](#testing) · [Configuration](#configuration) · [Production Checklist](#production-checklist) · [Documentation](#documentation) · [Local Development](#local-development)
+- **Production & reference** — [Testing](#testing) · [Configuration](#configuration) · [Production Checklist](#production-checklist) · [Documentation](#documentation) · [Companion packages](#companion-packages) · [Local Development](#local-development)
 
 ## Quick Start
 
@@ -668,6 +668,23 @@ The same content is mirrored in this repository; start with the [in-repo documen
 - [Maintenance](docs/maintenance.md)
 - [Public Surface Coverage](docs/public-surface.md)
 - [Examples](examples/README.md)
+
+## Companion packages
+
+Laravel Swarm is a small core with a growing family of companion packages —
+additive, MIT, and installed only when you need them. Each reads and extends the
+core through its public [contracts and events](docs/public-surface.md), never by
+patching internals. The full ecosystem map, with setup for each, lives on
+[swarm.builtbyberry.com](https://swarm.builtbyberry.com).
+
+- **[`laravel-swarm-filament`](https://github.com/builtbyberry/laravel-swarm-filament)** — a read-only Filament panel that turns every run into a topology-aware flow graph, with click-through to per-step inputs, outputs, tokens, timing, and memory.
+- **[`laravel-swarm-mcp`](https://github.com/builtbyberry/laravel-swarm-mcp)** — a read-only [Model Context Protocol](https://modelcontextprotocol.io) server that exposes run history, durable-run state, and audit-outbox health as MCP resources, so any MCP client (Claude, Cursor, …) can observe your swarms.
+- **[`laravel-swarm-pulse`](https://github.com/builtbyberry/laravel-swarm-pulse)** — [Laravel Pulse](https://laravel.com/docs/pulse) recorders and dashboard cards for swarm runs, steps, memory, and audit-outbox health (see [Pulse](docs/pulse.md)).
+- **[`laravel-swarm-memory-vector`](https://github.com/builtbyberry/laravel-swarm-memory-vector)** — vector-backed semantic memory recall on top of core [Swarm Memory](docs/memory.md).
+
+The Filament panel and the MCP server are two read-only *renderings* of the same
+public display seams — a panel for your team, an MCP surface for an AI client —
+neither able to mutate a run.
 
 ## Local Development
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Define a swarm once, return the Laravel AI agents that participate in it, and ru
 - **Getting started** — [Quick Start](#quick-start) · [Requirements](#requirements) · [Installation](#installation) · [Your First Swarm](#your-first-swarm) · [Running A Swarm](#running-a-swarm)
 - **Execution modes** — [Choosing An Execution Mode](#choosing-an-execution-mode) · [Queueing](#queueing-a-swarm) · [Streaming](#streaming-a-swarm) · [Durable Execution](#durable-execution)
 - **Capabilities** — [Memory](#memory-v090) · [Topologies](#topologies)
-- **Production & reference** — [Testing](#testing) · [Configuration](#configuration) · [Production Checklist](#production-checklist) · [Documentation](#documentation) · [Companion packages](#companion-packages) · [Local Development](#local-development)
+- **Production & reference** — [Testing](#testing) · [Configuration](#configuration) · [Production Checklist](#production-checklist) · [Documentation](#documentation) · [Companion Packages](#companion-packages) · [Local Development](#local-development)
 
 ## Quick Start
 
@@ -669,7 +669,7 @@ The same content is mirrored in this repository; start with the [in-repo documen
 - [Public Surface Coverage](docs/public-surface.md)
 - [Examples](examples/README.md)
 
-## Companion packages
+## Companion Packages
 
 Laravel Swarm is a small core with a growing family of companion packages —
 additive, MIT, and installed only when you need them. Each reads and extends the

--- a/docs/README.md
+++ b/docs/README.md
@@ -84,6 +84,7 @@ The recommended reading path for new users.
 - [Operator Runbook: Streaming Substrate](operator-runbook-streaming-substrate.md) — hot/cold tiering, the compaction worker (`swarm:compact`), retention horizon, recovery and quarantine (v0.15.0+)
 - [Metadata Allowlist Governance](metadata-allowlist-governance.md) — what belongs in metadata, named anti-patterns, and the allowlist review pattern
 - [Pulse](pulse.md) — Laravel Pulse cards for run counts and step latencies
+- [`laravel-swarm-mcp`](https://github.com/builtbyberry/laravel-swarm-mcp) — a read-only MCP server that exposes run history, durable-run state, and audit-outbox health to an AI client (see [Companion Packages](#companion-packages))
 
 ---
 
@@ -93,6 +94,23 @@ The recommended reading path for new users.
 - [Public Surface](public-surface.md)
 - [Maintenance](maintenance.md)
 - [APP_KEY Rotation](app-key-rotation.md) — runbook for rotating the application key alongside sealed swarm rows
+
+---
+
+## Companion Packages
+
+Additive, MIT packages that read and extend the core through its public
+contracts — install only what you need. The full ecosystem map lives on
+[swarm.builtbyberry.com](https://swarm.builtbyberry.com).
+
+- [`laravel-swarm-filament`](https://github.com/builtbyberry/laravel-swarm-filament) — a read-only Filament panel: every run as a topology-aware flow graph with click-through to per-step detail.
+- [`laravel-swarm-mcp`](https://github.com/builtbyberry/laravel-swarm-mcp) — a read-only [Model Context Protocol](https://modelcontextprotocol.io) server: run history, durable-run state, and audit-outbox health as MCP resources for any MCP client.
+- [`laravel-swarm-pulse`](https://github.com/builtbyberry/laravel-swarm-pulse) — [Laravel Pulse](https://laravel.com/docs/pulse) recorders and cards (see [Pulse](pulse.md)).
+- [`laravel-swarm-memory-vector`](https://github.com/builtbyberry/laravel-swarm-memory-vector) — vector-backed semantic memory recall (see [Swarm Memory](memory.md)).
+
+The Filament panel and the MCP server are two read-only renderings of the same
+public [read-only inspection contracts](public-surface.md#read-only-inspection-contracts-v0190) —
+a panel for your team, an MCP surface for an AI client.
 
 ---
 

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -329,7 +329,7 @@ retried after a crash:
 
 Set via `.env`:
 
-```dotenv
+```env
 SWARM_MEMORY_REPLAY_MODE=frozen_view
 ```
 

--- a/docs/compliance-audit.md
+++ b/docs/compliance-audit.md
@@ -478,7 +478,7 @@ final class PhiMinimizingCapturePolicy implements MemoryCapturePolicy
 ],
 ```
 
-```dotenv
+```env
 # Stop scheduled deletion during an investigation or litigation hold.
 # MemoryPurged still fires (prevent_prune=true), so the audit trail is intact.
 SWARM_PREVENT_PRUNE=true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -317,7 +317,7 @@ Controls the memory subsystem introduced in v0.9.0. Memory stores scoped values 
 |-----|------|---------|---------|-------------|
 | `swarm.memory.replay_mode` | string | `frozen_view` | `SWARM_MEMORY_REPLAY_MODE` | Controls what memory a durable agent sees when a step is retried after a crash. `frozen_view` — the agent re-executes against the `MemoryScope::Run` entries frozen in the snapshot taken at the original invocation; live writes during the retry are buffered and never reach the backing store. `fresh_execution` — the agent re-executes against live memory with no snapshot guard; use only when idempotency is guaranteed externally. Override per swarm class with the `#[MemoryReplay]` attribute. |
 
-```ini
+```env
 # .env — override the global default
 SWARM_MEMORY_REPLAY_MODE=frozen_view
 ```

--- a/docs/durable-execution.md
+++ b/docs/durable-execution.md
@@ -686,8 +686,9 @@ and `signal()`.
 
 Where `SwarmOperator` is the **control** contract, `InspectsDurableRuns` is its
 **read** counterpart — the supported, container-bound seam for companion
-packages and external readers (a Filament panel, an MCP server, a custom
-dashboard) that need to **display** a durable run's state. Resolve it instead of
+packages and external readers (such as the [`laravel-swarm-filament`](https://github.com/builtbyberry/laravel-swarm-filament)
+panel and the [`laravel-swarm-mcp`](https://github.com/builtbyberry/laravel-swarm-mcp)
+server) that need to **display** a durable run's state. Resolve it instead of
 reaching into the `@internal` `DurableSwarmManager` / `DurableRunInspector` or the
 `@internal` `SwarmPersistenceCipher`:
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -870,7 +870,7 @@ The agent re-executes against live memory with no snapshot guard. Use only when 
 ],
 ```
 
-```ini
+```env
 # .env
 SWARM_MEMORY_REPLAY_MODE=frozen_view
 ```

--- a/docs/public-surface.md
+++ b/docs/public-surface.md
@@ -91,8 +91,9 @@ the consuming application's responsibility. Verbs fail loud (throw
 ## Read-Only Inspection Contracts (v0.19.0+)
 
 The public, container-bound read-only seams companion packages and external
-readers (a Filament panel, an MCP server, a custom dashboard) use to DISPLAY
-durable and audit data. They are the read-only counterparts to `SwarmOperator`:
+readers (the [`laravel-swarm-filament`](https://github.com/builtbyberry/laravel-swarm-filament)
+panel, the [`laravel-swarm-mcp`](https://github.com/builtbyberry/laravel-swarm-mcp)
+server, a custom dashboard) use to DISPLAY durable and audit data. They are the read-only counterparts to `SwarmOperator`:
 resolve them with `app(...)`, never bind the `@internal` engine types or the
 `@internal` `SwarmPersistenceCipher`.
 


### PR DESCRIPTION
Docs-only patch. Surfaces the shipped companion ecosystem from the core README.

- **New `## Companion packages` section** linking the four shipped companions — `laravel-swarm-filament`, `laravel-swarm-mcp`, `laravel-swarm-pulse`, `laravel-swarm-memory-vector` — and pointing to the ecosystem map on swarm.builtbyberry.com. Gives the Filament panel and the MCP server their first README package links.
- ToC entry + `CHANGELOG.md` v0.19.1 entry.

**No code changes, no API impact.** This is the companion-docs pass agreed for v0.19.1 (rather than a one-line patch) — the core README linked neither shipped observability companion before.