### PR TITLE
fix(ci): make the nightly lane actually test laravel/framework dev (#441)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,16 +3,21 @@ name: nightly
 on:
   schedule:
     # 06:17 UTC daily — off the hour to avoid contention with the GitHub-wide
-    # cron stampede at :00. Early signal for breaking changes on laravel/framework main.
+    # cron stampede at :00. Early signal for breaking changes on the
+    # laravel/framework 13.x development branch (the major this package requires).
     - cron: '17 6 * * *'
   workflow_dispatch:
 
 jobs:
   tests:
-    name: PHP 8.5 - Laravel dev-main
+    name: PHP 8.5 - Laravel 13.x-dev
     runs-on: ubuntu-24.04
-    # Non-blocking: surface failures via the badge but never gate PRs on upstream churn.
-    continue-on-error: true
+    # Deliberately NOT continue-on-error. This lane is scheduled-only and is not a
+    # PR check, so it cannot gate anything — but a job-level continue-on-error marks
+    # the run "success" even when it fails, which turns the badge green and hides
+    # exactly the upstream breakage this lane exists to surface. That is what went
+    # wrong before: the requires named branches that do not exist, every run failed
+    # to resolve, and 30/30 runs still reported success. A red nightly IS the signal.
 
     steps:
       - name: Checkout code
@@ -26,25 +31,43 @@ jobs:
           coverage: pcov
           ini-values: memory_limit=1G
 
-      - name: Require Laravel framework dev-main
-        run: |
-          composer require --no-update --dev \
-            "laravel/framework:dev-main" \
-            "illuminate/bus:dev-main as 13.x-dev" \
-            "illuminate/cache:dev-main as 13.x-dev" \
-            "illuminate/concurrency:dev-main as 13.x-dev" \
-            "illuminate/console:dev-main as 13.x-dev" \
-            "illuminate/container:dev-main as 13.x-dev" \
-            "illuminate/contracts:dev-main as 13.x-dev" \
-            "illuminate/database:dev-main as 13.x-dev" \
-            "illuminate/events:dev-main as 13.x-dev" \
-            "illuminate/filesystem:dev-main as 13.x-dev" \
-            "illuminate/queue:dev-main as 13.x-dev" \
-            "illuminate/support:dev-main as 13.x-dev" \
-            "illuminate/view:dev-main as 13.x-dev"
+      # laravel/framework `replace`s every illuminate/* split, so requiring the
+      # framework's dev branch alone pulls the whole illuminate surface from it —
+      # the package's own `illuminate/*: ^13.0` requires are satisfied by that
+      # replace, and no split resolves to a stable tag alongside it. Listing the
+      # splits individually is unnecessary and was the source of the bad
+      # `dev-main as 13.x-dev` aliases.
+      #
+      # The branch is `13.x-dev`, not `dev-main`: neither laravel/framework nor the
+      # illuminate splits publish a `main` branch, and `dev-master` is the NEXT
+      # major, which conflicts with this package's ^13.0 requires.
+      - name: Require laravel/framework 13.x-dev
+        run: composer require --no-update --dev "laravel/framework:13.x-dev"
 
       - name: Install dependencies
         run: composer update --prefer-dist --no-interaction --no-progress
+
+      # Belt and braces for the failure mode this lane shipped with: if the dev
+      # requirement silently stops taking effect, the suite would still run and
+      # pass against a STABLE framework while claiming to test the dev branch.
+      # Fail loudly instead of testing the wrong thing quietly.
+      - name: Verify a dev framework build was actually installed
+        run: |
+          VERSION=$(php -r '
+            $lock = json_decode(file_get_contents("composer.lock"), true);
+            foreach (array_merge($lock["packages"] ?? [], $lock["packages-dev"] ?? []) as $p) {
+              if ($p["name"] === "laravel/framework") { echo $p["version"]; exit; }
+            }
+            echo "MISSING";
+          ')
+          echo "laravel/framework resolved to: $VERSION"
+          case "$VERSION" in
+            dev-*|*-dev)
+              echo "OK — testing against a dev build." ;;
+            *)
+              echo "::error::Expected a dev build of laravel/framework, got '$VERSION'. The dev requirement did not take effect, so this lane would be testing stable code while reporting on dev."
+              exit 1 ;;
+          esac
 
       # testbench-core no longer auto-creates this symlink in some versions; the
       # process-concurrency tests spawn a real artisan subprocess that needs it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,16 @@ _To be filled in during release wrap-up._
 
 ### Fixed
 
-_To be filled in during release wrap-up._
+- **Nightly Laravel-dev CI lane now actually runs.** The `nightly` workflow
+  required `laravel/framework:dev-main` plus twelve `illuminate/*:dev-main`
+  aliases, but no such branch is published — every run failed to resolve
+  dependencies, and a job-level `continue-on-error` reported those runs as
+  successful, so the lane installed nothing and executed no tests from the day it
+  was added. It now requires `laravel/framework:13.x-dev` (the framework
+  `replace`s the `illuminate/*` splits, so the individual requires were
+  unnecessary), no longer swallows failures, and fails loudly if the resolved
+  framework is not a dev build. This lane is CI-only and does not affect the
+  published package.
 
 ## v0.22.0 - 2026-07-18
 


### PR DESCRIPTION
Resolves #441. Unblocks #435.

The nightly lane has never tested anything. It required `laravel/framework:dev-main` plus twelve `illuminate/*:dev-main as 13.x-dev` aliases — but neither the framework nor the splits publish a `main` branch, so `composer update` failed to resolve on **every** run. A job-level `continue-on-error: true` swallowed the failure, and **30 of 30** recorded runs reported success while installing nothing and executing no tests. Broken since the lane was introduced in `7bbe2c3` (2026-05-18) — not a regression.

## What changed

**1. Require `laravel/framework:13.x-dev`; drop the twelve split requires.**

`laravel/framework` `replace`s every `illuminate/*` split, so requiring the framework's dev branch alone pulls the entire illuminate surface from it. Verified: resolves exit 0, and **no `illuminate/*` package locks separately**, so nothing falls back to a stable tag alongside the dev framework.

`dev-master` is not an option — it is the next major and conflicts with this package's `^13.0` requires (verified: exit 2). `13.x-dev` is the only correct target.

**2. Remove the job-level `continue-on-error`.**

This lane is scheduled-only and is not a PR check, so it never gated anything. But `continue-on-error` at job level marks the run *successful* when it fails, which turns the badge green — directly contradicting the setting's own comment, *"surface failures via the badge."* A red nightly **is** the signal. Removed, with the reasoning recorded inline so it does not get re-added.

**3. Add a guard that fails when a dev build was not actually installed.**

The failure mode this lane shipped with is worse than a red run: if the dev requirement silently stops taking effect, the suite still runs and passes — against *stable* code, while reporting on dev. The new step reads the resolved `laravel/framework` version out of `composer.lock` and fails the job unless it is a dev build.

Exercised for real against this checkout's lock: it extracts `v13.20.0` and correctly fails.

## Verification

| Check | Result |
| --- | --- |
| `laravel/framework:13.x-dev` alone resolves | exit 0, locks `laravel/framework (13.x-dev cda436e)` |
| Any `illuminate/*` on a stable tag alongside it | none — all provided via `replace` |
| `dev-master` alternative | exit 2, conflicts with `^13.0` |
| Guard vs. a stable lock | correctly fails (`v13.20.0`) |
| YAML parses | 9 steps, `continue-on-error` absent |
| Same bug in other workflows (#441 criterion 5) | none — `dev-main` appears in no other workflow |

A dispatched run on this branch is linked in a comment below, per the issue's "observe a run that installs a dev build **and** executes the suite" criterion.

## Notes for review

- **Expect this lane to be able to go red now.** That is the point. If `laravel/framework` 13.x breaks something in swarm, the nightly will fail and the badge will show it. It still cannot block a PR.
- `audit.yml` and `mutation.yml` also carry `continue-on-error: true`. That is deliberately **not** touched here — graduating those into merge gates is #433, which today's finding is a strong argument for.
- No `CHANGELOG.md` entry: this is a CI-only change with no consumer-visible surface. Same open convention question as #445 — say the word and I'll add entries to both.

Closes #441
