### PR TITLE
chore(deps): tighten minimum-stability from dev to stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,14 @@ _To be filled in during release wrap-up._
 
 ### Changed
 
-_To be filled in during release wrap-up._
+- Tightened `minimum-stability` from `dev` to `stable` in `composer.json`. The
+  `dev` floor was inert — `prefer-stable: true` already resolved every dependency
+  to a stable tag, and no package in the tree required a dev version. Narrowing
+  the floor stops the package broadening transitive resolution for consumers.
+  Verified against both the default and `--prefer-lowest` resolutions, and
+  against an explicit dev-branch requirement (Composer adds its own stability
+  flags for those, so dev-branch CI lanes are unaffected). No dependency versions
+  changed.
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -88,6 +88,6 @@
             "pestphp/pest-plugin": true
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }


### PR DESCRIPTION
Resolves the v0.23.0 spike #436. Outcome: **tightened**.

## What changed

One line in `composer.json` — `minimum-stability` from `dev` to `stable` — plus a CHANGELOG entry. No dependency versions moved.

## Why it's safe

**The `dev` floor was inert.** `composer.lock` carried zero non-stable packages and an empty `stability-flags` map; `prefer-stable: true` was already resolving everything to a stable tag. Nothing in the tree required a dev version, so narrowing the floor changed no resolution — it only stops the package broadening transitive resolution for consumers.

| Check | Result |
| --- | --- |
| Stable floor, default resolve | exit 0 — laravel/ai v0.9.1, framework v13.20.0, testkit v0.1.2 |
| Stable floor, `--prefer-lowest` | exit 0 — laravel/ai v0.9.0, framework v13.16.0 |
| dev / alpha / beta / RC locked in either | none |
| `composer update --lock` after the change | "Nothing to modify in lock file" |
| pint | passed |
| phpstan L7 | No errors |
| full suite | 1973 passed, 7926 assertions |

The suite needs `memory_limit=1G` locally (the 128M default OOMs); this matches the `ini-values` CI already sets.

## Criterion 3 was unsatisfiable and has been replaced

The issue's third acceptance criterion — *"Nightly dev-main require still resolves locally"* — could not be met **before any change**. `nightly.yml` requires `dev-main` branches that do not exist for `laravel/framework` or the `illuminate/*` splits, so it fails to resolve on the old `dev` floor and the new `stable` one alike. That is a separate defect, filed as #441.

Replacement criterion, satisfied: *an explicit dev-branch requirement still resolves under a stable floor.* Verified with the corrected requires (`laravel/framework:13.x-dev` + `illuminate/*:13.x-dev`) — exit 0, locking `laravel/framework (13.x-dev cda436e)`. Composer adds implicit stability flags for explicitly-required dev versions, so this change does not affect dev-branch CI lanes once #441 fixes them.

The substitution is recorded on the Marshall component and in a comment on #436 rather than dropped silently.

## Notes for review

- Targets `release/v0.23.0`, not `main`.
- `composer.lock` is gitignored (library convention), so only `composer.json` appears in the diff.

Closes #436
