### PR TITLE
release: v0.20.0 — laravel/ai ^0.9

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Laravel Swarm — Agent Context
 
+<!-- swarm-channel: laravel-swarm -->
+
 This file is operational context for AI coding agents. Human contributors should
 start with [README.md](README.md), [CONTRIBUTING.md](CONTRIBUTING.md),
 [CHANGELOG.md](CHANGELOG.md), and the user-facing docs in [docs/](docs/).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ If a gap is deferred, it must be recorded as a named follow-up with an owner, no
 
 - PHP ^8.5
 - Laravel ^13.0
-- `laravel/ai` ^0.8
+- `laravel/ai` ^0.9
 - `orchestra/testbench` ^11
 - `pestphp/pest` ^4.4 + `pest-plugin-laravel` ^4.1
 - `larastan/larastan` ^3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v0.20.0 - 2026-07-13
+
+Upgrades the `laravel/ai` dependency to the v0.9 line. This is the first Swarm
+release to require `laravel/ai ^0.9` (v0.9.0); support for the 0.8 line is
+dropped. No Swarm source changes were required — the bump is verified against
+the full test suite (1919 passing) and PHPStan level 7 — but because Swarm does
+not isolate your application from Laravel AI, treat it as an integration-test
+event. See [UPGRADING.md](UPGRADING.md#upgrading-to-v0200) for the checklist.
+
+### Changed
+
+- **Requires `laravel/ai ^0.9`** (was `^0.8`). laravel/ai v0.9.0 consolidates
+  provider tool-calling onto a shared `TextGenerationLoop` / `StepTextGateway`,
+  switches Anthropic to native structured outputs by default (default text model
+  now Claude Sonnet 5), adds collection generics across response and streaming
+  events, and introduces new capabilities — filesystem tools for agents, a
+  `WithoutBroadcasting` stream-event attribute, native `anyOf` structured-output
+  schemas, and a configurable OpenAI-compatible provider. None of laravel/ai's
+  breaking changes (the removed `TextGateway` contract; the Anthropic
+  default-model change) affect Swarm's integration surface — the removed contract
+  is not referenced by Swarm, and no default model is pinned or asserted.
+
 ## v0.19.1 - 2026-07-11
 
 Documentation cohesiveness pass. Surfaces the shipped companion ecosystem — the

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ For background execution, streaming, and durable workflows, see [Choosing an Exe
 
 - PHP **^8.5**
 - Laravel **13** (`illuminate/*` **^13.0**)
-- `laravel/ai` **^0.8**
+- `laravel/ai` **^0.9**
 
-The PHP **^8.5** floor is a deliberate requirement — the package builds on 8.5 language features. As of **v0.13.0** the `laravel/ai` floor is **^0.8**; support for **0.6 / 0.7** was dropped. Consumers pinned below `laravel/ai` 0.8 must upgrade. See the [changelog](CHANGELOG.md#v0130---2026-06-23) for what the 0.8 adoption changes.
+The PHP **^8.5** floor is a deliberate requirement — the package builds on 8.5 language features. As of **v0.20.0** the `laravel/ai` floor is **^0.9**; support for **0.8** was dropped (0.6 / 0.7 were dropped earlier, in v0.13.0). Consumers pinned below `laravel/ai` 0.9 must upgrade. See the [changelog](CHANGELOG.md#v0200---2026-07-13) for what the 0.9 adoption changes.
 
 This package declares `"minimum-stability": "dev"` with `"prefer-stable": true` because `laravel/ai` is still pre-1.0 and ships dev-tagged releases. Composer will not resolve a pre-stable transitive dependency from a stable consuming project, so your application's `composer.json` must also set:
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -241,8 +241,9 @@ changes even when the application-facing swarm API stays the same.
 
 ## Dependency Upgrades
 
-`laravel/ai` is required in the **^0.8** range as of v0.13.0 (support for 0.6 /
-0.7 was dropped) and is **pre-1.0**. Public
+`laravel/ai` is required in the **^0.9** range as of v0.20.0 (support for 0.8
+was dropped; support for 0.6 / 0.7 was dropped earlier, in v0.13.0) and is
+**pre-1.0**. Public
 contracts, streaming behavior, and provider integrations can change between
 releases without the stability guarantees of a stable major line.
 
@@ -258,7 +259,7 @@ You may pin `laravel/ai` to an exact or narrower range in your application’s
 `composer.json` when you need reproducible builds or a slower upgrade cadence:
 
 ```bash
-composer require laravel/ai:0.8.1
+composer require laravel/ai:0.9.0
 ```
 
 That pins your application’s dependency resolution. It does not change the semver
@@ -268,6 +269,16 @@ This package’s `composer.json` uses `"minimum-stability": "dev"` with
 `"prefer-stable": true` so pre-stable dependencies can resolve while Composer
 still prefers tagged releases. Your application may need compatible Composer
 stability settings while Laravel AI remains pre-stable.
+
+## Upgrading to v0.20.0
+
+**Required action only if your application pins `laravel/ai` below 0.9.** This release raises Swarm's `laravel/ai` requirement from `^0.8` to `^0.9` (v0.9.0); support for the 0.8 line is dropped. Swarm's own source is unchanged — the upgrade is verified against the full test suite and PHPStan level 7 — but Composer will now resolve `laravel/ai` to 0.9.x, so treat it as an integration-test event:
+
+1. Run `composer update laravel/ai --with-all-dependencies`.
+2. Run your automated suite plus swarm-heavy smoke paths (queued, streamed, and durable execution).
+3. If you use structured-output agents, note that laravel/ai v0.9 uses native Anthropic structured outputs by default and strips markdown code fences before decoding; verify your structured-routing paths once against a live provider.
+
+None of laravel/ai's own breaking changes affect Swarm's integration surface: the removed `TextGateway` contract is not referenced by Swarm, and the Anthropic default-model change (now Claude Sonnet 5) is not pinned or asserted anywhere in Swarm. See the [CHANGELOG](CHANGELOG.md#v0200---2026-07-13) for details.
 
 ## Upgrading to v0.19.0
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "illuminate/queue": "^13.0",
         "illuminate/support": "^13.0",
         "illuminate/view": "^13.0",
-        "laravel/ai": "^0.8"
+        "laravel/ai": "^0.9"
     },
     "require-dev": {
         "builtbyberry/laravel-swarm-installer-testkit": "^0.1.0",

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "0.19.x-dev"
+            "dev-main": "0.20.x-dev"
         },
         "laravel": {
             "providers": [

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,11 +16,11 @@ the manual equivalent of every step the installer performs.
 
 - PHP **^8.5** (a deliberate floor — the package builds on 8.5 language features)
 - Laravel **13** (`illuminate/*` **^13.0**)
-- `laravel/ai` **^0.8** (a transitive dependency, installed by Composer)
+- `laravel/ai` **^0.9** (a transitive dependency, installed by Composer)
 
-As of **v0.13.0** the `laravel/ai` floor is **^0.8**; support for **0.6 / 0.7**
-was dropped. Applications pinned below `laravel/ai` 0.8 must upgrade before
-taking this release.
+As of **v0.20.0** the `laravel/ai` floor is **^0.9**; support for **0.8** was
+dropped (0.6 / 0.7 were dropped earlier, in v0.13.0). Applications pinned below
+`laravel/ai` 0.9 must upgrade before taking this release.
 
 Because `laravel/ai` is still pre-1.0 and ships dev-tagged releases, your
 application's `composer.json` must allow dev-stability resolution. Add the


### PR DESCRIPTION
## Release v0.20.0

Minor release. Raises the `laravel/ai` requirement from `^0.8` to `^0.9` (v0.9.0) and drops support for the 0.8 line. Semver-minor because it forces consumers pinned to laravel/ai 0.8.x to upgrade.

**No Swarm source changes** — this is a dependency-constraint bump plus its CHANGELOG/UPGRADING entries and an `AGENTS.md` Swarm-channel pin.

### laravel/ai v0.9.0 — breaking-change assessment (none hit Swarm)

- **`TextGateway` contract removed** → Swarm references neither it nor the new `StepTextGateway`/`TextGenerationLoop`; it sits a layer above provider gateways.
- **Anthropic default model → Claude Sonnet 5** → Swarm pins no default model and no test asserts on model names.
- All **22 laravel/ai symbols** Swarm imports still resolve under v0.9.0.
- `Enums\Lab` is used only as a type union — the new `Lab::OpenAICompatible` case is harmless (no exhaustive `match`).

### Verification (local, PHP 8.5.7)

- ✅ `pest` Feature/Unit/Installer — **1919 passed** (7720 assertions)
- ✅ `phpstan` larastan **level 7** — no errors (new upstream generics cost us nothing)
- ✅ `pest tests/ProcessConcurrency` (CI variant) — 5 passed
- ⏭️ Mutation suite skipped — measures test-suite quality, which this constraint-only diff doesn't change; `mutation.yml` covers it on its own cadence.

### Commits

- `chore: pin laravel-swarm Swarm channel in AGENTS.md`
- `chore: upgrade laravel/ai constraint to ^0.9`
- `docs: changelog + upgrading entries for v0.20.0 (laravel/ai ^0.9)`

### Notes / follow-ups (not in this release)

- Structured-output behavior changed upstream (native Anthropic + code-fence stripping). Our suite exercises it via fakes, not a live provider — worth an eyeball on the first real structured-routing run.
- New capabilities worth scoping later: `WithoutBroadcasting` (durable-streaming/broadcast path), upstream filesystem tools (blueprint corpus), native `anyOf` schemas (structured routing/dispatch).

Draft until `/release-wrap` (review → changelog finalize → readiness) is run.

---

## Wrap status — ready for tag ✅

- **Phase 1 · change review:** `approve-with-followups` — F1 branch-alias lag (fixed), F2 channel-pin-not-in-changelog (accepted, internal marker).
- **Phase 2 · release-wrap:** CHANGELOG + UPGRADING v0.20.0 finalized; branch-alias bumped `0.19.x-dev` → `0.20.x-dev`; README requirements reflect `^0.9`.
- **Phase 3 · readiness:** `ship` · non-blocker — all 8 lenses clean.
- **Gate before merge/tag:** full CI matrix on this PR must be green (OG1).

**Tag after merge** (on `main`, never the release branch):
```
git switch main && git pull && git tag v0.20.0 && git push origin v0.20.0
```