### PR TITLE
docs(changelog): backfill v0.23.0 entry for the AGENTS.md drift fix (#444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ _To be filled in during release wrap-up._
   against an explicit dev-branch requirement (Composer adds its own stability
   flags for those, so dev-branch CI lanes are unaffected). No dependency versions
   changed.
+- **`AGENTS.md` corrected against the codebase.** The contributor/agent guidance
+  had drifted: it pointed at a code-review skill that is not installed, and left
+  the topic-branch convention ambiguous about the `v` prefix (topic branches drop
+  it, the release branch keeps it). Both are now stated correctly. Five sections
+  that duplicated the codebase — pinned dependency versions, an Artisan command
+  list covering 8 of 24 commands, a `src/` directory tree, the checkout path, and
+  a capability summary — were replaced with pointers to the source of truth, so
+  they cannot silently go stale again. No runtime or public-API change.
 
 ### Fixed
 


### PR DESCRIPTION
Backfills the `CHANGELOG.md` entry for #444, which merged in #445 without one.

The Definition of Done in `AGENTS.md` requires a changelog entry per PR. #445 (agent guidance) and #446 (CI lane) were both opened without one on the reasoning that neither has a consumer-visible surface — that call has now been overruled, so both get entries. #446 carries its own; this backfills #445, which had already merged.

Placed under **Changed** rather than **Fixed** so it does not collide with the entry #446 adds to **Fixed** — the two merge cleanly in either order.

One line, no code.