### PR TITLE
feat(boost): ship swarm-development agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,7 +661,10 @@ For the full set — topologies, guardrails, the durable subsystems, observabili
 
 ## AI Coding Assistants (Laravel Boost)
 
-Laravel Swarm ships first-party [Laravel Boost](https://laravel.com/docs/boost) AI guidelines, so coding agents (Claude Code, Cursor, …) generate correct, governed swarm code in apps that use the package. When a consuming app runs `php artisan boost:install` (or `boost:update --discover`), Boost automatically picks up the package's guidelines and instructs the agent on the paved path — `Swarm::agent()`, the inline `Swarm::sequential()/parallel()/hierarchical()` builders, and class-based swarms — and to prefer them over a bare `laravel/ai` agent, which bypasses swarm's governance.
+Laravel Swarm ships first-party [Laravel Boost](https://laravel.com/docs/boost) AI guidelines **and** an agent skill, so coding agents (Claude Code, Cursor, …) generate correct, governed swarm code in apps that use the package. When a consuming app runs `php artisan boost:install` (or `boost:update --discover`), Boost automatically picks them up:
+
+- **Guidelines** (loaded upfront) instruct the agent on the paved path — `Swarm::agent()`, the inline `Swarm::sequential()/parallel()/hierarchical()` builders, and class-based swarms — and to prefer them over a bare `laravel/ai` agent, which bypasses swarm's governance.
+- The **`swarm-development` skill** (loaded on demand) carries the deeper end-to-end authoring patterns: topology and execution-mode choice, governed-by-default guardrails, and testing the audit trail.
 
 ## Companion Packages
 

--- a/resources/boost/skills/swarm-development/SKILL.md
+++ b/resources/boost/skills/swarm-development/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: swarm-development
+description: Build and work with Laravel Swarm (builtbyberry/laravel-swarm) — author single-agent, inline, and class-based swarms; pick topologies and execution modes; keep runs governed; and test the audit trail. Use when creating or editing swarm classes/agents, running agents through the governed pipeline, or writing swarm tests.
+---
+
+# Laravel Swarm Development
+
+Laravel Swarm runs one or more `laravel/ai` agents through a **governed pipeline** — audit trail, guardrails, capture, telemetry, encrypt-at-rest — on top of the official `laravel/ai` package. Governance is identical whether a run has one agent or many.
+
+## When to use this skill
+
+Use it when the task involves: creating or editing a swarm or its agents; running an agent through the governed pipeline instead of a bare `laravel/ai` call; choosing a topology (sequential / parallel / hierarchical) or execution mode (prompt / queue / stream / durable); or writing tests that assert what a run did.
+
+Prefer the **smallest** entry that fits, and always prefer these over a bare `laravel/ai` agent call, which bypasses governance.
+
+## Authoring — pick the smallest that fits
+
+### 1. One agent, no class
+
+```php
+use BuiltByBerry\LaravelSwarm\Facades\Swarm;
+
+$response = Swarm::agent($agent)->prompt($task);
+$response->output;              // string
+$response->steps;               // array<SwarmStep>
+
+// every execution mode is available:
+Swarm::agent($agent)->stream($task);           // StreamableSwarmResponse (SSE)
+Swarm::agent($agent)->queue($task);            // background
+Swarm::agent($agent)->broadcast($task, $ch);   // push to Echo/Reverb/Pusher
+Swarm::agent($agent)->dispatchDurable($task);  // checkpointed, recoverable
+```
+
+### 2. Several agents, no class
+
+```php
+Swarm::sequential([$researcher, $writer, $editor])->prompt($task);    // output feeds the next
+Swarm::parallel([$a, $b, $c])->prompt($task);                         // same task to every agent
+Swarm::hierarchical($coordinator, [$writer, $editor])->prompt($task); // coordinator routes over workers
+```
+
+Each inline builder pins its own topology and returns a fluent `PendingSwarmRun` with the same execution modes as above.
+
+### 3. A named, reusable swarm class
+
+Author a class when the same topology is reused, needs class-level attributes, or declares guardrails. Generate it with `php artisan make:swarm:swarm ContentPipeline` (use `--single` for a single-agent scaffold; the interactive `make:swarm` guides the choice), and `php artisan make:swarm:agent` for agents.
+
+```php
+use BuiltByBerry\LaravelSwarm\Attributes\Topology;
+use BuiltByBerry\LaravelSwarm\Concerns\Runnable;
+use BuiltByBerry\LaravelSwarm\Contracts\Swarm;
+use BuiltByBerry\LaravelSwarm\Enums\Topology as TopologyEnum;
+
+#[Topology(TopologyEnum::Sequential)]
+class ContentPipeline implements Swarm
+{
+    use Runnable;
+
+    public function agents(): array
+    {
+        return [new Researcher, new Writer, new Editor];   // hierarchical: agents()[0] is the coordinator
+    }
+}
+
+ContentPipeline::make()->prompt($task);
+```
+
+Class-level attributes worth knowing: `#[Topology]`, `#[Timeout]`, `#[MaxAgentSteps]`, `#[DurableRetry]`, `#[DurableWait]`. Declare guardrails by implementing `DefinesGuardrails::guardrails()`.
+
+## Choosing an execution mode
+
+- `prompt()`/`run()` — synchronous, returns `SwarmResponse`. Default.
+- `queue()` — background job; **retries are off by default** (a queued run has no checkpoint, so a retry re-runs from step 0).
+- `stream()` — SSE; sequential topology only.
+- `broadcast()`/`broadcastNow()`/`broadcastOnQueue()` — push stream events to a broadcast channel.
+- `dispatchDurable()` — checkpointed and recoverable; needs the DB persistence driver and `swarm:relay` scheduled every minute.
+
+## Governance — on by default
+
+- Globally configured guardrails (`config('swarm.guardrails.[input|step|output]')`) apply to **every** run. On the inline builders, `->guardrails([...])` is **additive**, not a replacement.
+- Capture is opt-in (`config('swarm.capture.*')`); with the database persistence driver, sensitive columns are encrypted at rest.
+- Operate with `swarm:*` commands: `swarm:health` (validate wiring + guardrail/audit/capture bindings), `swarm:status`, `swarm:trace`, `swarm:recover`, `swarm:relay`.
+
+## Testing a swarm
+
+Fake agents with `laravel/ai`'s fake, and assert the governed audit trail with the recording sink:
+
+```php
+use BuiltByBerry\LaravelSwarm\Facades\Swarm;
+use BuiltByBerry\LaravelSwarm\Testing\SwarmFake;
+
+$audit = SwarmFake::interceptSwarmAuditSink();
+
+Swarm::sequential([new Researcher, new Writer])->prompt('a task');
+
+$audit->assertAuditChain(['run.started', 'step.started', 'step.completed', 'run.completed']);
+$audit->assertEmittedAudit('run.completed');
+$audit->assertStepCount(2);
+```
+
+A class-based swarm also exposes `MySwarm::fake()` plus `assertPrompted()`, `assertRan()`, `assertStreamed()`, `assertQueued()`, `assertDispatchedDurably()`, and persisted-run / lifecycle-event assertions.
+
+## Reference
+
+Use Boost's `search-docs` tool for depth on durable execution, memory, guardrails, hierarchical routing, and the audit-evidence contract — the package mirrors its full documentation in `docs/`.


### PR DESCRIPTION
## Ship the `swarm-development` Boost agent skill

Adds `resources/boost/skills/swarm-development/SKILL.md` — the on-demand [third-party package skill](https://laravel.com/docs/13.x/boost#third-party-package-skills) Boost installs (per user preference) on `php artisan boost:install`. Complements the upfront guidelines (#417): guidelines set the paved path in every agent's context; this skill loads **on demand** with the deeper authoring patterns.

### Contents
Agent Skills format (YAML `name` + `description` frontmatter, Markdown body): when-to-use; authoring at all three altitudes (front door → inline → class); topology + execution-mode choice; governed-by-default guardrails; and **testing the audit trail** via `SwarmFake::interceptSwarmAuditSink()` (the assertion helper shipped earlier this release). README's Boost section now lists guidelines (upfront) + skill (on-demand).

### Scope decision (logged, not silently dropped)
The AC asked which deep-subsystem skills ship in v0.22.0 vs. later. **Decision:** ship **one** `swarm-development` skill now; **defer** durable-execution / guardrails+audit / memory skills to a later release. Rationale: one cohesive skill covers the v0.22.0 DX surface without over-splitting an agent's on-demand context; the deep subsystems already have thorough `docs/` reachable via Boost's `search-docs`.

### Verification
- Valid Agent Skills frontmatter (`name` + `description` present); correct path `resources/boost/skills/swarm-development/SKILL.md`.
- Content written against the merged front-door + inline builders + the new testing assertions.
- Full `boost:install` install can only be confirmed in a consuming app — `laravel/boost` isn't a dependency here (by design); the folder/format follows the documented convention.

### Acceptance criteria
- [x] `resources/boost/skills/swarm-development/SKILL.md` — when-to-use + end-to-end authoring
- [x] Deep-subsystem skills decision logged (defer durable/guardrails+audit/memory)
- [x] Valid frontmatter (name, description)
- [~] `boost:install` discovery — path/format correct; end-to-end needs a consuming app (noted)
- [x] Docs: README notes the skill
- [ ] CHANGELOG — deferred to release-wrap

Targets `release/v0.22.0`. Depends on #417 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
