### PR TITLE
feat(commands): guardrail/audit/capture sanity checks for swarm:health

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -156,6 +156,33 @@ hierarchical queueing, include the durable runtime tables:
 php artisan swarm:health --durable
 ```
 
+#### Governed-by-default checks
+
+Because the single-agent and inline front doors run governed by default,
+`swarm:health` also verifies (on every bare invocation — no flag required) that
+the governance wiring behind that promise is intact. Each check follows the same
+row shape as the persistence checks (`component`, `driver`, `store`, `status`,
+`details`) and is included in `--json` output:
+
+- **Guardrails** — every globally-configured ref in
+  `swarm.guardrails.input` / `.step` / `.output` resolves from the container,
+  the same resolution path the runner takes at run time. `ok` when they all
+  resolve (or none are configured); `failed` when a ref is neither a
+  container-resolvable class name nor an object instance, since it would
+  otherwise throw mid-run.
+- **Audit sink** — reports which `SwarmAuditSink` is bound. A real sink is `ok`.
+  The default `NoOpSwarmAuditSink` — which discards all evidence — is surfaced
+  as a `note` (not a failure), because discarding evidence is a valid choice for
+  non-regulated apps. Bind a real sink (or run `swarm:install:audit`) to retain
+  audit evidence.
+- **Capture policy** — the bound `CapturePolicy` resolves from the container.
+  `ok` when it resolves; `failed` when the binding is broken, since a run would
+  throw the first time it made a capture decision.
+
+These checks touch only the container (no database), so they are cheap and safe
+to run in every deployment check. They are skipped under `--audit`, which is
+scoped to the audit-outbox checks only.
+
 If you are using durable execution, also schedule the relay and recovery commands:
 
 ```php

--- a/src/Commands/SwarmHealthCommand.php
+++ b/src/Commands/SwarmHealthCommand.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Commands;
 
+use BuiltByBerry\LaravelSwarm\Audit\NoOpSwarmAuditSink;
 use BuiltByBerry\LaravelSwarm\Contracts\ArtifactRepository;
+use BuiltByBerry\LaravelSwarm\Contracts\CapturePolicy;
 use BuiltByBerry\LaravelSwarm\Contracts\ContextStore;
 use BuiltByBerry\LaravelSwarm\Contracts\DurableRunStore;
 use BuiltByBerry\LaravelSwarm\Contracts\RunHistoryStore;
 use BuiltByBerry\LaravelSwarm\Contracts\StreamEventStore;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
 use Carbon\CarbonInterface;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
@@ -62,6 +65,14 @@ class SwarmHealthCommand extends Command
                 $results[] = $this->runOutboxStalenessCheck($config, $connection);
                 $results[] = $this->runQueueRoutingCheck($config, $connection);
             }
+
+            // Governed-by-default checks: the single-agent/inline front door promises
+            // that globally-configured guardrails, the audit sink, and the capture
+            // policy are wired up. These are container-only checks (no database), so
+            // they run on a bare `swarm:health` alongside the persistence checks.
+            $results[] = $this->runGuardrailResolutionCheck($app, $config);
+            $results[] = $this->runAuditSinkCheck($app);
+            $results[] = $this->runCapturePolicyCheck($app);
         }
 
         // Audit outbox checks run by default (the audit lane is on by default in v0.5)
@@ -118,6 +129,142 @@ class SwarmHealthCommand extends Command
             'store' => 'n/a',
             'status' => 'failed',
             'details' => 'Queued and durable swarms require active runtime context persistence so workers can continue or recover the run. Enable [swarm.capture.active_context] (SWARM_CAPTURE_ACTIVE_CONTEXT=true) or use synchronous execution.',
+        ];
+    }
+
+    /**
+     * Every globally-configured guardrail ref (swarm.guardrails.input/step/output)
+     * must resolve from the container — the same resolution path {@see SwarmGuardrailRunner}
+     * takes at run time. A ref that is neither a container-resolvable class name nor an
+     * object instance would throw mid-run, so surfacing it here fails loud up front.
+     *
+     * @return array{component: string, driver: string, store: string, status: string, details: string}
+     */
+    protected function runGuardrailResolutionCheck(Application $app, ConfigRepository $config): array
+    {
+        $total = 0;
+        $problems = [];
+
+        foreach (['input', 'step', 'output'] as $phase) {
+            /** @var mixed $configured */
+            $configured = $config->get("swarm.guardrails.{$phase}", []);
+
+            if (! is_array($configured)) {
+                continue;
+            }
+
+            /** @var mixed $ref */
+            foreach ($configured as $ref) {
+                $total++;
+                $label = is_string($ref) ? $ref : get_debug_type($ref);
+
+                try {
+                    if (is_object($ref)) {
+                        continue;
+                    }
+
+                    if (is_string($ref) && class_exists($ref)) {
+                        $app->make($ref);
+
+                        continue;
+                    }
+
+                    $problems[] = "[{$phase}] {$label}";
+                } catch (Throwable $exception) {
+                    $problems[] = "[{$phase}] {$label} ({$exception->getMessage()})";
+                }
+            }
+        }
+
+        if ($problems !== []) {
+            return [
+                'component' => 'Guardrails',
+                'driver' => 'n/a',
+                'store' => 'n/a',
+                'status' => 'failed',
+                'details' => 'Configured guardrail ref(s) not resolvable: '.implode('; ', $problems).'. Each swarm.guardrails.[input|step|output] entry must be a container-resolvable class name or an object instance.',
+            ];
+        }
+
+        return [
+            'component' => 'Guardrails',
+            'driver' => 'n/a',
+            'store' => 'n/a',
+            'status' => 'ok',
+            'details' => $total === 0
+                ? 'no global guardrails configured (swarm.guardrails.input/step/output empty)'
+                : "{$total} global guardrail ref(s) resolve from the container",
+        ];
+    }
+
+    /**
+     * The audit lane is on by default, but the SwarmAuditSink binding defaults to
+     * NoOpSwarmAuditSink, which discards every evidence record. That is a valid
+     * choice for non-regulated apps, so a NoOp sink is a note (not a failure) — it
+     * tells the operator that no evidence is being retained and how to change that.
+     *
+     * @return array{component: string, driver: string, store: string, status: string, details: string}
+     */
+    protected function runAuditSinkCheck(Application $app): array
+    {
+        try {
+            $sink = $app->make(SwarmAuditSink::class);
+        } catch (Throwable $exception) {
+            return [
+                'component' => 'Audit sink',
+                'driver' => 'n/a',
+                'store' => 'n/a',
+                'status' => 'failed',
+                'details' => 'SwarmAuditSink could not be resolved from the container: '.$exception->getMessage(),
+            ];
+        }
+
+        if ($sink instanceof NoOpSwarmAuditSink) {
+            return [
+                'component' => 'Audit sink',
+                'driver' => 'n/a',
+                'store' => 'n/a',
+                'status' => 'note',
+                'details' => 'SwarmAuditSink is bound to NoOpSwarmAuditSink — audit evidence is discarded. Bind a real SwarmAuditSink (e.g. LogChannelSwarmAuditSink or your own append-only store) to retain evidence; run [php artisan swarm:install:audit] to scaffold one.',
+            ];
+        }
+
+        return [
+            'component' => 'Audit sink',
+            'driver' => 'n/a',
+            'store' => 'n/a',
+            'status' => 'ok',
+            'details' => 'SwarmAuditSink bound to '.get_debug_type($sink),
+        ];
+    }
+
+    /**
+     * The CapturePolicy governs what each run captures into audit evidence and
+     * history. A broken binding would throw the first time a run tried to make a
+     * capture decision, so verify it resolves up front.
+     *
+     * @return array{component: string, driver: string, store: string, status: string, details: string}
+     */
+    protected function runCapturePolicyCheck(Application $app): array
+    {
+        try {
+            $policy = $app->make(CapturePolicy::class);
+        } catch (Throwable $exception) {
+            return [
+                'component' => 'Capture policy',
+                'driver' => 'n/a',
+                'store' => 'n/a',
+                'status' => 'failed',
+                'details' => 'CapturePolicy could not be resolved from the container: '.$exception->getMessage().'. Bind a valid CapturePolicy or restore the default BooleanCapturePolicy binding.',
+            ];
+        }
+
+        return [
+            'component' => 'Capture policy',
+            'driver' => 'n/a',
+            'store' => 'n/a',
+            'status' => 'ok',
+            'details' => 'CapturePolicy resolves ('.get_debug_type($policy).')',
         ];
     }
 

--- a/tests/Feature/SwarmHealthCommandTest.php
+++ b/tests/Feature/SwarmHealthCommandTest.php
@@ -3,9 +3,11 @@
 declare(strict_types=1);
 
 use BuiltByBerry\LaravelSwarm\Contracts\ArtifactRepository;
+use BuiltByBerry\LaravelSwarm\Contracts\CapturePolicy;
 use BuiltByBerry\LaravelSwarm\Contracts\ContextStore;
 use BuiltByBerry\LaravelSwarm\Contracts\RunHistoryStore;
 use BuiltByBerry\LaravelSwarm\Contracts\StreamEventStore;
+use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSink;
 use BuiltByBerry\LaravelSwarm\Exceptions\SwarmException;
 use BuiltByBerry\LaravelSwarm\Persistence\CacheArtifactRepository;
 use BuiltByBerry\LaravelSwarm\Persistence\CacheContextStore;
@@ -45,6 +47,14 @@ class SwarmHealthFailingCacheStore extends ArrayStore
     public function put($key, $value, $seconds): bool
     {
         return false;
+    }
+}
+
+class SwarmHealthRecordingAuditSink implements SwarmAuditSink
+{
+    public function emit(string $category, array $payload): void
+    {
+        // no-op: presence of the binding is what the health check verifies.
     }
 }
 
@@ -111,11 +121,17 @@ test('swarm health json output is structured', function (): void {
 
     $payload = json_decode(Artisan::output(), true);
 
+    // 4 persistence checks + 3 governed-by-default checks (Guardrails, Audit sink, Capture policy).
     expect($payload)
         ->toBeArray()
         ->and($payload['ok'])->toBeTrue()
-        ->and($payload['checks'])->toHaveCount(4)
+        ->and($payload['checks'])->toHaveCount(7)
         ->and($payload['checks'][0])->toHaveKeys(['component', 'driver', 'store', 'status', 'details']);
+
+    // Every check — including the new governance checks — carries the same shape.
+    foreach ($payload['checks'] as $check) {
+        expect($check)->toHaveKeys(['component', 'driver', 'store', 'status', 'details']);
+    }
 });
 
 test('swarm health identifies failing cache component', function (): void {
@@ -733,5 +749,115 @@ describe('policy-aware audit outbox scoping (fix #247)', function (): void {
 
         expect($exitCode)->toBe(0)
             ->and($payload['ok'])->toBeTrue();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// v0.22.0 — governed-by-default checks (guardrails / audit sink / capture policy)
+// ---------------------------------------------------------------------------
+
+describe('guardrail resolution check', function (): void {
+    test('reports ok with an empty-config message when no guardrails are configured', function (): void {
+        $exitCode = Artisan::call('swarm:health');
+
+        expect($exitCode)->toBe(0);
+        expect(Artisan::output())
+            ->toContain('Guardrails')
+            ->toContain('no global guardrails configured');
+    });
+
+    test('reports ok when a configured guardrail ref resolves from the container', function (): void {
+        config()->set('swarm.guardrails.input', [stdClass::class]);
+
+        $exitCode = Artisan::call('swarm:health');
+
+        expect($exitCode)->toBe(0);
+        expect(Artisan::output())
+            ->toContain('Guardrails')
+            ->toContain('global guardrail ref(s) resolve');
+    });
+
+    test('reports failed and exits 1 when a configured guardrail ref is not resolvable', function (): void {
+        config()->set('swarm.guardrails.step', ['Not\\A\\Real\\GuardrailClass']);
+
+        $exitCode = Artisan::call('swarm:health');
+
+        expect($exitCode)->toBe(1);
+        expect(Artisan::output())
+            ->toContain('Guardrails')
+            ->toContain('failed')
+            ->toContain('not resolvable');
+    });
+});
+
+describe('audit sink check', function (): void {
+    test('reports a note (not a failure) when the sink is the default NoOp', function (): void {
+        $exitCode = Artisan::call('swarm:health');
+
+        expect($exitCode)->toBe(0);
+        expect(Artisan::output())
+            ->toContain('Audit sink')
+            ->toContain('NoOpSwarmAuditSink')
+            ->toContain('swarm:install:audit');
+    });
+
+    test('reports ok when a real SwarmAuditSink is bound', function (): void {
+        app()->singleton(SwarmAuditSink::class, SwarmHealthRecordingAuditSink::class);
+
+        $exitCode = Artisan::call('swarm:health');
+
+        expect($exitCode)->toBe(0);
+        expect(Artisan::output())
+            ->toContain('Audit sink')
+            ->toContain('SwarmHealthRecordingAuditSink');
+    });
+});
+
+describe('capture policy check', function (): void {
+    test('reports ok when the default CapturePolicy resolves', function (): void {
+        $exitCode = Artisan::call('swarm:health');
+
+        expect($exitCode)->toBe(0);
+        expect(Artisan::output())
+            ->toContain('Capture policy')
+            ->toContain('CapturePolicy resolves');
+    });
+
+    test('reports failed and exits 1 when the CapturePolicy binding cannot be resolved', function (): void {
+        app()->bind(CapturePolicy::class, function (): CapturePolicy {
+            throw new RuntimeException('capture policy binding is broken');
+        });
+
+        $exitCode = Artisan::call('swarm:health');
+
+        expect($exitCode)->toBe(1);
+        expect(Artisan::output())
+            ->toContain('Capture policy')
+            ->toContain('could not be resolved');
+    });
+});
+
+describe('governance checks in --json output', function (): void {
+    test('the three governance checks appear with the standard shape in --json', function (): void {
+        $exitCode = Artisan::call('swarm:health', ['--json' => true]);
+
+        $payload = json_decode(Artisan::output(), true);
+
+        $components = array_column($payload['checks'], 'component');
+
+        expect($exitCode)->toBe(0)
+            ->and($payload['ok'])->toBeTrue()
+            ->and($components)->toContain('Guardrails')
+            ->and($components)->toContain('Audit sink')
+            ->and($components)->toContain('Capture policy');
+    });
+
+    test('the three governance checks are skipped under --audit (audit-outbox scope only)', function (): void {
+        $output = Artisan::call('swarm:health', ['--audit' => true]);
+
+        expect($output)->toBe(0);
+        expect(Artisan::output())
+            ->not->toContain('Guardrails')
+            ->not->toContain('Capture policy');
     });
 });


### PR DESCRIPTION
## What

Extends the existing `swarm:health` command with three container-only checks that back the **governed-by-default** promise of the new single-agent / inline front door. No new command was added (`swarm:doctor` was explicitly out of scope).

The checks run on a bare `swarm:health` invocation (no flag required) alongside the persistence checks, and follow the exact same row shape as every existing check (`component`, `driver`, `store`, `status`, `details`), so they also appear in `--json` output:

- **Guardrails** — every globally-configured ref in `swarm.guardrails.input` / `.step` / `.output` resolves from the container (the same resolution path `SwarmGuardrailRunner` takes at run time). `ok` when all resolve (or none configured); `failed` when a ref is neither a container-resolvable class name nor an object instance — it would otherwise throw mid-run.
- **Audit sink** — reports which `SwarmAuditSink` is bound. A real sink is `ok`; the default `NoOpSwarmAuditSink` (discards all evidence) is surfaced as a `note`, not a failure — matching the tone of the existing audit checks, since discarding evidence is a valid choice for non-regulated apps. The detail points to `swarm:install:audit`.
- **Capture policy** — the bound `CapturePolicy` resolves from the container. `ok` when it resolves; `failed` when the binding is broken.

These checks are skipped under `--audit`, which stays scoped to the audit-outbox checks only. They touch only the container (no database), so they are cheap and safe in every deployment check.

## Files changed

- `src/Commands/SwarmHealthCommand.php` — three new check methods + wiring into `handle()`.
- `docs/maintenance.md` — new "Governed-by-default checks" subsection under the `swarm:health` docs.
- `tests/Feature/SwarmHealthCommandTest.php` — coverage for all three checks in human and `--json` output; updated the existing JSON count assertion (4 → 7) and added a per-check shape assertion.

## Verification

- `vendor/bin/pest tests/Feature/SwarmHealthCommandTest.php` — 50 passed (190 assertions).
- `vendor/bin/phpstan analyse src/Commands/SwarmHealthCommand.php --level=7 --memory-limit=1G` — no errors. (Tests are not in phpstan's analysed paths.)

## Acceptance criteria

- [x] New checks added to `SwarmHealthCommand`, each with an actionable `details` string.
- [x] Included in `--json` output with the same shape as existing checks.
- [x] No new command — extended the existing one.
- [x] `docs/maintenance.md` updated.
- [x] `tests/Feature/SwarmHealthCommandTest.php` extended for human and `--json` output.

CHANGELOG deferred to release-wrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
