### PR TITLE
feat(runner): Swarm::agent() single-agent front door

### DIFF
--- a/docs/execution-modes.md
+++ b/docs/execution-modes.md
@@ -2,6 +2,30 @@
 
 Every swarm class supports six execution modes through the `Runnable` trait: `prompt()` (and its alias `run()`), `queue()`, `stream()`, `broadcast()` / `broadcastNow()`, `broadcastOnQueue()`, and `dispatchDurable()`. The mode you choose determines whether the run is synchronous or background, whether it streams tokens to the caller, and whether it can recover from partial failures mid-run. Most of the modes mirror the Laravel AI agent API deliberately — if you know how to run an agent, the same verbs work on swarms.
 
+## Single Agent (`Swarm::agent()`)
+
+You do not need to author a `Swarm` class to get the governed pipeline for a single agent. `Swarm::agent($agent)` wraps a lone agent in a one-element swarm and runs it through the **same** `SwarmRunner` a multi-agent swarm uses — so it inherits audit, guardrails, capture, telemetry and encrypt-at-rest identically, and exposes **every** execution mode below:
+
+```php
+use BuiltByBerry\LaravelSwarm\Facades\Swarm;
+
+Swarm::agent($agent)->prompt($task);
+Swarm::agent($agent)->stream($task);
+Swarm::agent($agent)->queue($task);
+Swarm::agent($agent)->broadcast($task, $channel);
+Swarm::agent($agent)->dispatchDurable($task);
+```
+
+A swarm of one is still a swarm — there is no second, ungoverned path. Governance is on by default: the app's globally configured guardrails (`swarm.guardrails.*`) apply automatically, and you can layer per-call guardrails on top without replacing them:
+
+```php
+Swarm::agent($agent)
+    ->guardrails([BudgetGuardrail::class])
+    ->prompt($task);
+```
+
+Reach for a full `Swarm` class when you need multiple agents, a non-sequential topology, or class-level configuration; reach for `Swarm::agent()` when one agent is all you need and you still want the audit trail.
+
 ## Comparison Table
 
 | Method | Return Type | Runs in Background | Streaming | Checkpointing | Recovery | Complexity |

--- a/docs/public-surface.md
+++ b/docs/public-surface.md
@@ -8,6 +8,7 @@ adding a new public API.
 
 | Surface | Purpose | Primary documentation |
 | --- | --- | --- |
+| `Swarm::agent()` | Run a single agent through the full governed pipeline without authoring a `Swarm` class; returns a fluent `PendingAgentRun` exposing every execution mode. | [Execution Modes: Single Agent](execution-modes.md#single-agent-swarmagent) |
 | `prompt()` | Run a swarm synchronously and return `SwarmResponse`. | [README: Running A Swarm](../README.md#running-a-swarm), [Sequential Content Pipeline](../examples/sequential-content-pipeline/README.md) |
 | `run()` | Compatibility alias for `prompt()`. | [README: Running A Swarm](../README.md#running-a-swarm) |
 | `queue()` | Dispatch a lightweight background swarm job. | [README: Queueing A Swarm](../README.md#queueing-a-swarm), [Queued Workflow Events](../examples/queued-workflow-events/README.md) |

--- a/src/Runners/SwarmRunner.php
+++ b/src/Runners/SwarmRunner.php
@@ -6,6 +6,7 @@ namespace BuiltByBerry\LaravelSwarm\Runners;
 
 use BuiltByBerry\LaravelSwarm\Audit\RunAuditEmitter;
 use BuiltByBerry\LaravelSwarm\Contracts\ActorResolver;
+use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use BuiltByBerry\LaravelSwarm\Contracts\ArtifactRepository;
 use BuiltByBerry\LaravelSwarm\Contracts\ClaimsQueuedRunExecution;
 use BuiltByBerry\LaravelSwarm\Contracts\ContextStore;
@@ -34,6 +35,7 @@ use BuiltByBerry\LaravelSwarm\Responses\StreamableSwarmResponse;
 use BuiltByBerry\LaravelSwarm\Responses\SwarmResponse;
 use BuiltByBerry\LaravelSwarm\Streaming\Events\SwarmStreamEvent;
 use BuiltByBerry\LaravelSwarm\Support\MonotonicTime;
+use BuiltByBerry\LaravelSwarm\Support\PendingAgentRun;
 use BuiltByBerry\LaravelSwarm\Support\RunContext;
 use BuiltByBerry\LaravelSwarm\Support\SwarmCapture;
 use BuiltByBerry\LaravelSwarm\Support\SwarmExecutionState;
@@ -98,6 +100,21 @@ class SwarmRunner
     public function memory(): SwarmMemory
     {
         return Container::getInstance()->make(SwarmMemory::class);
+    }
+
+    /**
+     * Begin a governed run for a single agent without authoring a Swarm class.
+     *
+     * Returns a fluent {@see PendingAgentRun}: `Swarm::agent($agent)->prompt($task)`
+     * wraps the lone agent in a one-element {@see \BuiltByBerry\LaravelSwarm\Support\AdHocSwarm}
+     * and dispatches it through this same runner, so it inherits audit,
+     * guardrails, capture, telemetry and encrypt-at-rest identically to a
+     * multi-agent swarm — and every execution mode. A swarm of one is still a
+     * swarm; there is no second, ungoverned path.
+     */
+    public function agent(Agent $agent): PendingAgentRun
+    {
+        return new PendingAgentRun($agent);
     }
 
     /**

--- a/src/Support/AdHocSwarm.php
+++ b/src/Support/AdHocSwarm.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Support;
+
+use BuiltByBerry\LaravelSwarm\Concerns\Runnable;
+use BuiltByBerry\LaravelSwarm\Contracts\Agent;
+use BuiltByBerry\LaravelSwarm\Contracts\DefinesGuardrails;
+use BuiltByBerry\LaravelSwarm\Contracts\Swarm;
+
+/**
+ * A swarm assembled at call time rather than declared as a class.
+ *
+ * This backs the {@see \BuiltByBerry\LaravelSwarm\Runners\SwarmRunner::agent()}
+ * convenience: a lone agent becomes a one-element swarm that flows through the
+ * exact same {@see SwarmRunner} pipeline — audit, guardrails, capture,
+ * telemetry, encrypt-at-rest — as any hand-authored {@see Swarm} class. A swarm
+ * of one is still a swarm; there is no second, ungoverned path.
+ *
+ * It carries the {@see Runnable} trait so every execution mode (prompt, stream,
+ * queue, broadcast, dispatchDurable) is available with no bespoke runner, and
+ * implements {@see DefinesGuardrails} so per-call guardrails merge with the
+ * app's globally configured ones (the "governed by default" guarantee lives in
+ * {@see \BuiltByBerry\LaravelSwarm\Runners\SwarmGuardrailRunner}, which always
+ * folds in `config('swarm.guardrails')` regardless of what this returns).
+ *
+ * Topology is left to the resolver's default (sequential), which is a
+ * pass-through for a single agent.
+ *
+ * @internal Constructed by SwarmRunner / PendingAgentRun, not by consumers.
+ */
+class AdHocSwarm implements DefinesGuardrails, Swarm
+{
+    use Runnable;
+
+    /**
+     * @param  array<int, Agent>  $agents
+     * @param  array<int, object|class-string>  $guardrails
+     */
+    public function __construct(
+        protected array $agents,
+        protected array $guardrails = [],
+    ) {}
+
+    /**
+     * @return array<int, Agent>
+     */
+    public function agents(): array
+    {
+        return $this->agents;
+    }
+
+    /**
+     * @return array<int, object|class-string>
+     */
+    public function guardrails(): array
+    {
+        return $this->guardrails;
+    }
+}

--- a/src/Support/PendingAgentRun.php
+++ b/src/Support/PendingAgentRun.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Support;
+
+use BuiltByBerry\LaravelSwarm\Contracts\Agent;
+use BuiltByBerry\LaravelSwarm\Responses\DurableSwarmResponse;
+use BuiltByBerry\LaravelSwarm\Responses\QueuedSwarmResponse;
+use BuiltByBerry\LaravelSwarm\Responses\StreamableSwarmResponse;
+use BuiltByBerry\LaravelSwarm\Responses\SwarmResponse;
+use Illuminate\Broadcasting\Channel;
+
+/**
+ * Fluent entry point for running a single agent through the full governed
+ * Swarm pipeline without authoring a {@see \BuiltByBerry\LaravelSwarm\Contracts\Swarm}
+ * class.
+ *
+ * Returned by {@see \BuiltByBerry\LaravelSwarm\Runners\SwarmRunner::agent()}
+ * (reachable as `Swarm::agent($agent)`). Each terminal call materializes a
+ * fresh {@see AdHocSwarm} and dispatches it through the same
+ * {@see \BuiltByBerry\LaravelSwarm\Runners\SwarmRunner} every multi-agent run
+ * uses, so the lone agent inherits audit, guardrails, capture, telemetry and
+ * encrypt-at-rest identically — and every execution mode.
+ *
+ *   Swarm::agent($agent)->prompt($task);
+ *   Swarm::agent($agent)->guardrails([BudgetGuardrail::class])->stream($task);
+ *
+ * Guardrails passed here are additive: they merge with the app's globally
+ * configured guardrails, they do not replace them.
+ *
+ * @phpstan-import-type SwarmTaskInput from PhpStanTypeAliases
+ * @phpstan-import-type SwarmBroadcastChannels from PhpStanTypeAliases
+ */
+class PendingAgentRun
+{
+    /**
+     * Per-call guardrail refs (class names or instances) layered on top of the
+     * globally configured guardrails.
+     *
+     * @var array<int, object|class-string>
+     */
+    protected array $guardrails = [];
+
+    public function __construct(protected Agent $agent) {}
+
+    /**
+     * Attach per-call guardrails for this run. Additive to the globally
+     * configured guardrails, not a replacement.
+     *
+     * @param  array<int, object|class-string>  $guardrails
+     */
+    public function guardrails(array $guardrails): static
+    {
+        $this->guardrails = array_values($guardrails);
+
+        return $this;
+    }
+
+    /**
+     * Run the agent synchronously and return the terminal response.
+     *
+     * @param  SwarmTaskInput  $task
+     */
+    public function prompt(string|array|RunContext $task): SwarmResponse
+    {
+        return $this->toSwarm()->prompt($task);
+    }
+
+    /**
+     * Compatibility alias for {@see prompt()}.
+     *
+     * @param  SwarmTaskInput  $task
+     */
+    public function run(string|array|RunContext $task): SwarmResponse
+    {
+        return $this->prompt($task);
+    }
+
+    /**
+     * Stream the run, yielding typed stream events for SSE.
+     *
+     * @param  SwarmTaskInput  $task
+     */
+    public function stream(string|array|RunContext $task): StreamableSwarmResponse
+    {
+        return $this->toSwarm()->stream($task);
+    }
+
+    /**
+     * Queue the run to execute in the background.
+     *
+     * @param  SwarmTaskInput  $task
+     */
+    public function queue(string|array|RunContext $task): QueuedSwarmResponse
+    {
+        return $this->toSwarm()->queue($task);
+    }
+
+    /**
+     * Broadcast typed stream events for the run.
+     *
+     * @param  SwarmTaskInput  $task
+     * @param  SwarmBroadcastChannels  $channels
+     */
+    public function broadcast(string|array|RunContext $task, Channel|array $channels, bool $now = false): StreamableSwarmResponse
+    {
+        return $this->toSwarm()->broadcast($task, $channels, $now);
+    }
+
+    /**
+     * Broadcast typed stream events immediately.
+     *
+     * @param  SwarmTaskInput  $task
+     * @param  SwarmBroadcastChannels  $channels
+     */
+    public function broadcastNow(string|array|RunContext $task, Channel|array $channels): StreamableSwarmResponse
+    {
+        return $this->broadcast($task, $channels, now: true);
+    }
+
+    /**
+     * Queue the run's stream and broadcast each event from the worker.
+     *
+     * @param  SwarmTaskInput  $task
+     * @param  SwarmBroadcastChannels  $channels
+     */
+    public function broadcastOnQueue(string|array|RunContext $task, Channel|array $channels): QueuedSwarmResponse
+    {
+        return $this->toSwarm()->broadcastOnQueue($task, $channels);
+    }
+
+    /**
+     * Dispatch the run on the durable runtime.
+     *
+     * @param  SwarmTaskInput  $task
+     */
+    public function dispatchDurable(string|array|RunContext $task): DurableSwarmResponse
+    {
+        return $this->toSwarm()->dispatchDurable($task);
+    }
+
+    /**
+     * Materialize the one-element swarm carrying the collected guardrails.
+     */
+    protected function toSwarm(): AdHocSwarm
+    {
+        return new AdHocSwarm([$this->agent], $this->guardrails);
+    }
+}

--- a/tests/Feature/SwarmAgentFrontDoorTest.php
+++ b/tests/Feature/SwarmAgentFrontDoorTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
+use BuiltByBerry\LaravelSwarm\Exceptions\GuardrailViolation;
+use BuiltByBerry\LaravelSwarm\Facades\Swarm;
+use BuiltByBerry\LaravelSwarm\Responses\StreamableSwarmResponse;
+use BuiltByBerry\LaravelSwarm\Responses\SwarmResponse;
+use BuiltByBerry\LaravelSwarm\Support\PendingAgentRun;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\FakeResearcher;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Guardrails\BlocksInputWhenMatches;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\RecordingSwarmAuditSink;
+
+it('returns a fluent PendingAgentRun from Swarm::agent()', function () {
+    expect(Swarm::agent(new FakeResearcher))->toBeInstanceOf(PendingAgentRun::class);
+});
+
+it('runs a single agent through the full governed pipeline and emits the identical audit chain', function () {
+    FakeResearcher::fake(['single-agent-output']);
+
+    $sink = new RecordingSwarmAuditSink;
+    app()->instance(SwarmAuditSink::class, $sink);
+
+    $response = Swarm::agent(new FakeResearcher)->prompt('do the thing');
+
+    // The lone agent actually ran and produced output through one step.
+    expect($response)->toBeInstanceOf(SwarmResponse::class)
+        ->and((string) $response)->toContain('single-agent-output')
+        ->and($response->steps)->toHaveCount(1);
+
+    // The SAME evidence chain a multi-agent run emits fired here.
+    expect($sink->hasCategory('run.started'))->toBeTrue()
+        ->and($sink->hasCategory('step.started'))->toBeTrue()
+        ->and($sink->hasCategory('step.completed'))->toBeTrue()
+        ->and($sink->hasCategory('run.completed'))->toBeTrue();
+});
+
+it('applies per-call guardrails passed to ->guardrails()', function () {
+    FakeResearcher::fake(['never-reached']);
+
+    expect(fn () => Swarm::agent(new FakeResearcher)
+        ->guardrails([new BlocksInputWhenMatches('blocked-token')])
+        ->prompt('blocked-token'))
+        ->toThrow(GuardrailViolation::class);
+});
+
+it('governed by default: honors globally configured guardrails with no per-call override', function () {
+    config()->set('swarm.guardrails.input', [BlocksInputWhenMatches::class]);
+    app()->bind(BlocksInputWhenMatches::class, fn () => new BlocksInputWhenMatches('global-block'));
+    FakeResearcher::fake(['never-reached']);
+
+    expect(fn () => Swarm::agent(new FakeResearcher)->prompt('global-block'))
+        ->toThrow(GuardrailViolation::class);
+});
+
+it('exposes streaming as an execution mode on the single-agent front door', function () {
+    FakeResearcher::fake(['streamed-output']);
+
+    $response = Swarm::agent(new FakeResearcher)->stream('go');
+
+    expect($response)->toBeInstanceOf(StreamableSwarmResponse::class);
+});


### PR DESCRIPTION
## `Swarm::agent()` — single-agent front door

Run a single agent through the **full governed Swarm pipeline** without authoring a `Swarm` class:

```php
Swarm::agent($agent)->prompt($task);
Swarm::agent($agent)->guardrails([BudgetGuardrail::class])->stream($task);
```

### Why

A one-agent Swarm is *already* fully governed today — the runner is topology- and count-agnostic (`DispatchValidator` floor is "at least one agent"), and a lone agent emits the identical `run.started → step.* → run.completed` audit chain. The only gap was **DX ceremony**: to get that governance you had to author a `Swarm` class, which nudges callers to bare `laravel/ai` instead — dropping audit, guardrails, capture, telemetry, encrypt-at-rest. This deletes the ceremony. It is **convenience, not a security fix** (channel records 902 / 903).

### How

- **`Support\PendingAgentRun`** — fluent builder returned by `Swarm::agent($agent)`. Carries per-call guardrails; exposes every execution mode (`prompt`/`run`/`stream`/`queue`/`broadcast`/`broadcastNow`/`broadcastOnQueue`/`dispatchDurable`), each materializing a fresh swarm and delegating to `SwarmRunner`.
- **`Support\AdHocSwarm`** — a one-element `Swarm` implementing `DefinesGuardrails`, carrying the `Runnable` trait. No new runner machinery — it rides the sequential-of-one path.
- **`SwarmRunner::agent()`** — the entry point (reachable as `Swarm::agent()` via the facade `@mixin`).

**Governed by default:** `SwarmGuardrailRunner` already folds in `config('swarm.guardrails.*')` for every run, so globally configured guardrails apply even when the builder adds none; `->guardrails([...])` is additive, not a replacement.

### Tests

`tests/Feature/SwarmAgentFrontDoorTest.php` — 5 tests / 11 assertions:
- full audit chain emitted (`run.started`/`step.started`/`step.completed`/`run.completed`) for a single agent through the public API;
- per-call `->guardrails()` honored;
- governed-by-default: globally configured guardrails apply with no per-call override;
- streaming reachable; fluent builder returned.

phpstan L7 clean on the new surface; guardrails + parallel + audit regression subset green (25 tests / 128 assertions).

### Acceptance criteria

- [x] `Swarm::agent($agent)` returns a builder wrapping the agent in an ad-hoc one-element Swarm
- [x] `->prompt($task)` runs through the real `SwarmRunner` — identical evidence chain
- [x] All execution modes: prompt / stream / queue / broadcast / dispatchDurable
- [x] Governed-by-default (audit envelope + app-default guardrails)
- [x] Per-call override `->guardrails([...])`
- [x] Ad-hoc Swarm implements `DefinesGuardrails`; no new runner machinery
- [x] Octane-safe: no container-global mutable state
- [x] Docs updated: single-agent section (execution-modes.md + public-surface.md)
- [ ] CHANGELOG entry under v0.22.0 — **deferred to release-wrap** (house convention fills CHANGELOG in `chore/<v>-release-wrap`)

Targets `release/v0.22.0`, not `main`. Unblocks `inline-swarm-builders` (shared `AdHocSwarm` machinery) once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
