### PR TITLE
feat(testing): first-class audit-trail assertions (SwarmFake::interceptSwarmAuditSink)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -178,15 +178,38 @@ intentionally skips that code path for `prompt()` / `run()` / `queue()` /
 `stream()` / `dispatchDurable()`, so the three patterns below cover what
 the fake cannot observe directly.
 
-### Use `SwarmFake` intercepts for the three audit contracts (v0.7+)
+### Use `SwarmFake` intercepts for the audit contracts (v0.7+)
 
-`SwarmFake` ships three intercept helpers for `CapturePolicy`,
-`SinkFailureHandler`, and `SwarmAuditSigner`. Each helper swaps the
-container binding for the corresponding contract to a recording
-decorator and returns a recorder you can assert against. The decorators
-wrap an optional delegate, so existing policy / handler / signer logic
-still drives behavior — the recorder only captures inputs, the routed
-decision, and the resulting payload.
+`SwarmFake` ships intercept helpers for `CapturePolicy`,
+`SinkFailureHandler`, `SwarmAuditSigner`, and — since v0.22 — the
+`SwarmAuditSink` itself. Each helper swaps the container binding for the
+corresponding contract to a recording decorator and returns a recorder you
+can assert against. The decorators wrap an optional delegate, so existing
+policy / handler / signer / sink logic still drives behavior — the recorder
+only captures inputs, the routed decision, and the resulting payload.
+
+`SwarmFake::interceptSwarmAuditSink()` is the ergonomic way to assert the
+**audit trail a run emitted**, replacing a hand-rolled recording sink:
+
+```php
+use BuiltByBerry\LaravelSwarm\Testing\SwarmFake;
+
+test('article pipeline emits the full audit chain', function () {
+    $audit = SwarmFake::interceptSwarmAuditSink();
+
+    ArticlePipeline::make()->run('draft a launch post');
+
+    $audit->assertAuditChain(['run.started', 'step.started', 'step.completed', 'run.completed']);
+    $audit->assertEmittedAudit('run.completed');
+    $audit->assertStepCount(3);
+    $audit->assertNotEmittedAudit('run.failed');
+});
+```
+
+`assertAuditChain()` matches its categories as an ordered subsequence, so you
+can assert the backbone without enumerating every step event. It works the
+same for a single agent (`Swarm::agent($a)->prompt(...)`), an inline or
+class-based multi-agent swarm, and queued runs.
 
 Intercepts work during real (non-faked) swarm runs, since the
 recording happens when the real audit dispatcher resolves the contract
@@ -237,10 +260,15 @@ Each recorder exposes:
 - `assertSigned(?string $category = null, ?callable $matcher = null)`,
   `assertNeverSigned(?string $category = null)` on
   `RecordingSwarmAuditSigner`.
+- `assertAuditChain(array $categories)`,
+  `assertEmittedAudit(string $category, ?callable $matcher = null)`,
+  `assertNotEmittedAudit(string $category)`,
+  `assertStepCount(int $expected)` on `RecordingSwarmAuditSink`.
 
-All three recorders also expose `records()` and `recordsFor(string $category)`
+All four recorders also expose `records()` and `recordsFor(string $category)`
 for raw inspection when you need shape assertions richer than what the
-helpers cover.
+helpers cover (`RecordingSwarmAuditSink` adds `categories()` and
+`hasCategory()`).
 
 The intercepts cover the dispatch-time signal: was the contract invoked,
 with what category, and what did it decide. They do not replace the two
@@ -276,37 +304,33 @@ This pattern works for all four contracts. Worked examples live in
 `tests/Unit/Audit/` (`CapturePolicyTest`, `SinkFailureHandlerTest`,
 `SwarmAuditSignerTest`, `DefaultActorResolverTest`).
 
-### Bind a recording sink for end-to-end audit checks
+### Inspect the enriched envelope a sink saw
 
-When you need to verify what an actual run emitted — including the
-signed-and-actor-bound envelope — bind a recording sink in your test
-setup and inspect the emitted payloads:
+When you need to assert on the fully enriched, signed-and-actor-bound
+payload — beyond the category-level helpers above — use the same
+`interceptSwarmAuditSink()` recorder and read the raw records:
 
 ```php
-use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
+use BuiltByBerry\LaravelSwarm\Support\RunContext;
+use BuiltByBerry\LaravelSwarm\Testing\SwarmFake;
 
-$sink = new class implements SwarmAuditSink {
-    /** @var array<int, array{category: string, payload: array<string, mixed>}> */
-    public array $records = [];
-
-    public function emit(string $category, array $payload): void
-    {
-        $this->records[] = compact('category', 'payload');
-    }
-};
-
-app()->instance(SwarmAuditSink::class, $sink);
+$audit = SwarmFake::interceptSwarmAuditSink();
 
 ArticlePipeline::make()->run(
     RunContext::fromTask('task')->withActor('user:42'),
 );
 
-expect($sink->records[0]['payload']['metadata']['actor']['id'])->toBe('42');
+$audit->assertEmittedAudit(
+    'run.started',
+    fn (array $payload): bool => ($payload['metadata']['actor']['id'] ?? null) === '42',
+);
+
+// Or inspect the raw payloads directly:
+expect($audit->recordsFor('run.started')[0]['metadata']['actor']['id'])->toBe('42');
 ```
 
-The package ships an internal `RecordingSwarmAuditSink` fixture used by
-its own feature tests; copy that shape into your application test
-suite if you want a richer recording sink.
+Pass a delegate to `interceptSwarmAuditSink($realSink)` to keep a real sink
+in the loop behind the recorder.
 
 ### Use `'halt'` failure policy to assert run-level halt behavior
 

--- a/src/Testing/Audit/RecordingSwarmAuditSink.php
+++ b/src/Testing/Audit/RecordingSwarmAuditSink.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Testing\Audit;
+
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
+use Illuminate\Testing\Assert as PHPUnit;
+
+/**
+ * Test double for {@see SwarmAuditSink} that records every emitted evidence
+ * payload and exposes assertions over the audit trail a run produced.
+ *
+ * Install it with {@see \BuiltByBerry\LaravelSwarm\Testing\SwarmFake::interceptSwarmAuditSink()},
+ * which swaps the container binding and flushes the dispatcher so the next
+ * run records into this recorder:
+ *
+ *   $audit = SwarmFake::interceptSwarmAuditSink();
+ *   MySwarm::make()->prompt($task);
+ *   $audit->assertAuditChain(['run.started', 'step.started', 'step.completed', 'run.completed']);
+ *   $audit->assertStepCount(1);
+ *
+ * An optional delegate is forwarded behind the recorder so a real sink still
+ * receives every payload while the recorder observes it.
+ */
+class RecordingSwarmAuditSink implements SwarmAuditSink
+{
+    /**
+     * Every emitted payload in the order it was received. The dispatcher
+     * enriches each payload with its `category`, so the category is readable
+     * off the record itself.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    protected array $records = [];
+
+    public function __construct(
+        protected ?SwarmAuditSink $delegate = null,
+    ) {}
+
+    public function emit(string $category, array $payload): void
+    {
+        $this->records[] = $payload;
+
+        $this->delegate?->emit($category, $payload);
+    }
+
+    /**
+     * Every recorded payload, in emission order.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function records(): array
+    {
+        return $this->records;
+    }
+
+    /**
+     * The emitted categories, in order (with duplicates preserved).
+     *
+     * @return array<int, string>
+     */
+    public function categories(): array
+    {
+        return array_map(
+            fn (array $record): string => (string) ($record['category'] ?? ''),
+            $this->records,
+        );
+    }
+
+    /**
+     * Records emitted under a single category, in order.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function recordsFor(string $category): array
+    {
+        return array_values(array_filter(
+            $this->records,
+            fn (array $record): bool => ($record['category'] ?? null) === $category,
+        ));
+    }
+
+    public function hasCategory(string $category): bool
+    {
+        return $this->recordsFor($category) !== [];
+    }
+
+    /**
+     * Forget everything recorded so far.
+     */
+    public function reset(): void
+    {
+        $this->records = [];
+    }
+
+    /**
+     * Assert audit evidence was emitted for the given category at least once.
+     *
+     * Pass a callable matcher to inspect the payload; without one the
+     * assertion only verifies the category appeared.
+     */
+    public function assertEmittedAudit(string $category, ?callable $matcher = null): void
+    {
+        $records = $this->recordsFor($category);
+
+        if ($matcher === null) {
+            PHPUnit::assertNotEmpty(
+                $records,
+                "No audit evidence was emitted for category [{$category}]. Emitted: [".implode(', ', $this->categories()).'].',
+            );
+
+            return;
+        }
+
+        PHPUnit::assertTrue(
+            collect($records)->contains(fn (array $record): bool => (bool) $matcher($record)),
+            "No audit evidence for category [{$category}] matched the expected matcher.",
+        );
+    }
+
+    /**
+     * Assert no audit evidence was emitted for the given category.
+     */
+    public function assertNotEmittedAudit(string $category): void
+    {
+        PHPUnit::assertEmpty(
+            $this->recordsFor($category),
+            "Unexpected audit evidence was emitted for category [{$category}].",
+        );
+    }
+
+    /**
+     * Assert the given categories appear, in order, within the emitted trail.
+     *
+     * The chain is matched as an ordered subsequence — additional evidence
+     * between the expected categories is allowed — so a caller can assert the
+     * backbone (`run.started → … → run.completed`) without enumerating every
+     * step event.
+     *
+     * @param  array<int, string>  $categories
+     */
+    public function assertAuditChain(array $categories): void
+    {
+        $emitted = $this->categories();
+        $cursor = 0;
+
+        foreach ($emitted as $category) {
+            if ($cursor < count($categories) && $category === $categories[$cursor]) {
+                $cursor++;
+            }
+        }
+
+        PHPUnit::assertSame(
+            count($categories),
+            $cursor,
+            'The expected audit chain ['.implode(' → ', $categories).'] did not appear in order. Emitted: ['.implode(' → ', $emitted).'].',
+        );
+    }
+
+    /**
+     * Assert the run recorded exactly the given number of agent steps
+     * (counted by `step.started` evidence).
+     */
+    public function assertStepCount(int $expected): void
+    {
+        $actual = count($this->recordsFor('step.started'));
+
+        PHPUnit::assertSame(
+            $expected,
+            $actual,
+            "Expected [{$expected}] step(s) in the audit trail, but recorded [{$actual}].",
+        );
+    }
+}

--- a/src/Testing/SwarmFake.php
+++ b/src/Testing/SwarmFake.php
@@ -15,6 +15,7 @@ use BuiltByBerry\LaravelSwarm\Contracts\MemoryStore;
 use BuiltByBerry\LaravelSwarm\Contracts\SinkFailureHandler;
 use BuiltByBerry\LaravelSwarm\Contracts\Swarm;
 use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSigner;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
 use BuiltByBerry\LaravelSwarm\Contracts\SwarmMemory;
 use BuiltByBerry\LaravelSwarm\Enums\DurableLifecycleStatus;
 use BuiltByBerry\LaravelSwarm\Enums\Topology as TopologyEnum;
@@ -35,6 +36,7 @@ use BuiltByBerry\LaravelSwarm\Support\RunContext;
 use BuiltByBerry\LaravelSwarm\Testing\Audit\RecordingCapturePolicy;
 use BuiltByBerry\LaravelSwarm\Testing\Audit\RecordingSinkFailureHandler;
 use BuiltByBerry\LaravelSwarm\Testing\Audit\RecordingSwarmAuditSigner;
+use BuiltByBerry\LaravelSwarm\Testing\Audit\RecordingSwarmAuditSink;
 use BuiltByBerry\LaravelSwarm\Testing\Memory\RecordingMemoryCapturePolicy;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Container\Container;
@@ -740,6 +742,26 @@ class SwarmFake implements Swarm
         $recorder = new RecordingSwarmAuditSigner($delegate);
 
         self::bindAuditIntercept(SwarmAuditSigner::class, $recorder);
+
+        return $recorder;
+    }
+
+    /**
+     * Install a {@see RecordingSwarmAuditSink} as the bound
+     * {@see SwarmAuditSink} for the duration of the test, so the audit trail a
+     * run emits can be asserted with {@see RecordingSwarmAuditSink::assertAuditChain()},
+     * {@see RecordingSwarmAuditSink::assertEmittedAudit()}, and
+     * {@see RecordingSwarmAuditSink::assertStepCount()}.
+     *
+     * See {@see interceptCapturePolicy()} for the design contract. The default
+     * binding is {@see \BuiltByBerry\LaravelSwarm\Audit\NoOpSwarmAuditSink};
+     * pass a delegate to keep a real sink in the loop behind the recorder.
+     */
+    public static function interceptSwarmAuditSink(?SwarmAuditSink $delegate = null): RecordingSwarmAuditSink
+    {
+        $recorder = new RecordingSwarmAuditSink($delegate);
+
+        self::bindAuditIntercept(SwarmAuditSink::class, $recorder);
 
         return $recorder;
     }

--- a/tests/Feature/RecordingSwarmAuditSinkTest.php
+++ b/tests/Feature/RecordingSwarmAuditSinkTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Facades\Swarm;
+use BuiltByBerry\LaravelSwarm\Testing\Audit\RecordingSwarmAuditSink;
+use BuiltByBerry\LaravelSwarm\Testing\SwarmFake;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\FakeEditor;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\FakeResearcher;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents\FakeWriter;
+use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\FakeSequentialSwarm;
+
+beforeEach(function () {
+    FakeResearcher::fake(['research-out']);
+    FakeWriter::fake(['writer-out']);
+    FakeEditor::fake(['editor-out']);
+});
+
+it('installs a recording sink and returns it', function () {
+    expect(SwarmFake::interceptSwarmAuditSink())->toBeInstanceOf(RecordingSwarmAuditSink::class);
+});
+
+it('records the full audit chain for a single-agent run', function () {
+    $audit = SwarmFake::interceptSwarmAuditSink();
+
+    Swarm::agent(new FakeResearcher)->prompt('a task');
+
+    $audit->assertAuditChain(['run.started', 'step.started', 'step.completed', 'run.completed']);
+    $audit->assertEmittedAudit('run.completed');
+    $audit->assertStepCount(1);
+    $audit->assertNotEmittedAudit('run.failed');
+});
+
+it('counts every step for a multi-agent run', function () {
+    $audit = SwarmFake::interceptSwarmAuditSink();
+
+    FakeSequentialSwarm::make()->prompt('original-task');
+
+    $audit->assertAuditChain(['run.started', 'run.completed']);
+    $audit->assertStepCount(3);
+});
+
+it('asserts on a specific evidence payload with a matcher', function () {
+    $audit = SwarmFake::interceptSwarmAuditSink();
+
+    Swarm::agent(new FakeResearcher)->prompt('a task');
+
+    $audit->assertEmittedAudit('run.completed', fn (array $payload): bool => ($payload['category'] ?? null) === 'run.completed');
+});
+
+it('records the audit chain for a queued run', function () {
+    config()->set('queue.default', 'sync');
+    config()->set('swarm.capture.active_context', true);
+
+    $audit = SwarmFake::interceptSwarmAuditSink();
+
+    FakeSequentialSwarm::make()->queue('original-task');
+
+    $audit->assertAuditChain(['run.started', 'run.completed']);
+    $audit->assertStepCount(3);
+});
+
+it('forwards every payload to an optional delegate behind the recorder', function () {
+    $delegate = new RecordingSwarmAuditSink;
+    $audit = SwarmFake::interceptSwarmAuditSink($delegate);
+
+    Swarm::agent(new FakeResearcher)->prompt('a task');
+
+    $audit->assertEmittedAudit('run.completed');
+    $delegate->assertEmittedAudit('run.completed');
+});


### PR DESCRIPTION
## First-class audit-trail assertions

Asserting what a run emitted used to mean hand-binding a recording `SwarmAuditSink` in every test (I did exactly that while proving the single-agent front door). This promotes that pattern into a supported helper:

```php
$audit = SwarmFake::interceptSwarmAuditSink();

MySwarm::make()->prompt($task);

$audit->assertAuditChain(['run.started', 'step.started', 'step.completed', 'run.completed']);
$audit->assertEmittedAudit('run.completed');
$audit->assertStepCount(3);
$audit->assertNotEmittedAudit('run.failed');
```

### How

- **`Testing\Audit\RecordingSwarmAuditSink`** — public recording sink implementing `SwarmAuditSink`, with `assertAuditChain()` (ordered-subsequence match), `assertEmittedAudit()` (+ callable matcher), `assertNotEmittedAudit()`, `assertStepCount()` (counts `step.started`), plus `records()` / `recordsFor()` / `categories()` / `hasCategory()` for raw inspection. Optional delegate forwards every payload to a real sink behind the recorder.
- **`SwarmFake::interceptSwarmAuditSink()`** — the **fourth** audit-contract intercept, alongside the existing `interceptCapturePolicy` / `interceptSinkFailureHandler` / `interceptSwarmAuditSigner`. Uses the same `bindAuditIntercept` plumbing (swap binding + flush the dispatcher singleton), so it records during real (non-faked) runs.

Test-only surface — no runtime behavior change.

### Tests

`tests/Feature/RecordingSwarmAuditSinkTest.php` — 6 tests covering the AC's matrix: single-agent (`Swarm::agent()`), multi-agent (`FakeSequentialSwarm`, step count 3), **queued** (sync + active-context, chain recorded), payload matcher, and delegate forwarding.

Verification: new tests green; phpstan L7 clean on the new + changed surface; regression across the SwarmFake audit-intercepts + audit-chain + SwarmFake suites green (**77 tests / 272 assertions**).

### Acceptance criteria

- [x] Public recording audit sink in the Testing namespace (`Testing\Audit\RecordingSwarmAuditSink`) installed via `SwarmFake::interceptSwarmAuditSink()`
- [x] Assertions: `assertAuditChain([...])`, `assertEmittedAudit('run.completed')`, `assertStepCount(n)` (+ `assertNotEmittedAudit`)
- [x] Works for single-agent + multi-agent, sync + queued
- [x] Documented in `docs/testing.md`
- [ ] CHANGELOG entry under v0.22.0 — **deferred to release-wrap** (house convention)

Independent component — targets `release/v0.22.0`, no blockers, blocks nothing.

Note: the pre-existing internal `tests/Fixtures/RecordingSwarmAuditSink` fixture is left in place (still used by older tests); it can be migrated to this public helper in the docs-cohesiveness pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
