### PR TITLE
feat(facade): IDE autocomplete + phpstan-L7 generics for the fluent builders

### DIFF
--- a/src/Facades/Swarm.php
+++ b/src/Facades/Swarm.php
@@ -4,10 +4,36 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Facades;
 
+use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use BuiltByBerry\LaravelSwarm\Runners\SwarmRunner;
+use BuiltByBerry\LaravelSwarm\Support\PendingAgentRun;
+use BuiltByBerry\LaravelSwarm\Support\PendingSwarmRun;
 use Illuminate\Support\Facades\Facade;
 
 /**
+ * The public entry point for running swarms.
+ *
+ * The fluent, class-free builders below are surfaced explicitly so IDEs and
+ * static analysis autocomplete them straight off the facade (the backing
+ * {@see SwarmRunner} is `@internal`). Each returns a fluent pending run whose
+ * execution modes — `prompt()`, `run()`, `stream()`, `queue()`, `broadcast()`,
+ * `broadcastNow()`, `broadcastOnQueue()`, `dispatchDurable()` — and additive
+ * `guardrails()` live on {@see \BuiltByBerry\LaravelSwarm\Support\PendingRun}:
+ *
+ *   Swarm::agent($agent)->prompt($task);
+ *   Swarm::agent($agent)->guardrails([BudgetGuardrail::class])->stream($task);
+ *   Swarm::sequential([$research, $write])->prompt($task);
+ *   Swarm::parallel([$a, $b, $c])->guardrails([BudgetGuardrail::class])->prompt($task);
+ *   Swarm::hierarchical($coordinator, [$writer, $editor])->stream($task);
+ *
+ * The remaining runtime surface (running hand-authored swarm classes, `memory()`,
+ * etc.) is inherited from the `@mixin` below.
+ *
+ * @method static PendingAgentRun agent(Agent $agent) Begin a governed run for a single agent without authoring a Swarm class.
+ * @method static PendingSwarmRun sequential(array<int, Agent> $agents) Begin a governed sequential run for the given agents; each agent's output feeds the next.
+ * @method static PendingSwarmRun parallel(array<int, Agent> $agents) Begin a governed parallel run for the given agents; every agent runs against the same task.
+ * @method static PendingSwarmRun hierarchical(Agent $coordinator, array<int, Agent> $workers = []) Begin a governed hierarchical run; the coordinator routes over the given worker agents.
+ *
  * @mixin SwarmRunner
  */
 class Swarm extends Facade


### PR DESCRIPTION
## What changed

Annotates the new **class-free fluent builders** so they autocomplete in IDEs and resolve under phpstan level 7.

- `src/Facades/Swarm.php` — added explicit `@method` tags for the four fluent entry points (`agent()`, `sequential()`, `parallel()`, `hierarchical()`) with precise param generics (`array<int, Agent>`) and concrete return types (`PendingAgentRun` / `PendingSwarmRun`). The backing `SwarmRunner` is `@internal`, so surfacing these directly on the facade means IDEs/static analysis autocomplete `Swarm::agent(...)` etc. first-class instead of dimming them through the internal mixin. Also documented the fluent usage patterns and where the execution modes / `guardrails()` live (`PendingRun`).

No other files needed changes: `PendingRun`, `PendingAgentRun`, `PendingSwarmRun`, and the `AdHoc*Swarm` classes already carry correct generics (`array<int, Agent>`, `array<int, object|class-string>`, `static` fluent returns, `class-string<AdHocSwarm>`) and were already phpstan-clean. `docs/public-surface.md` already describes the builders accurately — the public surface didn't change, only its annotations.

## How verified

- **phpstan L7 clean**: `vendor/bin/phpstan analyse --memory-limit=2G --no-progress` -> `[OK] No errors` (whole suite).
- **Type resolution** confirmed via `PHPStan\dumpType`: `Swarm::agent($a)` -> `PendingAgentRun`; `sequential/parallel/hierarchical` -> `PendingSwarmRun`; the chained `Swarm::agent($a)->guardrails([])->stream($task)` -> `StreamableSwarmResponse`; `->prompt($task)` -> `SwarmResponse`.
- **Tests green**: `InlineSwarmBuildersTest` + `SwarmAgentFrontDoorTest` — 10 passed (31 assertions). These already assert the builder types and terminal response types, so no redundant test was added.

## Acceptance criteria

- [x] `Swarm::agent($a)->prompt($task)`, `->guardrails([...])->stream(...)`, and inline builders autocomplete — precise `@method`/param/return docblocks on the facade; builder classes carry correct generics/return-type annotations.
- [x] phpstan level 7 clean over touched files and the whole suite.
- [x] `docs/public-surface.md` fluent-builder rows verified accurate (no change needed — surface unchanged).
- [x] Fluent-builder type + terminal-response coverage exists and stays green (existing tests; no redundant test added).

CHANGELOG deferred to release-wrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
