### PR TITLE
chore: drop @var overrides now covered by ^0.9 collection generics (v0.21.0 ④)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ _To be filled in during release wrap-up._
 
 ### Changed
 
-_To be filled in during release wrap-up._
+- Dropped now-redundant local `@var` overrides in `SnapshotToolCallNormalizer`:
+  `laravel/ai` ^0.9 types `TextResponse::$toolCalls` / `$toolResults` as
+  `Collection<int, ToolCall>` / `Collection<int, ToolResult>`, so the element
+  types now flow across the boundary without hand-maintained casts. Internal
+  only — no behavior change; PHPStan level 7 stays clean.
 
 ## v0.20.0 - 2026-07-13
 

--- a/src/Memory/SnapshotToolCallNormalizer.php
+++ b/src/Memory/SnapshotToolCallNormalizer.php
@@ -46,12 +46,13 @@ final class SnapshotToolCallNormalizer
             return [];
         }
 
-        /** @var array<int, ToolCall> $toolCalls */
-        $toolCalls = $response->toolCalls->all();
-        /** @var array<int, ToolResult> $toolResults */
-        $toolResults = $response->toolResults->all();
-
-        return self::pair($toolCalls, $toolResults);
+        // laravel/ai ^0.9 types these as Collection<int, ToolCall> /
+        // Collection<int, ToolResult>, so `->all()` is already precisely typed
+        // across the boundary — no local @var override needed.
+        return self::pair(
+            $response->toolCalls->all(),
+            $response->toolResults->all(),
+        );
     }
 
     /**


### PR DESCRIPTION
**Component ④ of v0.21.0** — `collection-generics-cleanup` (Marshall-tracked).

`laravel/ai` ^0.9 types `TextResponse::$toolCalls` / `$toolResults` as `Collection<int, ToolCall>` / `Collection<int, ToolResult>`, so `->all()` is already precisely typed across the boundary. Drops the two now-redundant local `@var` overrides in `SnapshotToolCallNormalizer::fromResponse()`.

Internal type-annotation cleanup — **no behavior change**. PHPStan level 7 clean; existing normalizer behavior tests (backward-compat + MCP passthrough, 7 tests) green. No `phpstan.neon` changes (its only ignore block is unrelated DB `stdClass` rows).

Base: `release/v0.21.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)