### PR TITLE
feat: honor #[WithoutBroadcasting] in swarm's broadcast path (v0.21.0 ①)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@ tightened static analysis across the `laravel/ai` collection boundary.
 
 ### Added
 
-_To be filled in during release wrap-up._
+- **Broadcast suppression via `#[WithoutBroadcasting]`.** A swarm can now declare
+  `laravel/ai`'s `#[WithoutBroadcasting(SwarmTextDelta::class, ...)]` attribute to
+  keep high-frequency stream-event types out of the broadcast. All three broadcast
+  helpers (`broadcast()`, `broadcastNow()`, `broadcastOnQueue()`) honor it.
+  Suppression affects broadcast delivery only — the events still flow through the
+  returned stream and crash-replay persistence, and suppressed events emit no
+  `broadcast.event` telemetry. See [docs/streaming.md](docs/streaming.md#suppressing-event-types-from-broadcast).
 
 ### Changed
 

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -124,6 +124,44 @@ helper or queued job still fails, but swarm execution has already completed:
 history remains completed, and persisted replay may include the terminal event.
 Use Laravel's broadcast and queue infrastructure for transport retries.
 
+### Suppressing event types from broadcast
+
+High-frequency events — `swarm_text_delta`, `swarm_reasoning_delta` — can flood a
+broadcast channel while adding little to a UI that only needs step boundaries and
+the final output. Declare `laravel/ai`'s `#[WithoutBroadcasting]` attribute on the
+swarm to keep those event types out of the broadcast, naming the
+`SwarmStreamEvent` classes to skip:
+
+```php
+use BuiltByBerry\LaravelSwarm\Concerns\Runnable;
+use BuiltByBerry\LaravelSwarm\Contracts\Swarm;
+use BuiltByBerry\LaravelSwarm\Streaming\Events\SwarmReasoningDelta;
+use BuiltByBerry\LaravelSwarm\Streaming\Events\SwarmTextDelta;
+use Laravel\Ai\Attributes\WithoutBroadcasting;
+
+#[WithoutBroadcasting(SwarmTextDelta::class, SwarmReasoningDelta::class)]
+class ArticlePipeline implements Swarm
+{
+    use Runnable;
+
+    // ...
+}
+```
+
+The attribute is honored by all three broadcast helpers — `broadcast()`,
+`broadcastNow()`, and `broadcastOnQueue()`. It is a **static, per-class opt-out**:
+it names event *types* to skip, not a dynamic size threshold.
+
+Suppression affects **broadcast delivery only**. The suppressed events still flow
+through the returned stream and through crash-replay persistence exactly as
+before — so the final output is fully assembled, `stream()` consumers are
+unaffected, and a persisted replay still contains every event. Suppressed events
+also emit no `broadcast.event` telemetry, since nothing was broadcast for them
+(the broadcast sequence index still advances past them, so surviving events keep
+their true stream position). To drop an event type from the stream *and* replay,
+not just the broadcast, use the context-growth governor instead (see
+`swarm.context_growth`).
+
 ## Stream Event Types
 
 Swarm streams emit typed events, including:

--- a/src/Jobs/BroadcastSwarm.php
+++ b/src/Jobs/BroadcastSwarm.php
@@ -20,6 +20,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Laravel\Ai\Attributes\WithoutBroadcasting;
 
 /**
  * @phpstan-import-type SwarmBroadcastChannels from \BuiltByBerry\LaravelSwarm\Support\PhpStanTypeAliases
@@ -68,8 +69,20 @@ class BroadcastSwarm implements ShouldQueue
             $sequenceIndex = 0;
             $channelNames = self::normalizeBroadcastChannelNames($this->channels);
 
+            // A swarm may declare #[WithoutBroadcasting(SwarmTextDelta::class, ...)]
+            // to suppress specific stream-event types from the broadcast. Resolve
+            // the skip set once; excluded events advance the sequence position but
+            // are neither broadcast nor recorded as broadcast telemetry.
+            $withoutBroadcasting = WithoutBroadcasting::eventsFor($swarm);
+
             $runner->stream($swarm, $context)
-                ->each(function (SwarmStreamEvent $event) use ($telemetry, $context, $swarm, &$sequenceIndex, $streamStart, $channelNames, $resolver): void {
+                ->each(function (SwarmStreamEvent $event) use ($telemetry, $context, $swarm, &$sequenceIndex, $streamStart, $channelNames, $resolver, $withoutBroadcasting): void {
+                    if (WithoutBroadcasting::excludes($withoutBroadcasting, $event)) {
+                        $sequenceIndex++;
+
+                        return;
+                    }
+
                     $type = $event->toArray()['type'] ?? 'unknown';
 
                     $telemetry->emit('broadcast.event', [

--- a/src/Runners/SwarmRunner.php
+++ b/src/Runners/SwarmRunner.php
@@ -43,6 +43,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Foundation\Bus\PendingDispatch;
+use Laravel\Ai\Attributes\WithoutBroadcasting;
 use Throwable;
 
 /**
@@ -324,8 +325,17 @@ class SwarmRunner
      */
     public function broadcast(Swarm $swarm, string|array|RunContext $task, Channel|array $channels, bool $now = false): StreamableSwarmResponse
     {
+        // Honor a swarm's #[WithoutBroadcasting(...)] declaration: excluded
+        // stream-event types still flow through the returned stream (so replay
+        // and terminal persistence are unaffected) but are never broadcast.
+        $withoutBroadcasting = WithoutBroadcasting::eventsFor($swarm);
+
         return $this->stream($swarm, $task)
-            ->each(function (SwarmStreamEvent $event) use ($channels, $now): void {
+            ->each(function (SwarmStreamEvent $event) use ($channels, $now, $withoutBroadcasting): void {
+                if (WithoutBroadcasting::excludes($withoutBroadcasting, $event)) {
+                    return;
+                }
+
                 $event->{$now ? 'broadcastNow' : 'broadcast'}($channels);
             });
     }

--- a/tests/Feature/WithoutBroadcastingTest.php
+++ b/tests/Feature/WithoutBroadcastingTest.php
@@ -12,7 +12,6 @@ use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\FakeSequentialSwarm;
 use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\WithoutBroadcastingSequentialSwarm;
 use Illuminate\Broadcasting\AnonymousEvent;
 use Illuminate\Broadcasting\Channel;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Event;
 
 /**

--- a/tests/Feature/WithoutBroadcastingTest.php
+++ b/tests/Feature/WithoutBroadcastingTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmTelemetrySink;
+use BuiltByBerry\LaravelSwarm\Telemetry\SwarmTelemetryDispatcher;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\FakeEditor;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\FakeResearcher;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\FakeWriter;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\RecordingSwarmTelemetrySink;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\FakeSequentialSwarm;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\WithoutBroadcastingSequentialSwarm;
+use Illuminate\Broadcasting\AnonymousEvent;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Event;
+
+/**
+ * Collect the type strings (`broadcastAs()`) of every anonymous broadcast the
+ * run dispatched, in order.
+ *
+ * @return array<int, string>
+ */
+function broadcastTypes(): array
+{
+    return Event::dispatched(AnonymousEvent::class)
+        ->map(fn (array $event): AnonymousEvent => $event[0])
+        ->map(fn (AnonymousEvent $event): string => $event->broadcastAs())
+        ->values()
+        ->all();
+}
+
+beforeEach(function () {
+    FakeResearcher::fake(['research-out']);
+    FakeWriter::fake(['writer-out']);
+    FakeEditor::fake(['editor-out']);
+});
+
+test('sync broadcast suppresses the excluded stream-event type but keeps the rest', function () {
+    Event::fake([AnonymousEvent::class]);
+
+    $response = WithoutBroadcastingSequentialSwarm::make()
+        ->broadcast('broadcast-task', new Channel('swarm.run'));
+
+    // The stream itself is untouched: the text delta still flows through, so the
+    // final output is fully assembled even though the delta is never broadcast.
+    expect($response->streamedResponse?->output)->toBe('editor-out');
+
+    $types = broadcastTypes();
+
+    // The excluded type is gone from the broadcast...
+    expect($types)->not->toContain('swarm_text_delta');
+    // ...while every other event type still broadcasts, in order.
+    expect($types)->toContain('swarm_stream_start', 'swarm_text_end', 'swarm_stream_end');
+});
+
+test('a swarm without the attribute still broadcasts the delta (control)', function () {
+    Event::fake([AnonymousEvent::class]);
+
+    FakeSequentialSwarm::make()->broadcast('broadcast-task', new Channel('swarm.run'));
+
+    // Guards against over-suppression: absent the attribute, nothing is filtered.
+    expect(broadcastTypes())->toContain('swarm_text_delta');
+});
+
+test('queued broadcast suppresses the excluded type from both broadcast and broadcast.event telemetry', function () {
+    config(['queue.default' => 'sync']);
+    Event::fake([AnonymousEvent::class]);
+
+    $sink = new RecordingSwarmTelemetrySink;
+    app()->instance(SwarmTelemetrySink::class, $sink);
+    app()->forgetInstance(SwarmTelemetryDispatcher::class);
+
+    WithoutBroadcastingSequentialSwarm::make()
+        ->broadcastOnQueue('broadcast-task', new Channel('swarm.run'));
+
+    // Not broadcast...
+    expect(broadcastTypes())
+        ->not->toContain('swarm_text_delta')
+        ->toContain('swarm_stream_start', 'swarm_stream_end');
+
+    // ...and not recorded as a broadcast.event (nothing was broadcast for it).
+    $broadcastEventTypes = collect($sink->recordsForCategory('broadcast.event'))
+        ->map(fn (array $r): string => (string) ($r['event_type'] ?? ''))
+        ->all();
+
+    expect($broadcastEventTypes)
+        ->not->toContain('swarm_text_delta')
+        ->toContain('swarm_stream_start', 'swarm_stream_end');
+
+    // The suppressed event still advances the broadcast sequence, so the indices
+    // of the events that DO broadcast stay strictly increasing (gaps allowed).
+    $indices = collect($sink->recordsForCategory('broadcast.event'))
+        ->map(fn (array $r): int => (int) ($r['sequence_index'] ?? -1))
+        ->all();
+
+    expect($indices)->toBe(array_values(collect($indices)->sort()->values()->all()));
+    expect(count($indices))->toBe(count(array_unique($indices)));
+});

--- a/tests/Fixtures/Swarms/WithoutBroadcastingSequentialSwarm.php
+++ b/tests/Fixtures/Swarms/WithoutBroadcastingSequentialSwarm.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms;
+
+use BuiltByBerry\LaravelSwarm\Attributes\Topology;
+use BuiltByBerry\LaravelSwarm\Concerns\Runnable;
+use BuiltByBerry\LaravelSwarm\Contracts\Swarm;
+use BuiltByBerry\LaravelSwarm\Enums\Topology as TopologyEnum;
+use BuiltByBerry\LaravelSwarm\Streaming\Events\SwarmTextDelta;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\FakeEditor;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\FakeResearcher;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\FakeWriter;
+use Laravel\Ai\Attributes\WithoutBroadcasting;
+
+/**
+ * A sequential swarm that suppresses the high-frequency {@see SwarmTextDelta}
+ * stream events from broadcast via laravel/ai's #[WithoutBroadcasting] attribute,
+ * while leaving every other event type (and the underlying stream / persistence)
+ * untouched.
+ */
+#[Topology(TopologyEnum::Sequential)]
+#[WithoutBroadcasting(SwarmTextDelta::class)]
+class WithoutBroadcastingSequentialSwarm implements Swarm
+{
+    use Runnable;
+
+    public function agents(): array
+    {
+        return [
+            new FakeResearcher,
+            new FakeWriter,
+            new FakeEditor,
+        ];
+    }
+}


### PR DESCRIPTION
**Component ① of v0.21.0** — `without-broadcasting-honoring` (Marshall-tracked).

Swarm's own broadcast path (`BroadcastSwarm` queued job + `SwarmRunner::broadcast` sync) now consults `laravel/ai`'s `WithoutBroadcasting::eventsFor($swarm)` and skips excluded stream-event types. `laravel/ai` honored the attribute in `Promptable`/`BroadcastAgent`, but swarm re-wraps events into its own `SwarmStreamEvent` broadcast loop, which ignored it.

Suppression affects **broadcast delivery only** — excluded events still flow through the returned stream and crash-replay persistence, and emit no `broadcast.event` telemetry (the broadcast sequence index still advances past them).

### Changes
- `src/Jobs/BroadcastSwarm.php`, `src/Runners/SwarmRunner.php` — honor the attribute in both paths
- `tests/Feature/WithoutBroadcastingTest.php` (+fixture) — sync + queued suppression, a control (no attribute → delta still broadcasts), and telemetry suppression
- `docs/streaming.md` — "Suppressing event types from broadcast"
- `CHANGELOG.md` — v0.21.0 Added entry

Base: `release/v0.21.0`. phpstan L7 clean, Pest green (17 passed in the touched suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)