### PR TITLE
chore(events): declare value classes readonly once, not per property (#432)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ _To be filled in during release wrap-up._
 
 ### Changed
 
+- **Value classes now declare `readonly class` once instead of repeating
+  `readonly` per property.** 39 event and DTO classes across `src/Events`,
+  `src/Responses` and `src/Support` were declaring every constructor-promoted
+  property `readonly` individually; they now carry the modifier on the class, so
+  immutability is stated once and cannot be silently forgotten when a property is
+  added later. No behaviour or constructor signature changed.
+
+  Five classes were deliberately left alone because they hold genuinely mutable
+  state: `SwarmFailed`, `DurableSwarmResponse`, `QueuedSwarmResponse`,
+  `StreamableSwarmResponse` and `ActiveRunRecord`.
+
 - Tightened `minimum-stability` from `dev` to `stable` in `composer.json`. The
   `dev` floor was inert — `prefer-stable: true` already resolved every dependency
   to a stable tag, and no package in the tree required a dev version. Narrowing

--- a/src/Events/Memory/MemoryDumped.php
+++ b/src/Events/Memory/MemoryDumped.php
@@ -36,15 +36,15 @@ use BuiltByBerry\LaravelSwarm\Contracts\ConversationRunResolver;
  * Listeners doing audit-trail capture will typically pair this event with the
  * `command.memory.dump` audit category emitted alongside it.
  */
-final class MemoryDumped
+final readonly class MemoryDumped
 {
     public function __construct(
-        public readonly string $subjectType,
-        public readonly string $subjectId,
-        public readonly string $format,
-        public readonly bool $includeSnapshots,
-        public readonly int $entryCount,
-        public readonly int $snapshotCount,
-        public readonly bool $runsExpanded,
+        public string $subjectType,
+        public string $subjectId,
+        public string $format,
+        public bool $includeSnapshots,
+        public int $entryCount,
+        public int $snapshotCount,
+        public bool $runsExpanded,
     ) {}
 }

--- a/src/Events/Memory/MemoryForgotten.php
+++ b/src/Events/Memory/MemoryForgotten.php
@@ -42,12 +42,12 @@ use BuiltByBerry\LaravelSwarm\Memory\DefaultSwarmMemory;
  * the dispatch-layer note on {@see DefaultSwarmMemory}
  * for the rationale.
  */
-final class MemoryForgotten
+final readonly class MemoryForgotten
 {
     public function __construct(
-        public readonly MemoryScope $scope,
-        public readonly string $scopeId,
-        public readonly string $key,
-        public readonly bool $existed,
+        public MemoryScope $scope,
+        public string $scopeId,
+        public string $key,
+        public bool $existed,
     ) {}
 }

--- a/src/Events/Memory/MemoryInspected.php
+++ b/src/Events/Memory/MemoryInspected.php
@@ -33,13 +33,13 @@ use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
  * Listeners doing audit-trail capture will typically pair this event with the
  * `command.memory.inspect` audit category emitted alongside it.
  */
-final class MemoryInspected
+final readonly class MemoryInspected
 {
     public function __construct(
-        public readonly string $runId,
-        public readonly ?int $stepIndex,
-        public readonly ?MemoryScope $scopeFilter,
-        public readonly string $format,
-        public readonly int $snapshotCount,
+        public string $runId,
+        public ?int $stepIndex,
+        public ?MemoryScope $scopeFilter,
+        public string $format,
+        public int $snapshotCount,
     ) {}
 }

--- a/src/Events/Memory/MemoryPurged.php
+++ b/src/Events/Memory/MemoryPurged.php
@@ -62,7 +62,7 @@ use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
  * from their purge implementation to keep the listener contract uniform
  * across drivers.
  */
-final class MemoryPurged
+final readonly class MemoryPurged
 {
     /**
      * @param  array<string, int>  $counts  scope value (and `snapshots`, `checkpoints`) keyed deletion counts
@@ -77,8 +77,8 @@ final class MemoryPurged
      * }  $criteria
      */
     public function __construct(
-        public readonly array $counts,
-        public readonly array $criteria,
+        public array $counts,
+        public array $criteria,
     ) {}
 
     /**

--- a/src/Events/Memory/MemoryRead.php
+++ b/src/Events/Memory/MemoryRead.php
@@ -30,7 +30,7 @@ use BuiltByBerry\LaravelSwarm\Memory\DefaultSwarmMemory;
  * the dispatch-layer note on {@see DefaultSwarmMemory}
  * for the rationale.
  */
-final class MemoryRead
+final readonly class MemoryRead
 {
     /**
      * @param  bool  $hit  `true` when the read returned a stored entry, `false`
@@ -41,9 +41,9 @@ final class MemoryRead
      *                     accidental hit.
      */
     public function __construct(
-        public readonly MemoryScope $scope,
-        public readonly string $scopeId,
-        public readonly string $key,
-        public readonly bool $hit = false,
+        public MemoryScope $scope,
+        public string $scopeId,
+        public string $key,
+        public bool $hit = false,
     ) {}
 }

--- a/src/Events/Memory/MemoryRedacted.php
+++ b/src/Events/Memory/MemoryRedacted.php
@@ -25,11 +25,11 @@ use BuiltByBerry\LaravelSwarm\Memory\RedactingMemoryStore;
  * A {@see CaptureDecision::Full} write fires no
  * such event, so the default no-op policy's event stream is unchanged.
  */
-final class MemoryRedacted
+final readonly class MemoryRedacted
 {
     public function __construct(
-        public readonly MemoryScope $scope,
-        public readonly string $scopeId,
-        public readonly string $key,
+        public MemoryScope $scope,
+        public string $scopeId,
+        public string $key,
     ) {}
 }

--- a/src/Events/Memory/MemoryScopeOutOfSnapshot.php
+++ b/src/Events/Memory/MemoryScopeOutOfSnapshot.php
@@ -25,14 +25,14 @@ use BuiltByBerry\LaravelSwarm\Memory\ReplaySwarmMemory;
  * No value payload is exposed — same redaction-safety stance as
  * {@see MemoryRead}.
  */
-final class MemoryScopeOutOfSnapshot
+final readonly class MemoryScopeOutOfSnapshot
 {
     public function __construct(
-        public readonly string $runId,
-        public readonly int $stepIndex,
-        public readonly MemoryScope $scope,
-        public readonly string $scopeId,
-        public readonly string $key,
-        public readonly string $operation,
+        public string $runId,
+        public int $stepIndex,
+        public MemoryScope $scope,
+        public string $scopeId,
+        public string $key,
+        public string $operation,
     ) {}
 }

--- a/src/Events/Memory/MemorySnapshotted.php
+++ b/src/Events/Memory/MemorySnapshotted.php
@@ -32,13 +32,13 @@ namespace BuiltByBerry\LaravelSwarm\Events\Memory;
  *                  at dispatch time. `null` when the driver does not report
  *                  the entry count.
  */
-final class MemorySnapshotted
+final readonly class MemorySnapshotted
 {
     public function __construct(
-        public readonly string $runId,
-        public readonly int $stepIndex,
-        public readonly string $snapshotId,
-        public readonly ?int $bytes = null,
-        public readonly ?int $entryCount = null,
+        public string $runId,
+        public int $stepIndex,
+        public string $snapshotId,
+        public ?int $bytes = null,
+        public ?int $entryCount = null,
     ) {}
 }

--- a/src/Events/Memory/MemoryWriteSkipped.php
+++ b/src/Events/Memory/MemoryWriteSkipped.php
@@ -24,11 +24,11 @@ use BuiltByBerry\LaravelSwarm\Memory\RedactingMemoryStore;
  * leaves any pre-existing entry at the address untouched; it suppresses this
  * write, it does not delete prior state.
  */
-final class MemoryWriteSkipped
+final readonly class MemoryWriteSkipped
 {
     public function __construct(
-        public readonly MemoryScope $scope,
-        public readonly string $scopeId,
-        public readonly string $key,
+        public MemoryScope $scope,
+        public string $scopeId,
+        public string $key,
     ) {}
 }

--- a/src/Events/Memory/MemoryWritten.php
+++ b/src/Events/Memory/MemoryWritten.php
@@ -29,7 +29,7 @@ use BuiltByBerry\LaravelSwarm\Memory\MemoryEntry;
  * the dispatch-layer note on {@see DefaultSwarmMemory}
  * for the rationale.
  */
-final class MemoryWritten
+final readonly class MemoryWritten
 {
     /**
      * @param  array<string, mixed>  $metadata
@@ -44,10 +44,10 @@ final class MemoryWritten
      *                           database row footprint.
      */
     public function __construct(
-        public readonly MemoryScope $scope,
-        public readonly string $scopeId,
-        public readonly string $key,
-        public readonly array $metadata = [],
-        public readonly ?int $bytes = null,
+        public MemoryScope $scope,
+        public string $scopeId,
+        public string $key,
+        public array $metadata = [],
+        public ?int $bytes = null,
     ) {}
 }

--- a/src/Events/SwarmCancelled.php
+++ b/src/Events/SwarmCancelled.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Events;
 
-class SwarmCancelled
+readonly class SwarmCancelled
 {
     /**
      * @param  array<string, mixed>  $metadata
      */
     public function __construct(
-        public readonly string $runId,
-        public readonly string $swarmClass,
-        public readonly string $topology,
-        public readonly array $metadata = [],
-        public readonly ?string $executionMode = null,
+        public string $runId,
+        public string $swarmClass,
+        public string $topology,
+        public array $metadata = [],
+        public ?string $executionMode = null,
     ) {}
 }

--- a/src/Events/SwarmChildCompleted.php
+++ b/src/Events/SwarmChildCompleted.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Events;
 
-class SwarmChildCompleted
+readonly class SwarmChildCompleted
 {
     public function __construct(
-        public readonly string $parentRunId,
-        public readonly string $childRunId,
-        public readonly string $childSwarmClass,
-        public readonly string $executionMode = 'durable',
+        public string $parentRunId,
+        public string $childRunId,
+        public string $childSwarmClass,
+        public string $executionMode = 'durable',
     ) {}
 }

--- a/src/Events/SwarmChildFailed.php
+++ b/src/Events/SwarmChildFailed.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Events;
 
-class SwarmChildFailed
+readonly class SwarmChildFailed
 {
     /**
      * @param  array<string, mixed>|null  $failure
      */
     public function __construct(
-        public readonly string $parentRunId,
-        public readonly string $childRunId,
-        public readonly string $childSwarmClass,
-        public readonly ?array $failure = null,
-        public readonly string $executionMode = 'durable',
+        public string $parentRunId,
+        public string $childRunId,
+        public string $childSwarmClass,
+        public ?array $failure = null,
+        public string $executionMode = 'durable',
     ) {}
 }

--- a/src/Events/SwarmChildStarted.php
+++ b/src/Events/SwarmChildStarted.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Events;
 
-class SwarmChildStarted
+readonly class SwarmChildStarted
 {
     public function __construct(
-        public readonly string $parentRunId,
-        public readonly string $childRunId,
-        public readonly string $childSwarmClass,
-        public readonly string $executionMode = 'durable',
+        public string $parentRunId,
+        public string $childRunId,
+        public string $childSwarmClass,
+        public string $executionMode = 'durable',
     ) {}
 }

--- a/src/Events/SwarmCompleted.php
+++ b/src/Events/SwarmCompleted.php
@@ -6,20 +6,20 @@ namespace BuiltByBerry\LaravelSwarm\Events;
 
 use BuiltByBerry\LaravelSwarm\Responses\SwarmArtifact;
 
-class SwarmCompleted
+readonly class SwarmCompleted
 {
     /**
      * @param  array<string, mixed>  $metadata
      * @param  array<int, SwarmArtifact>  $artifacts
      */
     public function __construct(
-        public readonly string $runId,
-        public readonly string $swarmClass,
-        public readonly string $topology,
-        public readonly ?string $output,
-        public readonly int $durationMs,
-        public readonly array $metadata = [],
-        public readonly array $artifacts = [],
-        public readonly ?string $executionMode = null,
+        public string $runId,
+        public string $swarmClass,
+        public string $topology,
+        public ?string $output,
+        public int $durationMs,
+        public array $metadata = [],
+        public array $artifacts = [],
+        public ?string $executionMode = null,
     ) {}
 }

--- a/src/Events/SwarmPaused.php
+++ b/src/Events/SwarmPaused.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Events;
 
-class SwarmPaused
+readonly class SwarmPaused
 {
     /**
      * @param  array<string, mixed>  $metadata
      */
     public function __construct(
-        public readonly string $runId,
-        public readonly string $swarmClass,
-        public readonly string $topology,
-        public readonly array $metadata = [],
-        public readonly ?string $executionMode = null,
+        public string $runId,
+        public string $swarmClass,
+        public string $topology,
+        public array $metadata = [],
+        public ?string $executionMode = null,
     ) {}
 }

--- a/src/Events/SwarmProgressRecorded.php
+++ b/src/Events/SwarmProgressRecorded.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Events;
 
-class SwarmProgressRecorded
+readonly class SwarmProgressRecorded
 {
     /**
      * @param  array<string, mixed>  $progress
      */
     public function __construct(
-        public readonly string $runId,
-        public readonly ?string $branchId,
-        public readonly array $progress,
-        public readonly string $executionMode = 'durable',
-        public readonly ?string $swarmClass = null,
-        public readonly ?string $topology = null,
+        public string $runId,
+        public ?string $branchId,
+        public array $progress,
+        public string $executionMode = 'durable',
+        public ?string $swarmClass = null,
+        public ?string $topology = null,
     ) {}
 }

--- a/src/Events/SwarmResumed.php
+++ b/src/Events/SwarmResumed.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Events;
 
-class SwarmResumed
+readonly class SwarmResumed
 {
     /**
      * @param  array<string, mixed>  $metadata
      */
     public function __construct(
-        public readonly string $runId,
-        public readonly string $swarmClass,
-        public readonly string $topology,
-        public readonly array $metadata = [],
-        public readonly ?string $executionMode = null,
+        public string $runId,
+        public string $swarmClass,
+        public string $topology,
+        public array $metadata = [],
+        public ?string $executionMode = null,
     ) {}
 }

--- a/src/Events/SwarmSignalled.php
+++ b/src/Events/SwarmSignalled.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Events;
 
-class SwarmSignalled
+readonly class SwarmSignalled
 {
     public function __construct(
-        public readonly string $runId,
-        public readonly string $swarmClass,
-        public readonly string $topology,
-        public readonly string $signalName,
-        public readonly bool $accepted,
-        public readonly string $executionMode = 'durable',
+        public string $runId,
+        public string $swarmClass,
+        public string $topology,
+        public string $signalName,
+        public bool $accepted,
+        public string $executionMode = 'durable',
     ) {}
 }

--- a/src/Events/SwarmStarted.php
+++ b/src/Events/SwarmStarted.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Events;
 
-class SwarmStarted
+readonly class SwarmStarted
 {
     /**
      * @param  array<string, mixed>  $metadata
      */
     public function __construct(
-        public readonly string $runId,
-        public readonly string $swarmClass,
-        public readonly string $topology,
-        public readonly ?string $input,
-        public readonly array $metadata = [],
-        public readonly ?string $executionMode = null,
+        public string $runId,
+        public string $swarmClass,
+        public string $topology,
+        public ?string $input,
+        public array $metadata = [],
+        public ?string $executionMode = null,
     ) {}
 }

--- a/src/Events/SwarmStepCompleted.php
+++ b/src/Events/SwarmStepCompleted.php
@@ -6,23 +6,23 @@ namespace BuiltByBerry\LaravelSwarm\Events;
 
 use BuiltByBerry\LaravelSwarm\Responses\SwarmArtifact;
 
-class SwarmStepCompleted
+readonly class SwarmStepCompleted
 {
     /**
      * @param  array<string, mixed>  $metadata
      * @param  array<int, SwarmArtifact>  $artifacts
      */
     public function __construct(
-        public readonly string $runId,
-        public readonly string $swarmClass,
-        public readonly string $topology,
-        public readonly int $index,
-        public readonly string $agentClass,
-        public readonly ?string $input,
-        public readonly ?string $output,
-        public readonly int $durationMs,
-        public readonly array $metadata = [],
-        public readonly array $artifacts = [],
-        public readonly ?string $executionMode = null,
+        public string $runId,
+        public string $swarmClass,
+        public string $topology,
+        public int $index,
+        public string $agentClass,
+        public ?string $input,
+        public ?string $output,
+        public int $durationMs,
+        public array $metadata = [],
+        public array $artifacts = [],
+        public ?string $executionMode = null,
     ) {}
 }

--- a/src/Events/SwarmStepStarted.php
+++ b/src/Events/SwarmStepStarted.php
@@ -4,19 +4,19 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Events;
 
-class SwarmStepStarted
+readonly class SwarmStepStarted
 {
     /**
      * @param  array<string, mixed>  $metadata
      */
     public function __construct(
-        public readonly string $runId,
-        public readonly string $swarmClass,
-        public readonly int $index,
-        public readonly string $agentClass,
-        public readonly ?string $input,
-        public readonly array $metadata = [],
-        public readonly ?string $topology = null,
-        public readonly ?string $executionMode = null,
+        public string $runId,
+        public string $swarmClass,
+        public int $index,
+        public string $agentClass,
+        public ?string $input,
+        public array $metadata = [],
+        public ?string $topology = null,
+        public ?string $executionMode = null,
     ) {}
 }

--- a/src/Events/SwarmWaitTimedOut.php
+++ b/src/Events/SwarmWaitTimedOut.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Events;
 
-class SwarmWaitTimedOut
+readonly class SwarmWaitTimedOut
 {
     public function __construct(
-        public readonly string $runId,
-        public readonly string $swarmClass,
-        public readonly string $topology,
-        public readonly string $waitName,
-        public readonly string $executionMode = 'durable',
+        public string $runId,
+        public string $swarmClass,
+        public string $topology,
+        public string $waitName,
+        public string $executionMode = 'durable',
     ) {}
 }

--- a/src/Events/SwarmWaiting.php
+++ b/src/Events/SwarmWaiting.php
@@ -4,18 +4,18 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Events;
 
-class SwarmWaiting
+readonly class SwarmWaiting
 {
     /**
      * @param  array<string, mixed>  $metadata
      */
     public function __construct(
-        public readonly string $runId,
-        public readonly string $swarmClass,
-        public readonly string $topology,
-        public readonly string $waitName,
-        public readonly ?string $reason = null,
-        public readonly array $metadata = [],
-        public readonly string $executionMode = 'durable',
+        public string $runId,
+        public string $swarmClass,
+        public string $topology,
+        public string $waitName,
+        public ?string $reason = null,
+        public array $metadata = [],
+        public string $executionMode = 'durable',
     ) {}
 }

--- a/src/Responses/DurableCancelResult.php
+++ b/src/Responses/DurableCancelResult.php
@@ -14,14 +14,14 @@ use BuiltByBerry\LaravelSwarm\Enums\DurableLifecycleStatus;
  * definite SCHEDULED transition, not a no-op. The {@see $status} field reports
  * which of the two happened so callers never have to guess.
  */
-class DurableCancelResult
+readonly class DurableCancelResult
 {
     public function __construct(
-        public readonly string $runId,
-        public readonly string $swarmClass,
-        public readonly string $topology,
+        public string $runId,
+        public string $swarmClass,
+        public string $topology,
         /** Either DurableLifecycleStatus::Cancelled (applied now) or ::CancelScheduled (will cancel at the next boundary). */
-        public readonly DurableLifecycleStatus $status,
+        public DurableLifecycleStatus $status,
     ) {}
 
     /**

--- a/src/Responses/DurableChildRun.php
+++ b/src/Responses/DurableChildRun.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Responses;
 
-class DurableChildRun
+readonly class DurableChildRun
 {
     public function __construct(
-        public readonly string $parentRunId,
-        public readonly string $childRunId,
-        public readonly string $childSwarmClass,
-        public readonly string $status,
+        public string $parentRunId,
+        public string $childRunId,
+        public string $childSwarmClass,
+        public string $status,
     ) {}
 }

--- a/src/Responses/DurablePauseResult.php
+++ b/src/Responses/DurablePauseResult.php
@@ -14,14 +14,14 @@ use BuiltByBerry\LaravelSwarm\Enums\DurableLifecycleStatus;
  * definite SCHEDULED transition, not a no-op. The {@see $status} field reports
  * which of the two happened so callers never have to guess.
  */
-class DurablePauseResult
+readonly class DurablePauseResult
 {
     public function __construct(
-        public readonly string $runId,
-        public readonly string $swarmClass,
-        public readonly string $topology,
+        public string $runId,
+        public string $swarmClass,
+        public string $topology,
         /** Either DurableLifecycleStatus::Paused (applied now) or ::PauseScheduled (will pause at the next boundary). */
-        public readonly DurableLifecycleStatus $status,
+        public DurableLifecycleStatus $status,
     ) {}
 
     /**

--- a/src/Responses/DurableResumeResult.php
+++ b/src/Responses/DurableResumeResult.php
@@ -15,16 +15,16 @@ use BuiltByBerry\LaravelSwarm\Enums\DurableLifecycleStatus;
  * the run resumed into, and {@see $waitingBoundaryDispatched} reports whether a
  * waiting boundary was re-dispatched, so callers never have to guess.
  */
-class DurableResumeResult
+readonly class DurableResumeResult
 {
     public function __construct(
-        public readonly string $runId,
-        public readonly string $swarmClass,
-        public readonly string $topology,
+        public string $runId,
+        public string $swarmClass,
+        public string $topology,
         /** Either DurableLifecycleStatus::Resumed (a step was re-dispatched) or ::Waiting (resumed back into a waiting boundary). */
-        public readonly DurableLifecycleStatus $status,
+        public DurableLifecycleStatus $status,
         /** True when resuming re-dispatched a waiting boundary rather than a step. */
-        public readonly bool $waitingBoundaryDispatched = false,
+        public bool $waitingBoundaryDispatched = false,
     ) {}
 
     /**

--- a/src/Responses/DurableRetryPolicy.php
+++ b/src/Responses/DurableRetryPolicy.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Responses;
 
-class DurableRetryPolicy
+readonly class DurableRetryPolicy
 {
     /**
      * @param  array<int, int>  $backoffSeconds
      * @param  array<int, string>  $nonRetryable
      */
     public function __construct(
-        public readonly int $maxAttempts = 1,
-        public readonly array $backoffSeconds = [],
-        public readonly array $nonRetryable = [],
+        public int $maxAttempts = 1,
+        public array $backoffSeconds = [],
+        public array $nonRetryable = [],
     ) {}
 
     /**

--- a/src/Responses/DurableRunDetail.php
+++ b/src/Responses/DurableRunDetail.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Responses;
 
-class DurableRunDetail
+readonly class DurableRunDetail
 {
     /**
      * @param  array<string, mixed>|null  $run
@@ -19,17 +19,17 @@ class DurableRunDetail
      * @param  array<int, array<string, mixed>>  $hierarchicalNodeOutputs
      */
     public function __construct(
-        public readonly string $runId,
-        public readonly ?array $run,
-        public readonly ?array $history = null,
-        public readonly array $labels = [],
-        public readonly array $details = [],
-        public readonly array $waits = [],
-        public readonly array $signals = [],
-        public readonly array $progress = [],
-        public readonly array $children = [],
-        public readonly array $branches = [],
-        public readonly array $hierarchicalNodeOutputs = [],
+        public string $runId,
+        public ?array $run,
+        public ?array $history = null,
+        public array $labels = [],
+        public array $details = [],
+        public array $waits = [],
+        public array $signals = [],
+        public array $progress = [],
+        public array $children = [],
+        public array $branches = [],
+        public array $hierarchicalNodeOutputs = [],
     ) {}
 
     /**

--- a/src/Responses/DurableSignalResult.php
+++ b/src/Responses/DurableSignalResult.php
@@ -4,18 +4,18 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Responses;
 
-class DurableSignalResult
+readonly class DurableSignalResult
 {
     /**
      * @param  array<string, mixed>|null  $signal
      */
     public function __construct(
-        public readonly string $runId,
-        public readonly string $name,
-        public readonly string $status,
-        public readonly bool $accepted,
-        public readonly bool $duplicate = false,
-        public readonly ?array $signal = null,
-        public readonly ?string $swarmClass = null,
+        public string $runId,
+        public string $name,
+        public string $status,
+        public bool $accepted,
+        public bool $duplicate = false,
+        public ?array $signal = null,
+        public ?string $swarmClass = null,
     ) {}
 }

--- a/src/Responses/DurableWaitOutcome.php
+++ b/src/Responses/DurableWaitOutcome.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Responses;
 
-class DurableWaitOutcome
+readonly class DurableWaitOutcome
 {
     public function __construct(
-        public readonly string $name,
-        public readonly string $status,
-        public readonly mixed $payload = null,
-        public readonly bool $timedOut = false,
+        public string $name,
+        public string $status,
+        public mixed $payload = null,
+        public bool $timedOut = false,
     ) {}
 }

--- a/src/Responses/StreamedSwarmResponse.php
+++ b/src/Responses/StreamedSwarmResponse.php
@@ -10,14 +10,14 @@ use BuiltByBerry\LaravelSwarm\Streaming\Events\SwarmStreamEvent;
 use BuiltByBerry\LaravelSwarm\Streaming\Events\SwarmTextDelta;
 use Illuminate\Support\Collection;
 
-class StreamedSwarmResponse extends SwarmResponse
+readonly class StreamedSwarmResponse extends SwarmResponse
 {
     /**
      * @param  Collection<int, SwarmStreamEvent>  $events
      */
     public function __construct(
         SwarmResponse $response,
-        public readonly Collection $events,
+        public Collection $events,
     ) {
         parent::__construct(
             output: $response->output,

--- a/src/Responses/SwarmArtifact.php
+++ b/src/Responses/SwarmArtifact.php
@@ -10,16 +10,16 @@ use JsonSerializable;
 /**
  * @implements Arrayable<string, mixed>
  */
-class SwarmArtifact implements Arrayable, JsonSerializable
+readonly class SwarmArtifact implements Arrayable, JsonSerializable
 {
     /**
      * @param  array<string, mixed>  $metadata
      */
     public function __construct(
-        public readonly string $name,
-        public readonly mixed $content,
-        public readonly array $metadata = [],
-        public readonly ?string $stepAgentClass = null,
+        public string $name,
+        public mixed $content,
+        public array $metadata = [],
+        public ?string $stepAgentClass = null,
     ) {}
 
     /**

--- a/src/Responses/SwarmResponse.php
+++ b/src/Responses/SwarmResponse.php
@@ -11,7 +11,7 @@ use JsonSerializable;
 /**
  * @implements Arrayable<string, mixed>
  */
-class SwarmResponse implements Arrayable, JsonSerializable
+readonly class SwarmResponse implements Arrayable, JsonSerializable
 {
     /**
      * @param  array<int, SwarmStep>  $steps
@@ -20,12 +20,12 @@ class SwarmResponse implements Arrayable, JsonSerializable
      * @param  array<string, mixed>  $metadata
      */
     public function __construct(
-        public readonly string $output,
-        public readonly array $steps = [],
-        public readonly array $usage = [],
-        public readonly ?RunContext $context = null,
-        public readonly array $artifacts = [],
-        public readonly array $metadata = [],
+        public string $output,
+        public array $steps = [],
+        public array $usage = [],
+        public ?RunContext $context = null,
+        public array $artifacts = [],
+        public array $metadata = [],
     ) {}
 
     /**

--- a/src/Support/BranchWaitPayload.php
+++ b/src/Support/BranchWaitPayload.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Support;
 
-final class BranchWaitPayload
+final readonly class BranchWaitPayload
 {
     /**
      * @param  array<string, mixed>  $routeCursor  Durable cursor shape: {entries, offset, current_node_id, ...}
@@ -12,14 +12,14 @@ final class BranchWaitPayload
      * @param  array<int, array<string, mixed>>  $branches  Branch definitions to create
      */
     public function __construct(
-        public readonly string $executionToken,
-        public readonly int $nextStepIndex,
-        public readonly string $parentNodeId,
-        public readonly RunContext $context,
-        public readonly int $ttlSeconds,
-        public readonly array $routeCursor = [],
-        public readonly ?array $routePlan = null,
-        public readonly ?int $totalSteps = null,
-        public readonly array $branches = [],
+        public string $executionToken,
+        public int $nextStepIndex,
+        public string $parentNodeId,
+        public RunContext $context,
+        public int $ttlSeconds,
+        public array $routeCursor = [],
+        public ?array $routePlan = null,
+        public ?int $totalSteps = null,
+        public array $branches = [],
     ) {}
 }

--- a/src/Support/PayloadLimitResult.php
+++ b/src/Support/PayloadLimitResult.php
@@ -7,13 +7,13 @@ namespace BuiltByBerry\LaravelSwarm\Support;
 /**
  * @internal
  */
-final class PayloadLimitResult
+final readonly class PayloadLimitResult
 {
     /**
      * @param  array<string, mixed>  $metadata
      */
     public function __construct(
-        public readonly string $value,
-        public readonly array $metadata = [],
+        public string $value,
+        public array $metadata = [],
     ) {}
 }

--- a/src/Support/QueuedRunAcquisition.php
+++ b/src/Support/QueuedRunAcquisition.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Support;
 
-final class QueuedRunAcquisition
+final readonly class QueuedRunAcquisition
 {
     private function __construct(
-        public readonly string $outcome,
-        public readonly ?string $executionToken = null,
+        public string $outcome,
+        public ?string $executionToken = null,
     ) {}
 
     public static function fresh(string $executionToken): self

--- a/src/Support/SwarmExecutionState.php
+++ b/src/Support/SwarmExecutionState.php
@@ -16,27 +16,27 @@ use Illuminate\Contracts\Events\Dispatcher;
 /**
  * @internal
  */
-class SwarmExecutionState
+readonly class SwarmExecutionState
 {
     public function __construct(
-        public readonly Swarm $swarm,
-        public readonly Topology $topology,
-        public readonly ExecutionMode $executionMode,
-        public readonly float $deadlineMonotonic,
-        public readonly int $maxAgentExecutions,
-        public readonly int $ttlSeconds,
-        public readonly ?int $leaseSeconds,
-        public readonly ?string $executionToken,
-        public readonly ?Closure $verifyOwnership,
-        public readonly RunContext $context,
-        public readonly ContextStore $contextStore,
-        public readonly ArtifactRepository $artifactRepository,
-        public readonly RunHistoryStore $historyStore,
-        public readonly Dispatcher $events,
+        public Swarm $swarm,
+        public Topology $topology,
+        public ExecutionMode $executionMode,
+        public float $deadlineMonotonic,
+        public int $maxAgentExecutions,
+        public int $ttlSeconds,
+        public ?int $leaseSeconds,
+        public ?string $executionToken,
+        public ?Closure $verifyOwnership,
+        public RunContext $context,
+        public ContextStore $contextStore,
+        public ArtifactRepository $artifactRepository,
+        public RunHistoryStore $historyStore,
+        public Dispatcher $events,
         /**
          * When set to `multi_worker` for hierarchical `queue()`, parallel route nodes use
          * coordinated branch jobs instead of in-process execution.
          */
-        public readonly ?string $queueHierarchicalParallelCoordination = null,
+        public ?string $queueHierarchicalParallelCoordination = null,
     ) {}
 }


### PR DESCRIPTION
Resolves #432. 39 event and DTO classes across `src/Events`, `src/Responses` and `src/Support` declared every constructor-promoted property `readonly` individually; they now carry the modifier on the class. Immutability is stated once and cannot be silently forgotten when a property is added later. 13 sibling files already used this shape.

**No behaviour or constructor signatures changed.**

## Candidate selection was done by reflection, not by reading

The plan said "~25 classes, exclude 1". The reality is **44 candidates, 5 excluded** — its exclusion list was 1 of 6, and each miss would have been a fatal error rather than a style regression:

| Excluded | Why |
| --- | --- |
| `DurableSwarmResponse` | mutable `$dispatchable`, `$manager`; reassigns — *the only one the plan named* |
| `SwarmFailed` | assigns `$this->exceptionClass` |
| `QueuedSwarmResponse` | mutable `$dispatchable`; reassigns |
| `ActiveRunRecord` | mutable `$memoryOverride` |
| `StreamableSwarmResponse` | **15 mutable properties, 8 reassignment sites** — a streaming state machine, not a value object |

## The inheritance trap

PHP allows a `readonly class` to be extended **only** by readonly classes. `StreamedSwarmResponse extends SwarmResponse`, and `SwarmResponse` is a candidate — so promoting the parent alone would have made the child illegal. Both move together here. It is the only inheritance pair among the candidates, and the only subclass of `SwarmResponse` anywhere in `src/`.

## Serialization

Not a concern, checked rather than assumed: none of these classes carry `SerializesModels` or `ShouldQueue`, and PHP's unserializer treats property writes as initialization — so a consumer's queued listener receiving one of these events is unaffected.

## Verification

Pint clean · PHPStan L7 no errors · **1988 passed** (7960 assertions). Diff confirmed to contain only two transformations: the class declaration, and `readonly` dropping off promoted properties. The 5 excluded files are untouched.

Closes #432