### PR TITLE
feat(boost): ship Laravel Boost AI guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,10 @@ The same content is mirrored in this repository; the [in-repo documentation inde
 
 For the full set — topologies, guardrails, the durable subsystems, observability, operator runbooks, and examples — see the [documentation index](docs/README.md).
 
+## AI Coding Assistants (Laravel Boost)
+
+Laravel Swarm ships first-party [Laravel Boost](https://laravel.com/docs/boost) AI guidelines, so coding agents (Claude Code, Cursor, …) generate correct, governed swarm code in apps that use the package. When a consuming app runs `php artisan boost:install` (or `boost:update --discover`), Boost automatically picks up the package's guidelines and instructs the agent on the paved path — `Swarm::agent()`, the inline `Swarm::sequential()/parallel()/hierarchical()` builders, and class-based swarms — and to prefer them over a bare `laravel/ai` agent, which bypasses swarm's governance.
+
 ## Companion Packages
 
 Laravel Swarm is a small core with a growing family of companion packages —

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -1,0 +1,62 @@
+## Laravel Swarm
+
+`builtbyberry/laravel-swarm` adds reusable **multi-agent orchestration** on top of the official `laravel/ai` package. It runs one or more `laravel/ai` agents through a governed pipeline — audit trail, guardrails, capture, telemetry, and encrypt-at-rest — across sequential, parallel, and hierarchical topologies, with synchronous, queued, streamed, and durable execution modes.
+
+Everything a swarm run does is governed the same way whether it uses one agent or many. Prefer the paved path below over calling a bare `laravel/ai` agent directly, which bypasses all of this.
+
+### The paved path — pick the smallest that fits
+
+**One agent, no class.** Run a single agent through the full governed pipeline with one line:
+
+@verbatim
+<code-snippet name="Single agent, fully governed" lang="php">
+use BuiltByBerry\LaravelSwarm\Facades\Swarm;
+
+$response = Swarm::agent($agent)->prompt($task);
+// also ->stream($task), ->queue($task), ->broadcast($task, $channel), ->dispatchDurable($task)
+$response->output;
+</code-snippet>
+@endverbatim
+
+**Several agents, no class.** Compose a multi-agent swarm inline; each builder pins its topology:
+
+@verbatim
+<code-snippet name="Inline multi-agent swarms" lang="php">
+Swarm::sequential([$researcher, $writer, $editor])->prompt($task);   // each output feeds the next
+Swarm::parallel([$a, $b, $c])->stream($task);                        // every agent sees the same task
+Swarm::hierarchical($coordinator, [$writer, $editor])->prompt($task); // coordinator routes over workers
+</code-snippet>
+@endverbatim
+
+**A named, reusable swarm.** Author a class when the same topology is reused, carries class-level attributes (`#[Topology]`, `#[Timeout]`, `#[MaxAgentSteps]`, `#[DurableRetry]`, …), or declares guardrails via `DefinesGuardrails`. Generate one with `php artisan make:swarm:swarm`:
+
+@verbatim
+<code-snippet name="Class-based swarm" lang="php">
+use BuiltByBerry\LaravelSwarm\Attributes\Topology;
+use BuiltByBerry\LaravelSwarm\Concerns\Runnable;
+use BuiltByBerry\LaravelSwarm\Contracts\Swarm;
+use BuiltByBerry\LaravelSwarm\Enums\Topology as TopologyEnum;
+
+#[Topology(TopologyEnum::Sequential)]
+class ContentPipeline implements Swarm
+{
+    use Runnable;
+
+    public function agents(): array
+    {
+        return [new Researcher, new Writer, new Editor];
+    }
+}
+
+ContentPipeline::make()->prompt($task);
+</code-snippet>
+@endverbatim
+
+### Conventions
+
+- **Governed by default.** The app's globally configured guardrails (`config('swarm.guardrails.*')`) always apply; per-call `->guardrails([...])` on the inline builders is additive, not a replacement.
+- **Agents are `laravel/ai` agents.** Any class implementing `Laravel\Ai\Contracts\Agent` (or the swarm marker `BuiltByBerry\LaravelSwarm\Contracts\Agent`) works. Use `php artisan make:swarm:agent`.
+- **Persistence & capture are opt-in.** Prompt/agent payloads are not persisted unless enabled in `config/swarm.php` (`swarm.capture.*`); when database persistence is on, sensitive columns are encrypted at rest.
+- **Operate with the `swarm:*` Artisan commands** (`swarm:status`, `swarm:health`, `swarm:trace`, `swarm:recover`, …). Queued and durable runs need the queue worker running; durable runs also need `swarm:relay` scheduled every minute.
+
+Use Boost's `search-docs` tool for depth on topologies, durable execution, memory, guardrails, and testing — and the `swarm-development` agent skill for end-to-end authoring patterns.


### PR DESCRIPTION
## Ship Laravel Boost AI guidelines

Adds `resources/boost/guidelines/core.blade.php` — the [third-party package AI guidelines](https://laravel.com/docs/13.x/boost#third-party-package-ai-guidelines) Boost auto-loads (upfront) when a consuming app runs `php artisan boost:install` / `boost:update --discover`. Pure dogfooding: swarm is itself an AI-orchestration package, so this helps coding agents write correct, **governed** swarm code downstream.

### Contents (kept concise — it loads into every agent's context)
- What the package is (multi-agent orchestration on `laravel/ai`, governed pipeline).
- The **paved path**, smallest-that-fits: `Swarm::agent()` → inline `Swarm::sequential()/parallel()/hierarchical()` → class-based swarm — each in a `@verbatim <code-snippet lang="php">` block per Boost convention.
- Conventions: governed-by-default (global `swarm.guardrails.*` + additive per-call), agents are `laravel/ai` agents, capture/persistence opt-in, `swarm:*` operate commands.
- Points at Boost's `search-docs` tool and the `swarm-development` skill (sibling PR) for depth rather than inlining everything.
- README: new "AI Coding Assistants (Laravel Boost)" section.

### Verification
- File at the documented path; **balanced** `@verbatim`/`@endverbatim` (3/3) and `<code-snippet>` open/close (3/3); code samples written against the merged front-door + inline-builder surfaces.
- Full `boost:install` pickup can only be confirmed in a consuming app — `laravel/boost` is not a dependency of this package (by design). The file follows the exact path + format convention Boost discovers.

### Acceptance criteria
- [x] `resources/boost/guidelines/core.blade.php` — overview + paved path + governed-by-default
- [x] `@verbatim <code-snippet name="..." lang="php">` blocks per convention
- [x] Kept short; points at search-docs / skills for depth
- [~] Verified pickup via `boost:install` — path/format correct; end-to-end needs a consuming app (noted)
- [x] Docs: README notes Boost support
- [ ] CHANGELOG — deferred to release-wrap

Sibling: `laravel-boost-skills` (on-demand depth) follows next. Targets `release/v0.22.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
