### PR TITLE
chore: upgrade laravel/ai to ^0.9

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Laravel Swarm — Agent Context
 
+<!-- swarm-channel: laravel-swarm -->
+
 This file is operational context for AI coding agents. Human contributors should
 start with [README.md](README.md), [CONTRIBUTING.md](CONTRIBUTING.md),
 [CHANGELOG.md](CHANGELOG.md), and the user-facing docs in [docs/](docs/).

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "illuminate/queue": "^13.0",
         "illuminate/support": "^13.0",
         "illuminate/view": "^13.0",
-        "laravel/ai": "^0.8"
+        "laravel/ai": "^0.9"
     },
     "require-dev": {
         "builtbyberry/laravel-swarm-installer-testkit": "^0.1.0",


### PR DESCRIPTION
## Summary

Bumps `laravel/ai` from `^0.8` (v0.8.1) → `^0.9` (v0.9.0), and pins the `laravel-swarm` Swarm channel in `AGENTS.md`.

laravel/ai v0.9.0 (2026-07-07) consolidated provider tool-calling onto a shared `TextGenerationLoop`/`StepTextGateway`, switched Anthropic to native structured outputs by default (default model → Claude Sonnet 5), added collection generics across responses/streaming events, and shipped new capabilities (filesystem tools, `WithoutBroadcasting` attribute, native `anyOf` schemas, OpenAI-compatible provider).

## Breaking-change assessment — none hit swarm

- **`TextGateway` contract removed** → swarm references neither it nor the new `StepTextGateway`/`TextGenerationLoop`; it operates a layer above provider gateways.
- **Anthropic default model → Sonnet 5** → swarm pins no default model and no test asserts on model names.
- All **22 laravel/ai symbols** swarm imports still resolve under v0.9.0.
- `Enums\Lab` is used only as a type union — the new `Lab::OpenAICompatible` case is harmless (no exhaustive `match`).

## Verification (local, PHP 8.5.7)

- ✅ `pest` Feature/Unit/Installer — **1919 passed** (7720 assertions)
- ✅ `phpstan` larastan **level 7** — no errors (new upstream generics cost us nothing)
- ✅ `pest tests/ProcessConcurrency` (CI variant) — 5 passed
- ⏭️ Mutation suite skipped — it measures test-suite quality, which this constraint-only diff doesn't change; the `mutation.yml` baseline covers it on its own cadence.

## Notes / follow-ups

- The `php ^8.5` floor is intentional and left untouched (laravel/ai loosened to `^8.3`; swarm is deliberately stricter).
- Structured-output behavior changed upstream (native Anthropic + code-fence stripping). Our suite exercises this via fakes, not a live provider — worth an eyeball on the first real structured-routing run, but not a blocker.
- New capabilities worth scoping separately: `WithoutBroadcasting` (fits the durable-streaming/broadcast path), upstream filesystem tools (blueprint corpus), native `anyOf` schemas (structured routing/dispatch).