### PR TITLE
docs: v0.22.0 cohesiveness pass (README + UPGRADING reconciliation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ In a sequential swarm, the first agent receives the original task. Each later ag
 
 ## Running a Swarm
 
+> **No class required.** For one agent — or a quick multi-agent composition — you don't need to author a `Swarm` class at all. `Swarm::agent($agent)->prompt($task)` runs a single agent through the **same** governed pipeline (audit, guardrails, capture, telemetry, encrypt-at-rest), and `Swarm::sequential()` / `Swarm::parallel()` / `Swarm::hierarchical()` do the same for inline multi-agent swarms — every execution mode included. See the [Cookbook](docs/cookbook.md) and [Execution Modes: Single Agent](docs/execution-modes.md#single-agent-swarmagent). Reach for a `Swarm` class when the topology is reused, named, or carries class-level attributes.
+
 Use `prompt()` when the caller can wait for the full workflow result:
 
 ```php

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -270,6 +270,18 @@ This package’s `composer.json` uses `"minimum-stability": "dev"` with
 still prefers tagged releases. Your application may need compatible Composer
 stability settings while Laravel AI remains pre-stable.
 
+## Upgrading to v0.22.0
+
+**No required action — additive, developer-experience release.** Nothing in your existing code changes behavior; every addition is new public surface you can adopt at your own pace:
+
+- **Class-free entry points.** `Swarm::agent($agent)` runs a single agent through the full governed pipeline, and `Swarm::sequential()` / `Swarm::parallel()` / `Swarm::hierarchical($coordinator, [$workers])` run inline multi-agent swarms — all without authoring a `Swarm` class, all with the same audit, guardrails, capture, telemetry, and encrypt-at-rest as a class-based swarm. See [Execution Modes](docs/execution-modes.md#single-agent-swarmagent) and the [Cookbook](docs/cookbook.md).
+- **Testing.** `SwarmFake::interceptSwarmAuditSink()` returns a recording sink with `assertAuditChain()`, `assertEmittedAudit()`, `assertNotEmittedAudit()`, and `assertStepCount()`. See [Testing](docs/testing.md#use-swarmfake-intercepts-for-the-audit-contracts-v07).
+- **`swarm:health`** gained governed-by-default checks (guardrails resolvable, audit sink reachable, capture policy sane), included in `--json`. See [Maintenance](docs/maintenance.md).
+- **`make:swarm`** is now an interactive front door (single-agent vs. multi-agent, topology prompts) with a `--single` scaffold; non-interactive/`--no-interaction` usage is unchanged. See [Generators](docs/generators.md).
+- **Laravel Boost.** The package ships Boost AI guidelines and a `swarm-development` skill; consuming apps pick them up via `php artisan boost:install`.
+
+No migration, config, or schema change. `Swarm::run()`, `prompt()`, and class-based swarms are untouched. See the [CHANGELOG](CHANGELOG.md) for the full list.
+
 ## Upgrading to v0.20.0
 
 **Required action only if your application pins `laravel/ai` below 0.9.** This release raises Swarm's `laravel/ai` requirement from `^0.8` to `^0.9` (v0.9.0); support for the 0.8 line is dropped. Swarm's own source is unchanged — the upgrade is verified against the full test suite and PHPStan level 7 — but Composer will now resolve `laravel/ai` to 0.9.x, so treat it as an integration-test event:


### PR DESCRIPTION
## Docs cohesiveness pass (v0.22.0)

The finale of v0.22.0 — reconciles the newly-merged DX surfaces with the top-level docs, rather than re-documenting features (each feature component already shipped its own docs). Targets the real cohesiveness gaps surfaced by a repo-wide survey:

### Changes
- **README — single-agent path discoverable from the top.** `Running a Swarm` now opens with a "No class required" note surfacing `Swarm::agent()` + the inline `sequential/parallel/hierarchical` builders, cross-linked to the [Cookbook](docs/cookbook.md) and [Execution Modes](docs/execution-modes.md#single-agent-swarmagent). Previously the front door only appeared far down in the Boost section.
- **UPGRADING.md — v0.22.0 block** (additive, no required action): class-free entry points, `SwarmFake::interceptSwarmAuditSink()` assertions, `swarm:health` governed-by-default checks, interactive `make:swarm`, and Boost guidelines/skill. Placed newest-first above v0.20.0.

### Verified
- Every referenced anchor resolves to a real heading (`#single-agent-swarmagent`, `#use-swarmfake-intercepts-for-the-audit-contracts-v07`) and every linked file exists (`cookbook.md`, `maintenance.md`, `generators.md`).
- Terminology consistent across README / execution-modes / cookbook / testing / Boost resources (governed pipeline · front door · inline builders · class-based swarm).
- `docs/README.md` index already lists the Cookbook (added when that component landed) — accurate.

### Scope note (no silent caps)
This pass **reconciles** discoverability + upgrade coverage; it does **not** rewrite the 40+ stable per-topic docs line-by-line. Those are individually accurate and current; a blanket rewrite would be churn and regression risk with little reader benefit. `configuration.md` needed no change — v0.22.0 added no new config keys (the front door reuses `swarm.guardrails.*`).

### Acceptance criteria
- [x] Consistent terminology and voice across docs/ and README
- [x] Public surfaces cross-linked; `docs/README.md` index accurate (Cookbook present)
- [x] README ↔ docs ↔ getting-started aligned; single-agent path discoverable from the top
- [x] UPGRADING.md covers v0.22.0 additions
- [x] configuration.md — no change needed (no new config keys); noted
- [ ] CHANGELOG — deferred to release-wrap

Final component of v0.22.0. Targets `release/v0.22.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
