### PR TITLE
feat: enrich hierarchical coordinator route-plan schema with anyOf (v0.21.0 ③)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,14 @@ tightened static analysis across the `laravel/ai` collection boundary.
 
 ### Added
 
-_To be filled in during release wrap-up._
+- **`RoutePlanSchema` for richer hierarchical coordinator schemas.** A reusable
+  helper (`BuiltByBerry\LaravelSwarm\Routing\RoutePlanSchema`) that types each
+  route-plan node variant (worker, rollup, parallel, finish) and combines them
+  with `laravel/ai` ^0.9's native `anyOf`, so a coordinator with a known node
+  skeleton can constrain the model to a valid node shape up front instead of
+  relying solely on post-hoc validation. The hierarchical-support-triage example
+  now uses it. `HierarchicalRoutePlanner` remains the authoritative validator.
+  See [docs/hierarchical-routing.md](docs/hierarchical-routing.md#constraining-node-shape-with-anyof).
 
 ### Changed
 

--- a/docs/hierarchical-routing.md
+++ b/docs/hierarchical-routing.md
@@ -66,6 +66,50 @@ Node definitions use a `type` discriminator:
 - `parallel`
 - `finish`
 
+### Constraining node shape with `anyOf`
+
+`nodes => $schema->object()` is intentionally loose: the model may emit any node
+payload and the [validator](#validation-rules) rejects a malformed plan only
+*after* generation. When your coordinator's plan has a **known node skeleton**
+(fixed node ids), you can type each slot precisely so the model self-constrains
+up front. `RoutePlanSchema` turns each node variant into a JsonSchema type and
+combines them with `laravel/ai` ^0.9's native `anyOf`:
+
+```php
+use BuiltByBerry\LaravelSwarm\Routing\RoutePlanSchema;
+
+public function schema(JsonSchema $schema): array
+{
+    return [
+        'start_at' => $schema->string()->required(),
+        'nodes' => $schema->object([
+            // A handler slot: worker | rollup | parallel | finish.
+            'respond' => RoutePlanSchema::node($schema),
+            // A terminal slot: exactly one of `output` / `output_from`.
+            'done' => RoutePlanSchema::finish($schema),
+        ])->required(),
+    ];
+}
+```
+
+`RoutePlanSchema` exposes `worker()`, `rollup()`, `parallel()`, `finish()` (the
+exactly-one-of `output` / `output_from` union), and `node()` (the full
+discriminated union of all four). Each returns a first-class `Type`, so you can
+compose them anywhere a schema property is expected.
+
+Two boundaries to keep in mind:
+
+- **The planner stays authoritative.** `anyOf` constrains per-node *shape* only.
+  The graph-level [validation rules](#validation-rules) — reachability, DAG
+  acyclicity, named-output ordering, loop bounds — are still enforced by
+  `HierarchicalRoutePlanner` after the plan is assembled. `anyOf` makes a
+  well-formed plan the easy path; it does not replace validation.
+- **`object()` types named properties only.** It cannot type the values of a
+  free-form map, so this pattern fits a fixed node skeleton. For a fully dynamic
+  node map, keep `nodes => $schema->object()` and rely on the planner. `laravel/ai`
+  ^0.9 preserves `anyOf` end-to-end (earlier versions collapsed it), so the union
+  reaches the provider intact.
+
 ## Node Types
 
 ### Worker Nodes

--- a/src/Routing/RoutePlanSchema.php
+++ b/src/Routing/RoutePlanSchema.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Routing;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\JsonSchema\Types\Type;
+
+/**
+ * Reusable JsonSchema builders for a hierarchical coordinator's route plan.
+ *
+ * A hierarchical coordinator declares its route-plan shape in `schema()`. Left
+ * to `nodes => $schema->object()`, that shape is opaque — the model is free to
+ * emit any node payload and {@see HierarchicalRoutePlanner} rejects malformed
+ * plans only *after* generation. These helpers turn each node variant the
+ * planner accepts (worker, rollup, parallel, finish) into a precise JsonSchema
+ * type, and combine them with `anyOf` so the model self-constrains to a valid
+ * node shape up front.
+ *
+ * `laravel/ai` ^0.9 preserves `anyOf` end-to-end (its `SchemaNormalizer` keeps
+ * the composition instead of collapsing it), so these unions reach the provider
+ * intact.
+ *
+ * **The planner stays authoritative.** These schemas describe per-node *shape*
+ * only — they cannot express the graph-level invariants the planner still
+ * enforces (reachability from `start_at`, DAG acyclicity, data-dependency
+ * ordering, loop bounds). Treat them as a first line of defense that makes a
+ * well-formed plan the easy path, not a replacement for validation.
+ *
+ * `JsonSchema\Types\ObjectType` types named properties only — it cannot type the
+ * values of a free-form map. So compose these where the plan's node ids are a
+ * known skeleton (`$schema->object(['classify' => node(), 'done' => finish()])`);
+ * for a fully dynamic node map, `nodes => $schema->object()` plus the planner's
+ * validation remains the fallback.
+ */
+final class RoutePlanSchema
+{
+    /**
+     * A worker node: run one agent with a prompt, then continue to `next`.
+     */
+    public static function worker(JsonSchema $schema): Type
+    {
+        return $schema->object([
+            'type' => $schema->string()->enum(['worker'])->required(),
+            'agent' => $schema->string()
+                ->description('Fully-qualified worker agent class to run for this node.')
+                ->required(),
+            'prompt' => $schema->string()
+                ->description('The prompt handed to the worker agent.')
+                ->required(),
+            'next' => $schema->string()
+                ->description('Id of the node to run after this worker completes.')
+                ->required(),
+        ]);
+    }
+
+    /**
+     * A rollup node: a worker that digests the generation(s) named by
+     * `with_outputs`. Like a worker but it must name what it digests and cannot
+     * carry a loop of its own.
+     */
+    public static function rollup(JsonSchema $schema): Type
+    {
+        return $schema->object([
+            'type' => $schema->string()->enum(['rollup'])->required(),
+            'agent' => $schema->string()
+                ->description('Fully-qualified agent class that digests the named generations.')
+                ->required(),
+            'prompt' => $schema->string()
+                ->description('The prompt handed to the rollup agent.')
+                ->required(),
+            'with_outputs' => $schema->array()
+                ->items($schema->string())
+                ->min(1)
+                ->description('Ids of the node generations this rollup digests.')
+                ->required(),
+            'next' => $schema->string()
+                ->description('Id of the node to run after this rollup completes.')
+                ->required(),
+        ]);
+    }
+
+    /**
+     * A parallel node: fan out to the worker nodes named in `branches`, joining
+     * at `next` once every branch completes.
+     */
+    public static function parallel(JsonSchema $schema): Type
+    {
+        return $schema->object([
+            'type' => $schema->string()->enum(['parallel'])->required(),
+            'branches' => $schema->array()
+                ->items($schema->string())
+                ->min(1)
+                ->description('Ids of the worker nodes to run concurrently.')
+                ->required(),
+            'next' => $schema->string()
+                ->description('The join node to run after all branches complete.')
+                ->required(),
+        ]);
+    }
+
+    /**
+     * A finish node: end the run, returning **exactly one** of `output` (a
+     * literal answer) or `output_from` (another node's generation). The
+     * exactly-one-of rule is expressed as an `anyOf` of the two variants.
+     */
+    public static function finish(JsonSchema $schema): Type
+    {
+        return $schema->anyOf([
+            self::finishWithOutput($schema),
+            self::finishWithOutputFrom($schema),
+        ]);
+    }
+
+    /**
+     * The full node discriminated union: a node is one of worker, rollup,
+     * parallel, or finish. Use this to type each slot of a known node skeleton.
+     */
+    public static function node(JsonSchema $schema): Type
+    {
+        return $schema->anyOf([
+            self::worker($schema),
+            self::rollup($schema),
+            self::parallel($schema),
+            self::finishWithOutput($schema),
+            self::finishWithOutputFrom($schema),
+        ]);
+    }
+
+    /**
+     * The `finish` variant that returns a literal `output`.
+     */
+    private static function finishWithOutput(JsonSchema $schema): Type
+    {
+        return $schema->object([
+            'type' => $schema->string()->enum(['finish'])->required(),
+            'output' => $schema->string()
+                ->description('A literal final answer to return from the run.')
+                ->required(),
+        ]);
+    }
+
+    /**
+     * The `finish` variant that returns another node's generation via
+     * `output_from`.
+     */
+    private static function finishWithOutputFrom(JsonSchema $schema): Type
+    {
+        return $schema->object([
+            'type' => $schema->string()->enum(['finish'])->required(),
+            'output_from' => $schema->string()
+                ->description("Id of the node whose generation becomes the run's output.")
+                ->required(),
+        ]);
+    }
+}

--- a/stubs/examples/hierarchical-support-triage/app/Ai/Agents/HierarchicalSupportTriage/RequestClassifier.php
+++ b/stubs/examples/hierarchical-support-triage/app/Ai/Agents/HierarchicalSupportTriage/RequestClassifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace {{ rootNamespace }}\Ai\Agents\HierarchicalSupportTriage;
 
+use BuiltByBerry\LaravelSwarm\Routing\RoutePlanSchema;
 use BuiltByBerry\LaravelSwarm\Testing\ScriptedAgent;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Support\Str;
@@ -38,13 +39,27 @@ class RequestClassifier extends ScriptedAgent implements HasStructuredOutput
      * The route-plan schema the coordinator promises to fill. Laravel Swarm
      * validates the coordinator's output against this shape before executing.
      *
+     * This coordinator's plan is a fixed two-node skeleton — a `respond` handler
+     * followed by a `done` terminal — so each slot is typed precisely with
+     * {@see RoutePlanSchema}: `respond` is the full node union (here the model
+     * always picks a worker, but a parallel fan-out would also validate), and
+     * `done` is a finish node returning exactly one of `output` / `output_from`.
+     * The `anyOf` unions let the model self-constrain to a valid node shape;
+     * {@see \BuiltByBerry\LaravelSwarm\Routing\HierarchicalRoutePlanner} still
+     * validates the assembled plan as a DAG.
+     *
      * @return array<string, \Illuminate\JsonSchema\Types\Type>
      */
     public function schema(JsonSchema $schema): array
     {
         return [
-            'start_at' => $schema->string()->required(),
-            'nodes' => $schema->object()->required(),
+            'start_at' => $schema->string()
+                ->description('Id of the first node to run.')
+                ->required(),
+            'nodes' => $schema->object([
+                'respond' => RoutePlanSchema::node($schema),
+                'done' => RoutePlanSchema::finish($schema),
+            ])->required(),
         ];
     }
 

--- a/tests/Fixtures/Agents/AnyOfRoutePlanCoordinator.php
+++ b/tests/Fixtures/Agents/AnyOfRoutePlanCoordinator.php
@@ -7,6 +7,7 @@ namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents;
 use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use BuiltByBerry\LaravelSwarm\Routing\RoutePlanSchema;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\JsonSchema\Types\Type;
 use Laravel\Ai\Contracts\HasStructuredOutput;
 use Laravel\Ai\Promptable;
 
@@ -27,7 +28,7 @@ class AnyOfRoutePlanCoordinator implements Agent, HasStructuredOutput
     }
 
     /**
-     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     * @return array<string, Type>
      */
     public function schema(JsonSchema $schema): array
     {

--- a/tests/Fixtures/Agents/AnyOfRoutePlanCoordinator.php
+++ b/tests/Fixtures/Agents/AnyOfRoutePlanCoordinator.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents;
+
+use BuiltByBerry\LaravelSwarm\Contracts\Agent;
+use BuiltByBerry\LaravelSwarm\Routing\RoutePlanSchema;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\HasStructuredOutput;
+use Laravel\Ai\Promptable;
+
+/**
+ * A hierarchical coordinator whose route-plan schema uses {@see RoutePlanSchema}
+ * `anyOf` node unions — mirroring the shipped hierarchical-support-triage example
+ * stub. Exists so the anyOf enrichment is exercised against a real
+ * container-resolvable agent (the stub itself carries a `{{ rootNamespace }}`
+ * placeholder and is not autoloadable).
+ */
+class AnyOfRoutePlanCoordinator implements Agent, HasStructuredOutput
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'Route the request to exactly one handler, then finish.';
+    }
+
+    /**
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'start_at' => $schema->string()
+                ->description('Id of the first node to run.')
+                ->required(),
+            'nodes' => $schema->object([
+                'respond' => RoutePlanSchema::node($schema),
+                'done' => RoutePlanSchema::finish($schema),
+            ])->required(),
+        ];
+    }
+}

--- a/tests/Unit/Routing/RoutePlanSchemaTest.php
+++ b/tests/Unit/Routing/RoutePlanSchemaTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use BuiltByBerry\LaravelSwarm\Routing\RoutePlanSchema;
 use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\AnyOfRoutePlanCoordinator;
 use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\JsonSchema\Types\Type;
 use Laravel\Ai\Schema\SchemaNormalizer;
 
 /**
@@ -12,7 +13,7 @@ use Laravel\Ai\Schema\SchemaNormalizer;
  * wrap the property map in an object type, render to a raw JSON Schema array,
  * then run it through laravel/ai's SchemaNormalizer.
  *
- * @param  array<string, \Illuminate\JsonSchema\Types\Type>  $properties
+ * @param  array<string, Type>  $properties
  * @return array<string, mixed>
  */
 function normalizeCoordinatorSchema(JsonSchemaTypeFactory $factory, array $properties): array

--- a/tests/Unit/Routing/RoutePlanSchemaTest.php
+++ b/tests/Unit/Routing/RoutePlanSchemaTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Routing\RoutePlanSchema;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\AnyOfRoutePlanCoordinator;
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\Schema\SchemaNormalizer;
+
+/**
+ * Serialize a coordinator's schema() the way laravel/ai does before dispatch:
+ * wrap the property map in an object type, render to a raw JSON Schema array,
+ * then run it through laravel/ai's SchemaNormalizer.
+ *
+ * @param  array<string, \Illuminate\JsonSchema\Types\Type>  $properties
+ * @return array<string, mixed>
+ */
+function normalizeCoordinatorSchema(JsonSchemaTypeFactory $factory, array $properties): array
+{
+    return SchemaNormalizer::normalize($factory->object($properties)->toArray());
+}
+
+test('the coordinator route-plan schema round-trips through laravel/ai with anyOf preserved', function () {
+    $factory = new JsonSchemaTypeFactory;
+
+    $normalized = normalizeCoordinatorSchema(
+        $factory,
+        (new AnyOfRoutePlanCoordinator)->schema($factory),
+    );
+
+    $encoded = json_encode($normalized, JSON_THROW_ON_ERROR);
+
+    // supportsAnyOf() is true on ^0.9, so the normalizer preserves both unions
+    // (the node union on `respond`, the finish union on `done`) rather than
+    // collapsing them.
+    expect(substr_count($encoded, '"anyOf"'))->toBe(2);
+
+    $respond = $normalized['properties']['nodes']['properties']['respond'];
+    expect($respond)->toHaveKey('anyOf');
+    // The node union enumerates every node variant the planner accepts.
+    expect($encoded)->toContain('worker', 'rollup', 'parallel', 'finish');
+});
+
+test('the finish union expresses exactly-one-of output / output_from', function () {
+    $factory = new JsonSchemaTypeFactory;
+
+    $normalized = normalizeCoordinatorSchema(
+        $factory,
+        (new AnyOfRoutePlanCoordinator)->schema($factory),
+    );
+
+    $done = $normalized['properties']['nodes']['properties']['done'];
+
+    expect($done)->toHaveKey('anyOf');
+    expect($done['anyOf'])->toHaveCount(2);
+
+    // Each branch requires the discriminator plus exactly one of the two output
+    // keys — the schema-level encoding of the planner's exactly-one-of rule.
+    $requiredSets = array_map(
+        fn (array $branch): array => $branch['required'],
+        $done['anyOf'],
+    );
+
+    expect($requiredSets)->toContain(['type', 'output']);
+    expect($requiredSets)->toContain(['type', 'output_from']);
+});
+
+test('RoutePlanSchema node union is composable directly by coordinator authors', function () {
+    $factory = new JsonSchemaTypeFactory;
+
+    // The helper returns a first-class Type usable anywhere a schema property is
+    // expected — not only inside the shipped example.
+    $node = RoutePlanSchema::node($factory);
+    $raw = $node->toArray();
+
+    expect($raw)->toHaveKey('anyOf');
+    expect($raw['anyOf'])->toHaveCount(5); // worker, rollup, parallel, finish×2
+
+    $normalized = SchemaNormalizer::normalize($raw);
+    expect($normalized)->toHaveKey('anyOf');
+});


### PR DESCRIPTION
**Component ③ of v0.21.0** — `anyof-coordinator-schemas` (Marshall-tracked).

Adds `Routing\RoutePlanSchema` — a reusable helper that types each route-plan node variant (worker, rollup, parallel, finish) and combines them with `laravel/ai` ^0.9's native `anyOf`, so a coordinator with a known node skeleton self-constrains the model to a valid node shape up front instead of relying solely on post-hoc rejection.

### Why a helper (not just a stub edit)
The shipped example stub carries a `{{ rootNamespace }}` placeholder and isn't autoloadable, so a copy-pasted schema couldn't be tested and would drift. `RoutePlanSchema` is real, reusable API — the stub and the test both use it.

### Changes
- `src/Routing/RoutePlanSchema.php` — `worker()`, `rollup()`, `parallel()`, `finish()` (exactly-one-of `output`/`output_from`), `node()` (full union)
- hierarchical-support-triage example stub — `respond` = node union, `done` = finish union
- `tests/Unit/Routing/RoutePlanSchemaTest.php` (+ fixture coordinator) — round-trips through `laravel/ai`'s `SchemaNormalizer` with `anyOf` preserved; finish union enforces exactly-one-of; helper is composable standalone
- `docs/hierarchical-routing.md` — "Constraining node shape with `anyOf`"
- `CHANGELOG.md`

### Boundaries (documented)
`anyOf` constrains per-node *shape* only — `HierarchicalRoutePlanner` still enforces graph invariants (reachability, acyclicity, named-output ordering, loop bounds). `object()` types named properties only, so the pattern fits a fixed node skeleton; dynamic node maps keep `object()` + planner validation.

Base: `release/v0.21.0`. phpstan L7 clean (full src); Pest green (3 new + 31 hierarchical routing, no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)