### PR TITLE
release: v0.24.0 — Durable-execution correctness and documentation integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,10 @@
 ## v0.24.0 - unreleased
 
 Durable-execution correctness and documentation integrity, carrying the work
-deferred from v0.23.0: the child-swarm dispatch race and the operational-input
-question underneath it, encrypt-at-rest coverage for the JSON payload columns,
-overlap protection for the two commands the package tells you to schedule, a
-`laravel/ai` compatibility policy with a nightly `0.x-dev` lane, CI merge gates,
-and PR-time validation of the package's own documentation references.
+deferred from v0.23.0: the child-swarm dispatch race, overlap protection for the
+two commands the package tells you to schedule, a `laravel/ai` compatibility
+policy with a nightly `0.x-dev` lane, CI merge gates, and PR-time validation of
+the package's own documentation references.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,52 @@ the package's own documentation references.
 
 ### Added
 
-_To be filled in during release wrap-up._
+- **The package's documentation references are now validated on every pull
+  request.** Nothing checked them before: `src/` carries ~600 `{@see}`
+  references plus file paths, Artisan command names and stated requirements
+  quoted in prose, and PHPStan has no phpdoc reference rules. v0.23.0 showed the
+  cost — `AGENTS.md` pointed every agent at a review skill that is not
+  installed, listed 8 of the package's 29 Artisan commands, and carried stale
+  dependency pins. All mechanically checkable; none checked.
+
+  `tests/Unit/DocumentationReferenceTest.php` asserts four things: every
+  `{@see}` in `src/` resolves to a real type, member, constant or function;
+  every repository path named in a source comment or a relative markdown link
+  exists; every documented `php artisan` command in this package's own
+  namespaces is registered by it; and the README's stated requirements agree
+  with `composer.json`. Failures name each offender with its file and line — a
+  corpus-total assertion is insufficient, as a `>= 11` floor in this repo once
+  demonstrated by passing while every generator stub beneath it was broken.
+
+  **Scope is referential only, by design.** These checks answer "does the thing
+  this sentence points at exist" and nothing more. They cannot catch a semantic
+  claim that was false when written, which was the other half of the v0.23.0
+  defects. A green run means the references resolve, not that the documentation
+  is true — the test says so in its own docblock, so the next reader does not
+  assume broader coverage.
+
+  Each check is narrow on purpose, because an over-eager reference check
+  produces false positives, gets suppressed, and then reports green while
+  testing nothing. Facade members, global functions, unimported package types
+  and uninstalled optional dependencies all resolve rather than failing;
+  `config/*.php` paths are excluded because every one named in prose except
+  `config/swarm.php` belongs to the consuming application; and the requirements
+  check reads only the README's `## Requirements` block, so prose that
+  legitimately cites an older version — "the MCP tools added in `laravel/ai`
+  0.8" — is not mistaken for a stale pin. Each check was verified to fail
+  against a deliberately broken reference of its own kind.
 
 ### Changed
 
-_To be filled in during release wrap-up._
+- **Five dead `{@see}` references in `src/` corrected**, all found by the new
+  check on its first run. `DatabaseDurableRunStore` pointed at
+  `openForDisplay()` twice as though it owned the method (it is on
+  `SwarmPersistenceCipher`) and at `openChildContextForDisplay()`, which exists
+  nowhere — the real helper is `openContextTopLevelInputForDisplay()`.
+  `StreamStepAccumulator` pointed at `SequentialRunner::mapStreamEvent()`, a
+  method that no longer exists; the mapping lives in `StreamEventMapper::map()`.
+  `PhpStanTypeAliases` used `{@see}` for `@phpstan-import-type`, which is an
+  annotation rather than a symbol. No behaviour changes.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,46 @@ the package's own documentation references.
 
 ### Fixed
 
+- **Console commands no longer hang forever on a stdin that cannot answer.** A
+  command that prompts with no terminal behind it did not fail — it blocked
+  indefinitely, which in CI or a test lane reads as a stuck runner rather than a
+  failure. Diagnosed by sampling a hung process: 2266 of 2313 samples sat inside
+  `stream_select()`, in Symfony's `TerminalInputHelper::waitForInput()`.
+
+  What blocks is narrower than "stdin is not a terminal". The busy-wait is keyed
+  on the *identity of the stream*: `QuestionHelper` reads
+  `$input->getStream() ?? \STDIN`, and `TerminalInputHelper` only spins when
+  that stream's uri is `php://stdin`. So every prompting command now detaches an
+  unanswerable stdin in `initialize()` — if the input has no stream of its own
+  and this process has no terminal, it is given an empty in-memory stream. The
+  busy-wait becomes unreachable, the question reads EOF, and the prompt returns
+  its own declared default, or aborts loudly where an argument is required.
+
+  This changes only what a prompt READS FROM, never whether it is asked, so
+  behaviour on a non-terminal run is unchanged: `laravel/prompts` already
+  returned its declared default there, and every command still reaches the same
+  branch it reached before. An operator at a real terminal is unaffected —
+  the hook does not fire when stdin is a TTY.
+
+  Covers all four generators (`make:swarm`, `make:swarm:swarm`,
+  `make:swarm:agent`, `make:memory-tool`) including the framework's inherited
+  prompt for a missing argument, which fires before `handle()` runs, plus
+  `make:swarm:blueprint`, `swarm:audit:reconcile` and the five
+  `swarm:install:*` sub-installers.
+
+  Note the condition arming the blocking fallback is
+  `windows_os() || $app->runningUnitTests()`, and `runningUnitTests()` is
+  `$app['env'] === 'testing'` — a shipped configuration value, not "PHPUnit is
+  running". An application deployed with `APP_ENV=testing` arms it in
+  production, so this was never a test-only concern.
+
+  **One behaviour change, and it is a regression:** a piped answer is no longer
+  read. `echo yes | php artisan swarm:audit:reconcile --dismiss=42` previously
+  confirmed and now declines. Nothing can distinguish a pipe that will deliver a
+  line from one that never will — the read blocks either way — so the choice is
+  between losing piped answers and hanging indefinitely. See `UPGRADING.md`;
+  `--force` is the replacement.
+
 - **Race-safe child-swarm dispatch: the dispatch marker is now an expiring lease,
   and the claim — not the error classifier — decides who dispatches.** A durable
   child could be dispatched twice, and the loser would bury the winner. More than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,64 @@ _To be filled in during release wrap-up._
 
 _To be filled in during release wrap-up._
 
+### Fixed
+
+- **Race-safe child-swarm dispatch: the dispatch marker is now an expiring lease,
+  and the claim — not the error classifier — decides who dispatches.** A durable
+  child could be dispatched twice, and the loser would bury the winner. More than
+  one worker can reach a child's dispatch: `swarm:recover` sweeps children the
+  parent may be inline-dispatching at that instant, and the `withoutOverlapping()`
+  the installer scaffolds is per-host, so it serialises neither a sweep against an
+  inline dispatch nor two sweeps on different hosts. Both saw `find() === null`,
+  both called `dispatchDurable()`, and the loser caught the unique-key
+  `QueryException` and wrote `failed` over the **winner's live child**, releasing
+  the parent's wait with `child_failed` while that child executed normally — so
+  under a fail-run policy the parent failed while its child was running. No
+  infrastructure fault was required. `SwarmChildStarted` also fired
+  unconditionally, so a re-dispatched intent emitted it twice.
+
+  `markChildRunDispatched()` now returns whether the caller won the conditional
+  claim (which is also guarded on status, so a child that already reached a
+  terminal state cannot be claimed and dispatched), and only that winner dispatches or emits `SwarmChildStarted` — a
+  duplicate `start()` is unreachable rather than something to recognise from a
+  driver-specific SQLSTATE after the fact. Every exit that does not leave a run
+  dispatched hands the claim back through the new
+  `DurableRunStore::releaseChildRunDispatch()`.
+
+  The claim does **not** expire, and one narrow strand is knowingly left open: a
+  worker killed uncatchably between claiming a child and committing its run —
+  SIGKILL on deploy, `queue:work --timeout`, OOM, eviction — leaves a claim
+  nobody hands back, and that child is not re-dispatched. Re-dispatching it would
+  mean a recovery sweep building the child's input from the stored
+  `context_payload`, which is the capture/evidence view and is `[redacted]`
+  whenever `swarm.capture.inputs` is `false` (the default) — so the sweep would
+  run the child on the literal sentinel and return a confident wrong answer
+  instead of failing. Closing the strand therefore waits on separating a child's
+  operational input from its evidence view; `UPGRADING.md` documents the window,
+  how narrow it is, and how to recover a parent stuck behind it.
+
+  `updateChildRun()` now returns whether it wrote and accepts an optional
+  expected-status set; the failure path uses it so a child that finished under
+  another worker is not overwritten with `failed`, and the parent is reconciled
+  only when this worker actually owns the terminal write. A dispatch that fails
+  *after* `start()` committed the child's run — reachable because the queue write
+  happens at `PendingDispatch` destruct — no longer marks that child failed
+  either; it is left to `recoverable()`, which is the same reasoning the run-row
+  gate applies. Both of those, and a claim that cannot be handed back, are now
+  logged rather than silently swallowed.
+
+  Covered by regression tests that fail without the fix, plus a
+  `tests/ProcessConcurrency` lane racing four real OS processes for one child's
+  claim.
+
+  Dispatch failures otherwise stay **terminal** for now: the retry path is gated
+  on separating a child's operational input from the capture/evidence view,
+  because a swept retry re-reads a `[redacted]` input under
+  `swarm.capture.inputs=false` and would run the child on the literal sentinel.
+
+  `DurableRunStore` is an internal contract, but implementors outside this package
+  must update four signatures — see `UPGRADING.md`.
+
 ## v0.23.0 - 2026-07-20
 
 Compatibility and correctness: `laravel/ai` agents drop in unchanged, plus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.24.0 - unreleased
+## v0.25.0 - unreleased
 
 Durable-execution correctness and documentation integrity, carrying the work
 deferred from v0.23.0: the child-swarm dispatch race, overlap protection for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## v0.24.0 - unreleased
 
-Documentation integrity: make the package's own claims verifiable. Seeded from
-v0.23.0, where five docblock and guidance defects surfaced in a single session —
-four semantic claims that were false when written, and one class of referential
-drift (a dead skill pointer, a command list covering 8 of 24 commands, stale
-pinned versions).
+Durable-execution correctness and documentation integrity, carrying the work
+deferred from v0.23.0: the child-swarm dispatch race and the operational-input
+question underneath it, encrypt-at-rest coverage for the JSON payload columns,
+overlap protection for the two commands the package tells you to schedule, a
+`laravel/ai` compatibility policy with a nightly `0.x-dev` lane, CI merge gates,
+and PR-time validation of the package's own documentation references.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.24.0 - unreleased
+
+Documentation integrity: make the package's own claims verifiable. Seeded from
+v0.23.0, where five docblock and guidance defects surfaced in a single session —
+four semantic claims that were false when written, and one class of referential
+drift (a dead skill pointer, a command list covering 8 of 24 commands, stale
+pinned versions).
+
+### Added
+
+_To be filled in during release wrap-up._
+
+### Changed
+
+_To be filled in during release wrap-up._
+
 ## v0.23.0 - 2026-07-20
 
 Compatibility and correctness: `laravel/ai` agents drop in unchanged, plus

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -269,9 +269,11 @@ stability settings to install Swarm — see
 
 ## Upgrading to v0.24.0
 
-v0.24.0 has **no migrations** and adds no configuration keys. One change may
-require attention from maintainers who implement `DurableRunStore` themselves,
-and one known limitation is worth reading if you use durable child swarms.
+v0.24.0 has **no migrations** and adds no configuration keys. Two changes may
+require attention: an interface change for maintainers who implement
+`DurableRunStore` themselves, and a console-prompt behaviour change for anyone
+piping answers into Artisan commands. One known limitation is also worth reading
+if you use durable child swarms.
 
 ### `DurableRunStore` interface: child-dispatch claim signatures changed (#431)
 
@@ -355,6 +357,34 @@ public function releaseChildRunDispatch(string $childRunId, DateTimeInterface $d
 is non-empty and return whether a row was written; `undispatchedChildRuns()`
 must select only children that are pending **and** unclaimed. A claim is never
 reclaimed on age — see the limitation below.
+
+### Piped answers to console prompts are no longer read
+
+Commands that prompt now detach stdin when this process has no terminal, so a
+prompt cannot block forever on a stream that will never become readable (#449).
+
+The side effect is that a piped answer is no longer consumed:
+
+```bash
+# Previously confirmed the action. Now declines and exits non-zero.
+echo yes | php artisan swarm:audit:reconcile --dismiss=42 --reason="stale"
+```
+
+**Action:** pass the command's own non-interactive flag instead. For
+`swarm:audit:reconcile` that is `--force`:
+
+```bash
+php artisan swarm:audit:reconcile --dismiss=42 --reason="stale" --force
+```
+
+**Why it cannot be avoided.** Nothing can distinguish a pipe that will deliver a
+line from one that never will — the read blocks either way, and a command that
+blocks forever is worse than one that declines. An operator at a real terminal
+is unaffected; the detach only happens when stdin is not a TTY.
+
+**Not affected:** interactive terminal use, `--no-interaction` (which
+short-circuits before any stream is read), and anything already passing explicit
+flags.
 
 ### Known limitation: a child stranded by an uncatchable worker death
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -267,6 +267,125 @@ with `"prefer-stable": true`. Your application needs no special Composer
 stability settings to install Swarm — see
 [Composer minimum-stability](#composer-minimum-stability).
 
+## Upgrading to v0.24.0
+
+v0.24.0 has **no migrations** and adds no configuration keys. One change may
+require attention from maintainers who implement `DurableRunStore` themselves,
+and one known limitation is worth reading if you use durable child swarms.
+
+### `DurableRunStore` interface: child-dispatch claim signatures changed (#431)
+
+The child-swarm dispatch marker became a **lease** rather than a one-way
+marker, so three methods changed shape and one is new:
+
+```php
+public function markChildRunDispatched(
+    string $childRunId,
+    ?DateTimeInterface $dispatchedAt = null,
+): bool;                                    // was: (string $childRunId): void
+
+public function releaseChildRunDispatch(
+    string $childRunId,
+    DateTimeInterface $dispatchedAt,
+): bool;                                    // new
+
+public function updateChildRun(
+    string $childRunId,
+    string $status,
+    ?string $output = null,
+    ?array $failure = null,
+    array $fromStatuses = [],
+): bool;                                    // was: (...): void
+
+public function undispatchedChildRuns(
+    ?string $runId = null,
+    ?string $swarmClass = null,
+    int $limit = 50,
+): array;                                   // unchanged signature, tighter contract
+```
+
+**Who is affected:** applications that implement `DurableRunStore` directly with
+a custom store class, and anything extending `DatabaseDurableRunStore` and
+overriding these four methods. PHP raises a fatal declaration-compatibility
+error at class load, so this fails immediately and visibly rather than silently.
+
+**Who is not affected:** applications that only *call* the store (via
+`app(DurableRunStore::class)->...`), use the default database driver, or reach
+the store through `DurableSwarmManager`. No application-level call site changes:
+the added parameters are optional and the `void → bool` returns are additive for
+callers that ignored them.
+
+**Action required:** custom stores must adopt the three changed signatures
+above. `undispatchedChildRuns()` keeps its signature but its contract tightens:
+it must select only pending, unclaimed children. The
+returns are load-bearing, so a stub that always reports success is wrong —
+`markChildRunDispatched()` must return `true` only for the caller that actually
+took the claim, or two workers will dispatch the same child. A minimal correct
+implementation mirrors the shipped one:
+
+```php
+public function markChildRunDispatched(
+    string $childRunId,
+    ?DateTimeInterface $dispatchedAt = null,
+): bool {
+    $timestamp = $dispatchedAt !== null
+        ? Carbon::instance($dispatchedAt)->utc()
+        : Carbon::now('UTC');
+
+    // One conditional UPDATE, so concurrent workers race a single row and
+    // exactly one wins. Returning true unconditionally would let two workers
+    // dispatch the same child.
+    return $this->childRunTable()
+        ->where('child_run_id', $childRunId)
+        ->whereIn('status', ['pending', 'running'])
+        ->whereNull('dispatched_at')
+        ->update(['dispatched_at' => $timestamp, 'updated_at' => $timestamp]) === 1;
+}
+
+public function releaseChildRunDispatch(string $childRunId, DateTimeInterface $dispatchedAt): bool
+{
+    return $this->childRunTable()
+        ->where('child_run_id', $childRunId)
+        ->where('dispatched_at', Carbon::instance($dispatchedAt)->utc())
+        ->update(['dispatched_at' => null, 'updated_at' => Carbon::now('UTC')]) === 1;
+}
+```
+
+`updateChildRun()` must apply `whereIn('status', $fromStatuses)` when the array
+is non-empty and return whether a row was written; `undispatchedChildRuns()`
+must select only children that are pending **and** unclaimed. A claim is never
+reclaimed on age — see the limitation below.
+
+### Known limitation: a child stranded by an uncatchable worker death
+
+Dispatching a child stamps a claim on its intent row so exactly one worker
+dispatches it. Every exit that does not leave a run dispatched hands that claim
+back — but a `catch` block cannot cover an uncatchable death. A worker SIGKILLed
+on deploy, reaped by `queue:work --timeout`, OOM-killed or evicted **between
+claiming the child and committing its run** leaves a claim nobody hands back, and
+that child is not re-dispatched: its parent waits on it indefinitely.
+
+**How narrow this is:** the window spans container resolution, input validation
+and input guardrails — ordinarily milliseconds — and closes as soon as the
+child's run row is committed. It requires an uncatchable kill inside that window
+specifically. A worker that throws, times out at the PHP level, or fails
+validation releases its claim normally.
+
+**Why it is not fixed here.** Re-dispatching a stranded child means a recovery
+sweep must dispatch it, and the sweep can only build the child's input from the
+stored `context_payload` — which is the capture/evidence view and is the literal
+string `[redacted]` whenever `swarm.capture.inputs` is `false` (the default). A
+sweep that re-dispatched today would run the child on that sentinel and return a
+confidently wrong answer instead of failing. Fixing the strand therefore requires
+separating a child's operational input from its evidence view, which is tracked
+separately.
+
+**What to do:** nothing is required. If a parent run is waiting on a child that
+never started, `php artisan swarm:inspect <run-id>` shows the child intent as
+`pending` with a stamped dispatch claim and no corresponding run; cancel the
+parent with `php artisan swarm:cancel <run-id>` and re-dispatch it. Keeping
+`swarm.capture.inputs` enabled does not currently change this behaviour.
+
 ## Upgrading to v0.23.0
 
 **Plain `laravel/ai` agents now work with Swarm unchanged.** Swarm type-hints

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -267,9 +267,9 @@ with `"prefer-stable": true`. Your application needs no special Composer
 stability settings to install Swarm — see
 [Composer minimum-stability](#composer-minimum-stability).
 
-## Upgrading to v0.24.0
+## Upgrading to v0.25.0
 
-v0.24.0 has **no migrations** and adds no configuration keys. Two changes may
+v0.25.0 has **no migrations** and adds no configuration keys. Two changes may
 require attention: an interface change for maintainers who implement
 `DurableRunStore` themselves, and a console-prompt behaviour change for anyone
 piping answers into Artisan commands. One known limitation is also worth reading

--- a/docs/events.md
+++ b/docs/events.md
@@ -420,6 +420,8 @@ Event::listen(SwarmProgressRecorded::class, function (SwarmProgressRecorded $eve
 
 **When it fires:** when a durable parent run dispatches a child swarm. Provides the link between parent and child run identifiers.
 
+**Exactly once per child, and only for a dispatch this process performed.** The event is gated on the dispatch claim, so a recovery sweep that re-selects an already-dispatched child does not re-emit it. It is also suppressed when a worker claims a child whose run row already exists — that means an earlier attempt created the run and died, and recovery owns its execution, so the row alone is not evidence anything started. Treat the event as "this process dispatched this child", not as "every child that ever executes emits one"; a child recovered by `swarm:recover` after its dispatcher died will run without a second `SwarmChildStarted`. Listeners that must be exhaustive should key off the child run's terminal events, or reconcile against `DurableSwarmManager::inspect()`.
+
 | Property | Type | Description |
 |---|---|---|
 | `$parentRunId` | `string` | Run identifier of the parent swarm that spawned the child. |

--- a/src/Commands/Concerns/DetachesUnanswerableStdin.php
+++ b/src/Commands/Concerns/DetachesUnanswerableStdin.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuiltByBerry\LaravelSwarm\Commands\Concerns;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\StreamableInputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Stops a prompt blocking forever on a stdin that will never answer.
+ *
+ * A console command that prompts with no terminal behind it does not fail — it
+ * hangs, which in CI or a test lane reads as a stuck runner rather than a
+ * failure. Issue #449: a generator test hung past ten minutes and had to be
+ * killed. The captured stack ran `Laravel\Prompts\select()` → the Prompts
+ * fallback → Symfony's `QuestionHelper` → `TerminalInputHelper::waitForInput()`,
+ * with 2266 of 2313 samples inside `stream_select()`.
+ *
+ * WHAT ACTUALLY BLOCKS is narrower than "stdin is not a terminal", and getting
+ * that wrong is how the first attempt at this fix went astray. The busy-wait
+ * is keyed on the *identity of the stream*, not on whether anyone can answer:
+ *
+ *     // QuestionHelper::ask()
+ *     $inputStream = $input instanceof StreamableInputInterface ? $input->getStream() : null;
+ *     $inputStream ??= \STDIN;
+ *
+ *     // TerminalInputHelper::__construct()
+ *     $this->isStdin = 'php://stdin' === stream_get_meta_data($inputStream)['uri'];
+ *
+ *     // TerminalInputHelper::waitForInput() — only ever reached when isStdin
+ *     while (0 === @stream_select($r, $w, $w, 0, 100)) { $r = [$this->inputStream]; }
+ *
+ * So the hang requires the `php://stdin` resource specifically. Give the input
+ * any other stream and the loop is unreachable: `QuestionHelper` reads the
+ * empty stream, gets nothing, and returns the question's own declared default —
+ * or aborts loudly where the argument is required.
+ *
+ * That is why this is an `initialize()` hook rather than a guard at each prompt.
+ * Guarding the call sites means deciding *whether to ask*, which changes what
+ * the command does; this changes only *what it reads from*, so every prompt
+ * still runs and still yields the same answer it yielded before. Production
+ * behaviour on a non-terminal run is unchanged — which matters, because
+ * `laravel/prompts` already degraded safely there (`Prompt::prompt()` returns
+ * `$this->default()` when `stream_isatty(STDIN)` is false) and an earlier
+ * call-site guard silently flipped migrations from applied to skipped.
+ *
+ * Note the condition that arms the blocking fallback is
+ * `windows_os() || $app->runningUnitTests()`, and `runningUnitTests()` is
+ * `$app['env'] === 'testing'` — a shipped configuration value, not "PHPUnit is
+ * running". An application deployed with `APP_ENV=testing` arms it in
+ * production, so this cannot be treated as a test-only concern.
+ *
+ * KNOWN LIMITATION, deliberately accepted: a pipe that *would* have answered is
+ * no longer read. `echo yes | php artisan swarm:audit:reconcile --dismiss=42`
+ * declines instead of confirming. Nothing here can distinguish a pipe that will
+ * deliver a line from one that never will — the read blocks either way — so the
+ * choice is between losing piped answers and hanging indefinitely. Documented in
+ * UPGRADING.md with `--force` as the replacement.
+ *
+ * @internal
+ */
+trait DetachesUnanswerableStdin
+{
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        if ($input instanceof StreamableInputInterface && $this->stdinCannotAnswer($input)) {
+            // Empty and readable: QuestionHelper reads EOF and falls through to
+            // the question's declared default rather than waiting on a stream
+            // that will never become readable.
+            $stream = fopen('php://memory', 'r+');
+
+            // If even a memory stream cannot be opened, leave the input as it
+            // was. Worse to break the command outright than to leave it with the
+            // behaviour it has today.
+            if ($stream !== false) {
+                $input->setStream($stream);
+            }
+        }
+
+        parent::initialize($input, $output);
+    }
+
+    /**
+     * Whether this input would read from the process's own stdin, with no
+     * terminal behind it.
+     *
+     * An explicit stream set by a caller — `CommandTester::setInputs()`, a test
+     * harness, an application driving the command itself — is left alone: it was
+     * provided precisely so it would be read, and it is not `php://stdin`, so it
+     * cannot reach the busy-wait anyway.
+     */
+    protected function stdinCannotAnswer(StreamableInputInterface $input): bool
+    {
+        if ($input->getStream() !== null) {
+            return false;
+        }
+
+        if (! defined('STDIN')) {
+            return false;
+        }
+
+        return ! @stream_isatty(STDIN);
+    }
+}

--- a/src/Commands/Install/InstallAuditCommand.php
+++ b/src/Commands/Install/InstallAuditCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Commands\Install;
 
+use BuiltByBerry\LaravelSwarm\Commands\Concerns\DetachesUnanswerableStdin;
 use BuiltByBerry\LaravelSwarm\Contracts\ActorResolver;
 use BuiltByBerry\LaravelSwarm\Contracts\CapturePolicy;
 use BuiltByBerry\LaravelSwarm\Contracts\SwarmAuditSigner;
@@ -50,6 +51,8 @@ use function Laravel\Prompts\select;
 #[AsCommand(name: 'swarm:install:audit')]
 class InstallAuditCommand extends Command
 {
+    use DetachesUnanswerableStdin;
+
     /**
      * @var string
      */

--- a/src/Commands/Install/InstallCommand.php
+++ b/src/Commands/Install/InstallCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Commands\Install;
 
+use BuiltByBerry\LaravelSwarm\Commands\Concerns\DetachesUnanswerableStdin;
 use BuiltByBerry\LaravelSwarm\LaravelSwarm;
 use BuiltByBerry\LaravelSwarm\SwarmServiceProvider;
 use Illuminate\Console\Command;
@@ -47,6 +48,8 @@ use function Laravel\Prompts\select;
 #[AsCommand(name: 'swarm:install')]
 class InstallCommand extends Command
 {
+    use DetachesUnanswerableStdin;
+
     /** @var string */
     protected $signature = 'swarm:install
         {--force : Overwrite existing config/swarm.php when re-publishing}

--- a/src/Commands/Install/InstallDurableCommand.php
+++ b/src/Commands/Install/InstallDurableCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Commands\Install;
 
+use BuiltByBerry\LaravelSwarm\Commands\Concerns\DetachesUnanswerableStdin;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Foundation\Application;
@@ -31,6 +32,8 @@ use function Laravel\Prompts\confirm;
 #[AsCommand(name: 'swarm:install:durable')]
 class InstallDurableCommand extends Command
 {
+    use DetachesUnanswerableStdin;
+
     protected $signature = 'swarm:install:durable
                             {--queue= : Queue name for durable jobs (default: swarm-durable)}
                             {--migrate : Run any pending package migrations without prompting}

--- a/src/Commands/Install/InstallExamplesCommand.php
+++ b/src/Commands/Install/InstallExamplesCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Commands\Install;
 
+use BuiltByBerry\LaravelSwarm\Commands\Concerns\DetachesUnanswerableStdin;
 use BuiltByBerry\LaravelSwarm\Commands\Concerns\InteractsWithBlueprintCorpus;
 use BuiltByBerry\LaravelSwarm\Commands\Concerns\ResolvesHostRootNamespace;
 use FilesystemIterator;
@@ -31,6 +32,7 @@ use function Laravel\Prompts\multiselect;
 #[AsCommand(name: 'swarm:install:examples')]
 final class InstallExamplesCommand extends Command
 {
+    use DetachesUnanswerableStdin;
     use InteractsWithBlueprintCorpus;
     use ResolvesHostRootNamespace;
 

--- a/src/Commands/Install/InstallMemoryCommand.php
+++ b/src/Commands/Install/InstallMemoryCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Commands\Install;
 
+use BuiltByBerry\LaravelSwarm\Commands\Concerns\DetachesUnanswerableStdin;
 use BuiltByBerry\LaravelSwarm\Memory\DefaultPropagationPolicy;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
@@ -38,6 +39,8 @@ use function Laravel\Prompts\confirm;
 #[AsCommand(name: 'swarm:install:memory')]
 class InstallMemoryCommand extends Command
 {
+    use DetachesUnanswerableStdin;
+
     /**
      * @var string
      */

--- a/src/Commands/MakeMemoryToolCommand.php
+++ b/src/Commands/MakeMemoryToolCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Commands;
 
+use BuiltByBerry\LaravelSwarm\Commands\Concerns\DetachesUnanswerableStdin;
 use BuiltByBerry\LaravelSwarm\Commands\Concerns\ResolvesStringConsoleInput;
 use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
 use Composer\InstalledVersions;
@@ -35,6 +36,7 @@ use Symfony\Component\Console\Input\InputOption;
 #[AsCommand(name: 'make:memory-tool')]
 class MakeMemoryToolCommand extends GeneratorCommand
 {
+    use DetachesUnanswerableStdin;
     use ResolvesStringConsoleInput;
 
     /**

--- a/src/Commands/MakeSwarmAgentCommand.php
+++ b/src/Commands/MakeSwarmAgentCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Commands;
 
+use BuiltByBerry\LaravelSwarm\Commands\Concerns\DetachesUnanswerableStdin;
 use BuiltByBerry\LaravelSwarm\Commands\Concerns\ResolvesStringConsoleInput;
 use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -23,6 +24,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 #[AsCommand(name: 'make:swarm:agent')]
 class MakeSwarmAgentCommand extends GeneratorCommand
 {
+    use DetachesUnanswerableStdin;
     use ResolvesStringConsoleInput;
 
     /**

--- a/src/Commands/MakeSwarmBlueprintCommand.php
+++ b/src/Commands/MakeSwarmBlueprintCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Commands;
 
+use BuiltByBerry\LaravelSwarm\Commands\Concerns\DetachesUnanswerableStdin;
 use BuiltByBerry\LaravelSwarm\Commands\Concerns\InteractsWithBlueprintCorpus;
 use BuiltByBerry\LaravelSwarm\Commands\Concerns\ResolvesHostRootNamespace;
 use Illuminate\Console\Command;
@@ -43,6 +44,7 @@ use function Laravel\Prompts\text;
 #[AsCommand(name: 'make:swarm:blueprint')]
 class MakeSwarmBlueprintCommand extends Command
 {
+    use DetachesUnanswerableStdin;
     use InteractsWithBlueprintCorpus;
     use ResolvesHostRootNamespace;
 

--- a/src/Commands/MakeSwarmSwarmCommand.php
+++ b/src/Commands/MakeSwarmSwarmCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BuiltByBerry\LaravelSwarm\Commands;
 
+use BuiltByBerry\LaravelSwarm\Commands\Concerns\DetachesUnanswerableStdin;
 use BuiltByBerry\LaravelSwarm\Commands\Concerns\ResolvesStringConsoleInput;
 use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -24,6 +25,7 @@ use function Laravel\Prompts\select;
 #[AsCommand(name: 'make:swarm:swarm')]
 class MakeSwarmSwarmCommand extends GeneratorCommand
 {
+    use DetachesUnanswerableStdin;
     use ResolvesStringConsoleInput;
 
     /**

--- a/src/Commands/SwarmAuditReconcileCommand.php
+++ b/src/Commands/SwarmAuditReconcileCommand.php
@@ -6,6 +6,7 @@ namespace BuiltByBerry\LaravelSwarm\Commands;
 
 use BuiltByBerry\LaravelSwarm\Audit\Actor;
 use BuiltByBerry\LaravelSwarm\Audit\SwarmAuditDispatcher;
+use BuiltByBerry\LaravelSwarm\Commands\Concerns\DetachesUnanswerableStdin;
 use BuiltByBerry\LaravelSwarm\Commands\Concerns\ResolvesStringConsoleInput;
 use BuiltByBerry\LaravelSwarm\Contracts\AuditOutbox;
 use BuiltByBerry\LaravelSwarm\Persistence\SwarmPersistenceCipher;
@@ -19,6 +20,7 @@ use Throwable;
 #[AsCommand(name: 'swarm:audit:reconcile')]
 class SwarmAuditReconcileCommand extends Command
 {
+    use DetachesUnanswerableStdin;
     use ResolvesStringConsoleInput;
 
     protected ?string $reconcileAuditError = null;

--- a/src/Contracts/DurableRunStore.php
+++ b/src/Contracts/DurableRunStore.php
@@ -6,6 +6,7 @@ namespace BuiltByBerry\LaravelSwarm\Contracts;
 
 use BuiltByBerry\LaravelSwarm\Support\BranchWaitPayload;
 use BuiltByBerry\LaravelSwarm\Support\RunContext;
+use DateTimeInterface;
 
 interface DurableRunStore
 {
@@ -100,7 +101,7 @@ interface DurableRunStore
     /**
      * @param  array<string, mixed>  $policy
      */
-    public function scheduleBranchRetry(string $runId, string $branchId, string $executionToken, array $policy, int $attempt, ?\DateTimeInterface $nextRetryAt): void;
+    public function scheduleBranchRetry(string $runId, string $branchId, string $executionToken, array $policy, int $attempt, ?DateTimeInterface $nextRetryAt): void;
 
     public function cancelBranches(string $runId, ?string $parentNodeId = null): void;
 
@@ -124,7 +125,7 @@ interface DurableRunStore
     /**
      * @param  array<string, mixed>  $policy
      */
-    public function scheduleRetry(string $runId, string $executionToken, array $policy, int $attempt, ?\DateTimeInterface $nextRetryAt): void;
+    public function scheduleRetry(string $runId, string $executionToken, array $policy, int $attempt, ?DateTimeInterface $nextRetryAt): void;
 
     public function markPaused(string $runId, string $executionToken): void;
 
@@ -257,16 +258,52 @@ interface DurableRunStore
      */
     public function childRunForChild(string $childRunId): ?array;
 
-    public function markChildRunDispatched(string $childRunId): void;
+    /**
+     * Claim a child run for dispatch, conditionally on it not already being claimed.
+     *
+     * This is a LEASE, not a brand: the winner is the only worker that may dispatch,
+     * and it hands the claim back via {@see self::releaseChildRunDispatch()} on every
+     * exit that does not leave a run actually dispatched. Returns true only for the
+     * worker that took it.
+     *
+     * The claim does NOT expire. A worker killed uncatchably between claiming and
+     * committing the child's run — SIGKILL on deploy, `queue:work --timeout`, OOM,
+     * eviction — therefore leaves a claim nobody hands back, and that child is not
+     * re-dispatched. That is a known, documented limitation: re-dispatching a stranded
+     * child requires an operational input distinct from the capture/evidence view,
+     * because the stored payload is `[redacted]` under `swarm.capture.inputs=false`
+     * and a sweep would otherwise run the child on the sentinel. See UPGRADING.md.
+     */
+    public function markChildRunDispatched(string $childRunId, ?DateTimeInterface $dispatchedAt = null): bool;
 
     /**
-     * @param  array<string, mixed>|null  $failure
+     * Hand back a dispatch claim, matching the timestamp the caller stamped.
+     *
+     * Matching the stamped value — rather than merely "not null" — is what stops a
+     * worker releasing a claim it does not own. Note the column is `timestamp(0)`, so
+     * the match is second-granular: it distinguishes claims taken in different
+     * seconds, not concurrent claims within one. That is sufficient here because only
+     * the claim's winner ever calls this, and it calls it once; the guarantee rests on
+     * the conditional claim above, and this match is the second line of defence.
      */
-    public function updateChildRun(string $childRunId, string $status, ?string $output = null, ?array $failure = null): void;
+    public function releaseChildRunDispatch(string $childRunId, DateTimeInterface $dispatchedAt): bool;
+
+    /**
+     * Write a child run's status, optionally only from an expected set of statuses.
+     *
+     * Pass `$fromStatuses` to make the write conditional; it returns false when the
+     * child has moved on, which means another worker owns its terminal state.
+     *
+     * @param  array<string, mixed>|null  $failure
+     * @param  array<int, string>  $fromStatuses
+     */
+    public function updateChildRun(string $childRunId, string $status, ?string $output = null, ?array $failure = null, array $fromStatuses = []): bool;
 
     public function markChildTerminalEventDispatched(string $childRunId): bool;
 
     /**
+     * Child intents awaiting dispatch: pending and unclaimed.
+     *
      * @return array<int, array<string, mixed>>
      */
     public function undispatchedChildRuns(?string $runId = null, ?string $swarmClass = null, int $limit = 50): array;

--- a/src/Persistence/DatabaseDurableRunStore.php
+++ b/src/Persistence/DatabaseDurableRunStore.php
@@ -672,7 +672,7 @@ class DatabaseDurableRunStore implements DurableRunStore
     /**
      * Evidence/display branch read (concrete-only, used by DurableRunInspector): the
      * per-row-degrading display twin of the now-strict operational branchesFor().
-     * Each branch's input/output decrypt via {@see openForDisplay()} and carry an
+     * Each branch's input/output decrypt via {@see SwarmPersistenceCipher::openForDisplay()} and carry an
      * `*_available` flag, so an undecryptable row degrades to null rather than
      * throwing or leaking ciphertext (record 632). Intentionally not on the
      * DurableRunStore contract — reached through {@see InspectsDurableRuns}.
@@ -2921,7 +2921,8 @@ class DatabaseDurableRunStore implements DurableRunStore
     /**
      * Policy-aware, per-row-degrading display twin of {@see mapChildRun()}: the
      * nested context input and the child output decrypt via the display helpers
-     * ({@see openChildContextForDisplay()} / {@see openForDisplay()}) and each
+     * ({@see SwarmPersistenceCipher::openContextTopLevelInputForDisplay()} /
+     * {@see SwarmPersistenceCipher::openForDisplay()}) and each
      * gains an `*_available` flag, so one undecryptable child never aborts the
      * batch or 500s a display surface (record 632).
      *

--- a/src/Persistence/DatabaseDurableRunStore.php
+++ b/src/Persistence/DatabaseDurableRunStore.php
@@ -12,6 +12,7 @@ use BuiltByBerry\LaravelSwarm\Persistence\Concerns\InteractsWithJsonColumns;
 use BuiltByBerry\LaravelSwarm\Support\BranchWaitPayload;
 use BuiltByBerry\LaravelSwarm\Support\DatabaseTtl;
 use BuiltByBerry\LaravelSwarm\Support\RunContext;
+use DateTimeInterface;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Database\Connection;
@@ -780,7 +781,7 @@ class DatabaseDurableRunStore implements DurableRunStore
         ]);
     }
 
-    public function scheduleBranchRetry(string $runId, string $branchId, string $executionToken, array $policy, int $attempt, ?\DateTimeInterface $nextRetryAt): void
+    public function scheduleBranchRetry(string $runId, string $branchId, string $executionToken, array $policy, int $attempt, ?DateTimeInterface $nextRetryAt): void
     {
         $this->guardedBranchUpdate($runId, $branchId, $executionToken, [
             'status' => 'pending',
@@ -894,7 +895,7 @@ class DatabaseDurableRunStore implements DurableRunStore
         $this->markTerminal($runId, $executionToken, 'failed', $failure);
     }
 
-    public function scheduleRetry(string $runId, string $executionToken, array $policy, int $attempt, ?\DateTimeInterface $nextRetryAt): void
+    public function scheduleRetry(string $runId, string $executionToken, array $policy, int $attempt, ?DateTimeInterface $nextRetryAt): void
     {
         $this->connection->transaction(function () use ($runId, $executionToken, $policy, $attempt, $nextRetryAt): void {
             $this->guardedUpdate($runId, $executionToken, [
@@ -1849,27 +1850,55 @@ class DatabaseDurableRunStore implements DurableRunStore
         return $record !== null ? $this->mapChildRun($record) : null;
     }
 
-    public function markChildRunDispatched(string $childRunId): void
+    public function markChildRunDispatched(string $childRunId, ?DateTimeInterface $dispatchedAt = null): bool
     {
-        $timestamp = Carbon::now('UTC');
+        $timestamp = $dispatchedAt !== null ? Carbon::instance($dispatchedAt)->utc() : Carbon::now('UTC');
 
-        $this->childRunTable()
+        // One conditional UPDATE against a single row: concurrent workers race it and
+        // exactly one wins, which is what makes a duplicate dispatch unreachable. The
+        // status predicate stops a child that has already reached a terminal state
+        // being claimed and dispatched by a worker holding a stale in-memory selection.
+        $claimed = $this->childRunTable()
             ->where('child_run_id', $childRunId)
+            ->whereIn('status', ['pending', 'running'])
             ->whereNull('dispatched_at')
             ->update([
                 'dispatched_at' => $timestamp,
                 'updated_at' => $timestamp,
             ]);
+
+        return $claimed === 1;
     }
 
-    public function updateChildRun(string $childRunId, string $status, ?string $output = null, ?array $failure = null): void
+    public function releaseChildRunDispatch(string $childRunId, DateTimeInterface $dispatchedAt): bool
     {
-        $this->childRunTable()->where('child_run_id', $childRunId)->update([
+        $released = $this->childRunTable()
+            ->where('child_run_id', $childRunId)
+            ->where('dispatched_at', Carbon::instance($dispatchedAt)->utc())
+            ->update([
+                'dispatched_at' => null,
+                'updated_at' => Carbon::now('UTC'),
+            ]);
+
+        return $released === 1;
+    }
+
+    public function updateChildRun(string $childRunId, string $status, ?string $output = null, ?array $failure = null, array $fromStatuses = []): bool
+    {
+        $query = $this->childRunTable()->where('child_run_id', $childRunId);
+
+        if ($fromStatuses !== []) {
+            $query->whereIn('status', $fromStatuses);
+        }
+
+        $updated = $query->update([
             'status' => $status,
             'output' => $output !== null ? $this->cipher->seal($output) : null,
             'failure' => $failure !== null ? $this->encodeJson($failure) : null,
             'updated_at' => Carbon::now('UTC'),
         ]);
+
+        return $updated === 1;
     }
 
     public function markChildTerminalEventDispatched(string $childRunId): bool
@@ -1891,6 +1920,16 @@ class DatabaseDurableRunStore implements DurableRunStore
         $childTable = (string) $this->config->get('swarm.tables.durable_child_runs', 'swarm_durable_child_runs');
         $durableTable = (string) $this->config->get('swarm.tables.durable', 'swarm_durable_runs');
 
+        // In practice this is `status = 'pending'`: nothing writes 'running' to a child row
+        // (createChildRun stamps 'pending'; updateChildRun only ever moves a child to a
+        // terminal status). The value is kept so an out-of-tree store implementing a
+        // running state is not silently skipped, not because this codebase produces one.
+        //
+        // `dispatched_at IS NULL` is the other half of the dispatch claim: a child whose
+        // claim is held is not selectable, and a claim handed back by a failed dispatch
+        // becomes selectable again. A claim is never reclaimed on age — see
+        // markChildRunDispatched() for why a stranded claim is a documented limitation
+        // rather than something this sweep may take over.
         $query = $this->connection->table($childTable.' as children')
             ->join($durableTable.' as parents', 'children.parent_run_id', '=', 'parents.run_id')
             ->whereIn('children.status', ['pending', 'running'])

--- a/src/Runners/Durable/DurableChildSwarmCoordinator.php
+++ b/src/Runners/Durable/DurableChildSwarmCoordinator.php
@@ -18,9 +18,12 @@ use BuiltByBerry\LaravelSwarm\Responses\DurableChildRun;
 use BuiltByBerry\LaravelSwarm\Runners\SwarmRunner;
 use BuiltByBerry\LaravelSwarm\Support\RunContext;
 use BuiltByBerry\LaravelSwarm\Support\SwarmCapture;
+use Carbon\CarbonImmutable;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Connection;
+use Psr\Log\LoggerInterface;
 use Throwable;
 
 /**
@@ -43,6 +46,8 @@ class DurableChildSwarmCoordinator
         protected DurableRunContext $runs,
         protected DurablePayloadCapture $payloads,
         protected DurableOutbox $outbox,
+        protected ConfigRepository $config,
+        protected LoggerInterface $logger,
     ) {}
 
     public function afterChildIntentForTesting(?callable $hook): void
@@ -136,36 +141,135 @@ class DurableChildSwarmCoordinator
         // capture/evidence view and is `[redacted]` under swarm.capture.inputs=false.
         $contextPayload = is_array($child['context_payload'] ?? null) ? $child['context_payload'] : [];
 
-        if ($this->durableRuns->find($childRunId) === null) {
-            try {
-                $swarm = $this->application->make($childSwarmClass);
+        // The CLAIM is authoritative, not the error classifier. More than one worker can
+        // arrive here for the same child: `swarm:recover` sweeps children the parent may be
+        // inline-dispatching this instant, and the withoutOverlapping() the installer
+        // scaffolds never serialises a sweep against that inline dispatch — it only
+        // serialises sweep against sweep, and only when the schedule mutex's cache store is
+        // shared and lock-capable. A manual `php artisan swarm:recover` is outside it
+        // entirely. Winning this conditional update is what grants the right to dispatch —
+        // exactly one worker wins however many arrive — so a duplicate start() is
+        // unreachable rather than something we must recognise from a driver-specific
+        // SQLSTATE after the fact. Everything below runs for the winner.
+        $dispatchedAt = CarbonImmutable::now('UTC');
 
-                if (! $swarm instanceof Swarm) {
-                    throw new SwarmException("Unable to resolve child swarm [{$childSwarmClass}] from the container.");
-                }
-
-                $response = $this->application->make(SwarmRunner::class)->dispatchDurable($swarm, RunContext::fromPayload($contextPayload));
-                unset($response);
-            } catch (Throwable $exception) {
-                $this->durableRuns->updateChildRun($childRunId, 'failed', null, $this->failurePayload($exception));
-
-                $parent = $this->durableRuns->find((string) $child['parent_run_id']);
-
-                if ($parent !== null) {
-                    $this->reconcileTerminalChildrenForParent($parent);
-                }
-
-                return;
-            }
+        if (! $this->durableRuns->markChildRunDispatched($childRunId, $dispatchedAt)) {
+            return;
         }
 
-        $this->durableRuns->markChildRunDispatched($childRunId);
+        // A run row already exists for a child we just claimed: an earlier attempt
+        // committed start() and then had its claim handed back without the run being
+        // reaped. Do not dispatch it a second time; its execution is recoverable()'s
+        // problem. SwarmChildStarted deliberately does NOT fire here —
+        // start() commits the row inside a transaction but enqueues the job later, at
+        // PendingDispatch destruct, so a row alone is not evidence anything is executing.
+        // The claim is deliberately KEPT here rather than handed back: the run exists, so
+        // the child genuinely is dispatched, and the claim is what stops the sweep
+        // re-selecting it on every pass.
+        if ($this->durableRuns->find($childRunId) !== null) {
+            return;
+        }
 
+        try {
+            $swarm = $this->application->make($childSwarmClass);
+
+            if (! $swarm instanceof Swarm) {
+                throw new SwarmException("Unable to resolve child swarm [{$childSwarmClass}] from the container.");
+            }
+
+            $response = $this->application->make(SwarmRunner::class)->dispatchDurable($swarm, RunContext::fromPayload($contextPayload));
+            unset($response);
+        } catch (Throwable $exception) {
+            $this->failDispatch($childRunId, $dispatchedAt, $child, $exception);
+
+            return;
+        }
+
+        // Gated on the claim, so it fires exactly once per child.
         $this->events->dispatch(new SwarmChildStarted(
             parentRunId: (string) $child['parent_run_id'],
             childRunId: $childRunId,
             childSwarmClass: $childSwarmClass,
         ));
+    }
+
+    /**
+     * Resolve the failure of a dispatch this worker holds the claim for.
+     *
+     * @param  array<string, mixed>  $child
+     */
+    protected function failDispatch(string $childRunId, CarbonImmutable $dispatchedAt, array $child, Throwable $exception): void
+    {
+        // start() commits the run row inside a transaction and enqueues the job later, at
+        // PendingDispatch destruct — so an exception raised on the way out lands here with
+        // the row already persisted. Marking that child failed would bury a run that is
+        // genuinely recoverable, which is the same reasoning the run-row gate above
+        // applies. Hand the claim back and let recoverable() own it.
+        if ($this->durableRuns->find($childRunId) !== null) {
+            // Keep the claim: the run exists, so the child is dispatched and recovery owns
+            // driving it. Handing the claim back here would put it straight back into the
+            // sweep, which would re-claim, re-see the run, and release again on every pass.
+            $this->logger->warning('laravel-swarm: durable child dispatch failed after its run was created; leaving it to recovery rather than failing it.', [
+                'child_run_id' => $childRunId,
+                'parent_run_id' => $child['parent_run_id'] ?? null,
+                'exception' => $exception::class,
+            ]);
+
+            return;
+        }
+
+        // A dispatch failure stays terminal: the retry path is gated on separating the
+        // child's operational input from the capture/evidence view, because a swept retry
+        // re-reads a `[redacted]` input under swarm.capture.inputs=false and would run the
+        // child on the literal sentinel. Until that lands the child fails loudly.
+        //
+        // The write is conditional: the child may have completed under another worker while
+        // this dispatch was failing, and a no-op means that worker owns its terminal state
+        // and is already reconciling the parent.
+        $failed = $this->durableRuns->updateChildRun($childRunId, 'failed', null, $this->failurePayload($exception), ['pending']);
+
+        if (! $failed) {
+            $this->logger->info('laravel-swarm: durable child dispatch failed but the child had already reached a terminal status; leaving reconciliation to its owner.', [
+                'child_run_id' => $childRunId,
+                'parent_run_id' => $child['parent_run_id'] ?? null,
+                'exception' => $exception::class,
+            ]);
+        }
+
+        $this->releaseClaim($childRunId, $dispatchedAt, $child);
+
+        if (! $failed) {
+            return;
+        }
+
+        $parent = $this->durableRuns->find((string) $child['parent_run_id']);
+
+        if ($parent !== null) {
+            $this->reconcileTerminalChildrenForParent($parent);
+        }
+    }
+
+    /**
+     * Hand this worker's dispatch claim back.
+     *
+     * A claim held by a worker that dispatched nothing keeps the child out of the
+     * recovery sweep until it goes stale, so failing to release it delays recovery by a
+     * full grace window. That is recoverable but not free — say so rather than
+     * discarding the signal.
+     *
+     * @param  array<string, mixed>  $child
+     */
+    protected function releaseClaim(string $childRunId, CarbonImmutable $dispatchedAt, array $child): void
+    {
+        if ($this->durableRuns->releaseChildRunDispatch($childRunId, $dispatchedAt)) {
+            return;
+        }
+
+        $this->logger->warning('laravel-swarm: could not hand back a durable child dispatch claim; recovery will re-claim it once it goes stale.', [
+            'child_run_id' => $childRunId,
+            'parent_run_id' => $child['parent_run_id'] ?? null,
+            'claimed_at' => $dispatchedAt->toIso8601String(),
+        ]);
     }
 
     /**

--- a/src/Streaming/StreamStepAccumulator.php
+++ b/src/Streaming/StreamStepAccumulator.php
@@ -6,7 +6,6 @@ namespace BuiltByBerry\LaravelSwarm\Streaming;
 
 use BuiltByBerry\LaravelSwarm\Memory\MemorySnapshot;
 use BuiltByBerry\LaravelSwarm\Responses\SwarmStep;
-use BuiltByBerry\LaravelSwarm\Runners\SequentialRunner;
 use Laravel\Ai\Responses\Data\ToolCall as ToolCallData;
 
 /**
@@ -17,7 +16,7 @@ use Laravel\Ai\Responses\Data\ToolCall as ToolCallData;
  * event: it accumulates the agent's output text, pairs tool calls with their
  * results into the frozen snapshot, records the final step usage, and notes any
  * unrecognized event class for the breadcrumb. This object holds exactly that
- * state so the mapping lives in one place ({@see SequentialRunner::mapStreamEvent()})
+ * state so the mapping lives in one place ({@see StreamEventMapper::map()})
  * and both the live `stream()` loop and the durable per-node `streamSingleStep()`
  * fold a step's events identically — no second copy of the mapping to drift.
  *

--- a/src/Support/PhpStanTypeAliases.php
+++ b/src/Support/PhpStanTypeAliases.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace BuiltByBerry\LaravelSwarm\Support;
 
 /**
- * PHPStan-only type aliases imported elsewhere via {@see \phpstan-import-type}.
+ * PHPStan-only type aliases imported elsewhere via `@phpstan-import-type`.
  * This class is not used at runtime.
  *
  * @phpstan-type SwarmTaskInput string|array<string, mixed>|RunContext

--- a/testbench.yaml
+++ b/testbench.yaml
@@ -1,0 +1,2 @@
+providers:
+  - BuiltByBerry\LaravelSwarm\SwarmServiceProvider

--- a/tests/Feature/ConsolePromptSafetyTest.php
+++ b/tests/Feature/ConsolePromptSafetyTest.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Commands\Concerns\DetachesUnanswerableStdin;
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\StreamableInputInterface;
+
+/**
+ * Pins the fix for #449: a console command must not block forever on a stdin
+ * that will never answer.
+ *
+ * WHY A SUBPROCESS. The hang cannot be observed in-process. It happens inside
+ * Symfony's `TerminalInputHelper::waitForInput()`, which busy-waits on the
+ * `php://stdin` resource of the *running process* — so a test that asserts on a
+ * guard, or that constructs a command directly, proves nothing about it. The
+ * first attempt at this fix shipped exactly that kind of test, and it passed
+ * identically with and without the fix.
+ *
+ * WHY A HELD-OPEN PIPE, NOT /dev/null. `/dev/null` reads EOF immediately, so
+ * every command completes in under a second whether or not it is fixed — a pin
+ * bound to it passes vacuously. The condition that actually hangs is a pipe held
+ * open by a writer that never writes: readable never becomes true and the
+ * busy-wait spins forever. That is what these tests create.
+ *
+ * WHY `--env=testing`. `ConfiguresPrompts` arms the blocking Prompts fallback
+ * when `windows_os() || $app->runningUnitTests()`, and `runningUnitTests()` is
+ * `$app['env'] === 'testing'` — a shipped configuration value, not "PHPUnit is
+ * running". An application deployed with `APP_ENV=testing` arms it in
+ * production, which is why this is not a test-only concern.
+ *
+ * Verified against the pre-fix tree: `make:swarm:swarm` with no name blocked to
+ * the 20s ceiling and exits in ~0.3s with the fix.
+ *
+ * @return array{timedOut: bool, seconds: float, output: string, spawned: bool}
+ */
+function promptSafetyRunWithDeadStdin(string $command, int $timeoutSeconds = 20): array
+{
+    $root = dirname(__DIR__, 2);
+
+    $process = proc_open(
+        'php vendor/bin/testbench '.$command,
+        [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+        $pipes,
+        $root
+    );
+
+    if (! is_resource($process)) {
+        return ['timedOut' => false, 'seconds' => 0.0, 'output' => '', 'spawned' => false];
+    }
+
+    // $pipes[0] is deliberately left open and never written to. Closing it would
+    // deliver EOF and defeat the entire point of the test.
+    stream_set_blocking($pipes[1], false);
+    stream_set_blocking($pipes[2], false);
+
+    $output = '';
+    $startedAt = microtime(true);
+    $timedOut = false;
+
+    while (true) {
+        $status = proc_get_status($process);
+        $output .= (string) stream_get_contents($pipes[1]);
+        $output .= (string) stream_get_contents($pipes[2]);
+
+        if (! $status['running']) {
+            break;
+        }
+
+        if (microtime(true) - $startedAt > $timeoutSeconds) {
+            $timedOut = true;
+            proc_terminate($process, 9);
+
+            break;
+        }
+
+        usleep(100_000);
+    }
+
+    $output .= (string) stream_get_contents($pipes[1]);
+
+    foreach ($pipes as $pipe) {
+        if (is_resource($pipe)) {
+            fclose($pipe);
+        }
+    }
+
+    proc_close($process);
+
+    return [
+        'timedOut' => $timedOut,
+        'seconds' => (float) (microtime(true) - $startedAt),
+        'output' => $output,
+        'spawned' => true,
+    ];
+}
+
+test('a prompting command exits on an unanswerable stdin instead of hanging', function (string $command, string $expected) {
+    $result = promptSafetyRunWithDeadStdin($command.' --env=testing');
+
+    expect($result['spawned'])->toBeTrue('Could not spawn the testbench subprocess.');
+
+    expect($result['timedOut'])->toBeFalse(sprintf(
+        "`%s` blocked on an unanswerable stdin for %.1fs instead of exiting.\nOutput:\n%s",
+        $command,
+        $result['seconds'],
+        $result['output'] === '' ? '(none — it blocked before writing anything)' : $result['output']
+    ));
+
+    // A POSITIVE requirement, deliberately, because "it did not hang" is not the
+    // same claim as "it ran". Anything that makes the subprocess die early also
+    // makes it finish fast, and this pin would bank the green: an unregistered
+    // service provider, a moved binary, a renamed command. An earlier version
+    // banned two known-bad output strings instead and still passed vacuously
+    // when `vendor/bin/testbench` could not be opened at all — PHP prints
+    // "Could not open input file", exits at once, and matches neither ban.
+    // Asserting what a completed run actually prints closes the whole class
+    // rather than the two members of it someone thought of.
+    expect($result['output'])->toContain($expected);
+})->with([
+    // The exact #449 shape: a required argument omitted, so the framework's
+    // inherited prompt-for-missing-input fires before handle() ever runs. This
+    // is the row that hangs against the pre-fix tree; it aborts rather than
+    // generating, because the name it needed could never be answered.
+    'make:swarm:swarm, missing required argument' => ['make:swarm:swarm', 'Aborted.'],
+    'make:swarm:swarm' => ['make:swarm:swarm PromptSafetyProbeSwarm', 'Swarm [app/Ai/Swarms/PromptSafetyProbeSwarm.php] created successfully.'],
+    'make:swarm:agent' => ['make:swarm:agent PromptSafetyProbeAgent', 'Agent [app/Ai/Agents/PromptSafetyProbeAgent.php] created successfully.'],
+    'make:memory-tool' => ['make:memory-tool PromptSafetyProbeTool', 'Tool [app/Ai/Tools/PromptSafetyProbeTool.php] created successfully.'],
+])->group('subprocess');
+
+test('every command that can prompt detaches an unanswerable stdin', function () {
+    $root = dirname(__DIR__, 2).'/src/Commands';
+    $offenders = [];
+    $scanned = 0;
+
+    /** @var array<string, string> $sources */
+    $sources = [];
+
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS)
+    );
+
+    foreach ($iterator as $file) {
+        if ($file->isFile() && $file->getExtension() === 'php') {
+            $sources[$file->getPathname()] = (string) file_get_contents($file->getPathname());
+        }
+    }
+
+    foreach ($sources as $path => $contents) {
+        if (str_contains($contents, 'trait DetachesUnanswerableStdin')) {
+            continue;
+        }
+
+        // Anything that can reach a question: a laravel/prompts helper imported
+        // or called fully-qualified, one of Laravel's own InteractsWithIO
+        // prompts (directly or via the components layer), or the
+        // prompt-for-missing-input behaviour inherited from GeneratorCommand.
+        //
+        // This is a literal match against how prompts are written today, and
+        // that is a real limit: a helper reached through an alias, a variable
+        // callable, or a base class outside src/Commands would be invisible
+        // here. It errs toward flagging — a docblock mentioning a prompt is
+        // enough to require the trait — because a false positive costs one line
+        // and a false negative ships another hang.
+        $canPrompt = str_contains($contents, 'use function Laravel\Prompts\\')
+            || str_contains($contents, '\\Laravel\\Prompts\\')
+            || preg_match('/\$this->(confirm|ask|askWithCompletion|choice|secret|anticipate)\(/', $contents) === 1
+            || preg_match('/\$this->components->(confirm|ask|askWithCompletion|choice|secret|anticipate)\(/', $contents) === 1
+            || str_contains($contents, 'extends GeneratorCommand');
+
+        if (! $canPrompt) {
+            continue;
+        }
+
+        $scanned++;
+
+        // Applying the trait is necessary but not sufficient. A class-declared
+        // method beats a trait's, so a command that grows its own initialize()
+        // silently stops running the hook while every other check here stays
+        // green — the trait is still imported, the scan still passes, and the
+        // command hangs again. Chaining to parent is what keeps it wired.
+        if (str_contains($contents, 'function initialize(')
+            && ! str_contains($contents, 'parent::initialize(')) {
+            $offenders[] = sprintf(
+                '%s — declares initialize() without calling parent::initialize(), which silently disables the stdin hook',
+                'src/Commands/'.str_replace($root.'/', '', $path)
+            );
+
+            continue;
+        }
+
+        if (str_contains($contents, 'use DetachesUnanswerableStdin;')) {
+            continue;
+        }
+
+        // A subclass inherits the hook from its parent; resolve one level, which
+        // is as deep as this package's command hierarchy goes.
+        if (preg_match('/class \w+ extends (\w+)/', $contents, $m) === 1) {
+            $inherited = false;
+
+            foreach ($sources as $candidate => $candidateContents) {
+                if (str_ends_with($candidate, '/'.$m[1].'.php')
+                    && str_contains($candidateContents, 'use DetachesUnanswerableStdin;')) {
+                    $inherited = true;
+
+                    break;
+                }
+            }
+
+            if ($inherited) {
+                continue;
+            }
+        }
+
+        $offenders[] = sprintf(
+            '%s — can prompt but neither applies DetachesUnanswerableStdin nor inherits it',
+            'src/Commands/'.str_replace($root.'/', '', $path)
+        );
+    }
+
+    // The `extends GeneratorCommand` clause is what the previous attempt lacked.
+    // Its scan banned a single literal string, so a command inheriting its
+    // prompt from a framework trait was invisible — which is how make:swarm:agent
+    // and make:memory-tool shipped still hanging while the pin stayed green.
+    expect($scanned)->toBeGreaterThan(5, 'The prompting-command scan found almost nothing — the check is probably broken.');
+
+    expect($offenders)->toBe([], "Commands that can prompt but do not detach stdin:\n".implode("\n", $offenders));
+});
+
+test('the concern leaves a caller-supplied input stream alone', function () {
+    $command = new class extends Command
+    {
+        use DetachesUnanswerableStdin;
+
+        protected $signature = 'swarm-test:stream-probe';
+
+        public function probe(StreamableInputInterface $input): bool
+        {
+            return $this->stdinCannotAnswer($input);
+        }
+    };
+
+    // A caller that set its own stream — CommandTester::setInputs(), a harness,
+    // an application driving the command — provided it precisely so it would be
+    // read, and it is not php://stdin, so it can never reach the busy-wait.
+    $withStream = new ArrayInput([]);
+    $withStream->setStream(fopen('php://memory', 'r+'));
+
+    expect($command->probe($withStream))->toBeFalse();
+
+    // No stream of its own: detach exactly when this process has no terminal.
+    // Asserted against the live value rather than a hard-coded expectation, so
+    // this passes under a pty as well as a pipe — the previous attempt's tests
+    // hard-asserted "not a terminal" and failed on a maintainer's machine.
+    $withoutStream = new ArrayInput([]);
+
+    expect($command->probe($withoutStream))->toBe(! @stream_isatty(STDIN));
+});
+
+/**
+ * Remove any probe classes a previous run generated into the testbench app.
+ */
+function promptSafetyClearProbeClasses(): void
+{
+    $app = dirname(__DIR__, 2).'/vendor/orchestra/testbench-core/laravel/app';
+
+    foreach (['Ai/Swarms', 'Ai/Agents', 'Ai/Tools'] as $dir) {
+        foreach (glob($app.'/'.$dir.'/PromptSafetyProbe*.php') ?: [] as $file) {
+            @unlink($file);
+        }
+    }
+}
+
+// BEFORE as well as after. The success assertions expect "created successfully",
+// and a generator whose target already exists reports "already exists" instead —
+// so a run killed between generating and cleaning up would leave this suite
+// failing on state rather than on behaviour, and the obvious reading of that
+// failure ("the hang is back") would be wrong. Cleaning up front makes each run
+// independent of how the last one ended.
+beforeEach(function () {
+    promptSafetyClearProbeClasses();
+});
+
+afterEach(function () {
+    promptSafetyClearProbeClasses();
+});

--- a/tests/Feature/DurableSwarmTest.php
+++ b/tests/Feature/DurableSwarmTest.php
@@ -13,6 +13,7 @@ use BuiltByBerry\LaravelSwarm\Contracts\RunHistoryStore;
 use BuiltByBerry\LaravelSwarm\Enums\Topology;
 use BuiltByBerry\LaravelSwarm\Events\SwarmCancelled;
 use BuiltByBerry\LaravelSwarm\Events\SwarmChildCompleted;
+use BuiltByBerry\LaravelSwarm\Events\SwarmChildStarted;
 use BuiltByBerry\LaravelSwarm\Events\SwarmCompleted;
 use BuiltByBerry\LaravelSwarm\Events\SwarmFailed;
 use BuiltByBerry\LaravelSwarm\Events\SwarmPaused;
@@ -30,6 +31,7 @@ use BuiltByBerry\LaravelSwarm\Responses\DrainResult;
 use BuiltByBerry\LaravelSwarm\Responses\DurableSwarmResponse;
 use BuiltByBerry\LaravelSwarm\Responses\SwarmResponse;
 use BuiltByBerry\LaravelSwarm\Responses\SwarmStep;
+use BuiltByBerry\LaravelSwarm\Runners\Durable\DurableChildSwarmCoordinator;
 use BuiltByBerry\LaravelSwarm\Runners\Durable\DurableJobDispatcher;
 use BuiltByBerry\LaravelSwarm\Runners\Durable\DurableNodeStreamRecorder;
 use BuiltByBerry\LaravelSwarm\Runners\Durable\DurableRunContext;
@@ -62,6 +64,7 @@ use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\ParallelChildDispatchingSwar
 use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\RetryableDurableSwarm;
 use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Swarms\RetryableParallelDurableSwarm;
 use BuiltByBerry\LaravelSwarm\Tests\Support\SkippingAuditCapturePolicy;
+use Carbon\CarbonImmutable;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 use Illuminate\Foundation\Bus\PendingDispatch;
@@ -2728,6 +2731,194 @@ test('durable child recovery does not create a second child run when dispatch ma
 
     expect(DB::table('swarm_durable_runs')->where('run_id', $child['child_run_id'])->count())->toBe(1)
         ->and(app(DurableRunStore::class)->childRunForChild($child['child_run_id'])['dispatched_at'])->not->toBeNull();
+});
+
+test('durable child dispatch claim admits exactly one worker', function () {
+    FakeResearcher::fake(['parent-step']);
+
+    $response = ChildDispatchingSwarm::make()->dispatchDurable('parent-task');
+    (new AdvanceDurableSwarm($response->runId, 0))->handle(app(DurableSwarmManager::class));
+
+    $childRunId = app(DurableRunStore::class)->childRuns($response->runId)[0]['child_run_id'];
+
+    // Hand the claim back so this test owns the race rather than the dispatch above.
+    DB::table('swarm_durable_child_runs')
+        ->where('child_run_id', $childRunId)
+        ->update(['dispatched_at' => null]);
+
+    $store = app(DurableRunStore::class);
+    $first = CarbonImmutable::now('UTC');
+    $second = $first->addSecond();
+
+    expect($store->markChildRunDispatched($childRunId, $first))->toBeTrue()
+        ->and($store->markChildRunDispatched($childRunId, $second))->toBeFalse()
+        // The loser's stamp must not have overwritten the winner's.
+        ->and(app(DurableRunStore::class)->childRunForChild($childRunId)['dispatched_at'])->not->toBeNull();
+
+    // A release only ever frees its OWN claim: the loser's timestamp must not free the
+    // winner's child, or a racing worker could hand back a claim it never held.
+    expect($store->releaseChildRunDispatch($childRunId, $second))->toBeFalse()
+        ->and(app(DurableRunStore::class)->childRunForChild($childRunId)['dispatched_at'])->not->toBeNull();
+
+    expect($store->releaseChildRunDispatch($childRunId, $first))->toBeTrue()
+        ->and(app(DurableRunStore::class)->childRunForChild($childRunId)['dispatched_at'])->toBeNull();
+
+    // Released, so the recovery sweep can see it again — the claim is a lease, not a brand.
+    expect(collect($store->undispatchedChildRuns($response->runId))->pluck('child_run_id'))
+        ->toContain($childRunId);
+});
+
+test('durable child dispatch fires SwarmChildStarted once when the intent is dispatched twice', function () {
+    Event::fake([SwarmChildStarted::class]);
+    FakeResearcher::fake(['parent-step']);
+
+    $response = ChildDispatchingSwarm::make()->dispatchDurable('parent-task');
+    $manager = app(DurableSwarmManager::class);
+
+    (new AdvanceDurableSwarm($response->runId, 0))->handle($manager);
+
+    $child = app(DurableRunStore::class)->childRuns($response->runId)[0];
+
+    // A second sweep re-dispatching the same intent — reachable today because
+    // reachable because withoutOverlapping() never serialises a sweep against the
+    // parent's inline dispatch, and a manual swarm:recover is outside it entirely.
+    app(DurableChildSwarmCoordinator::class)->dispatchChildIntent([
+        'parent_run_id' => $response->runId,
+        'child_run_id' => $child['child_run_id'],
+        'child_swarm_class' => $child['child_swarm_class'],
+        'wait_name' => $child['wait_name'],
+        'context_payload' => $child['context_payload'],
+        'status' => 'pending',
+    ]);
+
+    // The claim gates the event, and the second worker never held it.
+    Event::assertDispatchedTimes(SwarmChildStarted::class, 1);
+
+    // The loser must not have clobbered the winner's live child, nor created a second run.
+    expect(app(DurableRunStore::class)->childRunForChild($child['child_run_id'])['status'])->toBe('pending')
+        ->and(DB::table('swarm_durable_runs')->where('run_id', $child['child_run_id'])->count())->toBe(1);
+});
+
+test('durable child dispatch holds the claim across dispatch and hands it back on failure', function () {
+    FakeResearcher::fake(['parent-step']);
+
+    $response = ChildDispatchingSwarm::make()->dispatchDurable('parent-task');
+    $manager = app(DurableSwarmManager::class);
+
+    (new AdvanceDurableSwarm($response->runId, 0))->handle($manager);
+
+    $intent = app(DurableRunStore::class)->childRuns($response->runId)[0];
+
+    // Reset to an undispatched intent so the dispatch is attempted again, this time
+    // against a runner that throws.
+    DB::table('swarm_durable_runs')->where('run_id', $intent['child_run_id'])->delete();
+    DB::table('swarm_durable_child_runs')
+        ->where('child_run_id', $intent['child_run_id'])
+        ->update(['dispatched_at' => null, 'status' => 'pending']);
+
+    // Observe the claim from INSIDE the dispatch. Asserting only the end state would
+    // pass against the pre-fix code too, where dispatched_at was null because no claim
+    // was ever taken — a test that cannot fail for the reason it exists. The claim must
+    // be held while the dispatch runs, and gone once it has failed.
+    $claimDuringDispatch = null;
+
+    // Resolving the child swarm happens inside the try, after the claim is taken — so
+    // this closure runs exactly in the window under test.
+    app()->bind($intent['child_swarm_class'], function () use (&$claimDuringDispatch, $response): never {
+        $claimDuringDispatch = app(DurableRunStore::class)->childRuns($response->runId)[0]['dispatched_at'] ?? null;
+
+        throw new RuntimeException('dispatch exploded');
+    });
+
+    // Through the real sweep, so the coordinator is the one the manager builds.
+    $manager->recover(runId: $response->runId);
+
+    // Restore the fixture: the child swarm class is shared, and leaving it bound to a
+    // thrower breaks anything that resolves it after this point.
+    app()->bind($intent['child_swarm_class'], fn (): object => new ($intent['child_swarm_class']));
+
+    $child = app(DurableRunStore::class)->childRunForChild($intent['child_run_id']);
+
+    // Claimed before the dispatch ran...
+    expect($claimDuringDispatch)->not->toBeNull();
+
+    // ...and handed back after it failed. A claim held by a worker that dispatched
+    // nothing keeps the child out of the recovery sweep until it goes stale.
+    expect($child['status'])->toBe('failed')
+        ->and($child['dispatched_at'])->toBeNull();
+
+    // And the parent was reconciled rather than left waiting on a child that never ran.
+    expect($manager->inspect($response->runId)->children[0]['status'])->toBe('failed');
+});
+
+test('durable child dispatch does not fail a child whose run was already created', function () {
+    FakeResearcher::fake(['parent-step']);
+
+    $response = ChildDispatchingSwarm::make()->dispatchDurable('parent-task');
+    $manager = app(DurableSwarmManager::class);
+
+    (new AdvanceDurableSwarm($response->runId, 0))->handle($manager);
+
+    $intent = app(DurableRunStore::class)->childRuns($response->runId)[0];
+    $childRunId = $intent['child_run_id'];
+
+    // Re-open the intent, keeping NO run row, so the dispatch is genuinely attempted.
+    DB::table('swarm_durable_runs')->where('run_id', $childRunId)->delete();
+    DB::table('swarm_durable_child_runs')
+        ->where('child_run_id', $childRunId)
+        ->update(['dispatched_at' => null, 'status' => 'pending']);
+
+    $runRow = ['run_id' => $childRunId, 'swarm_class' => $intent['child_swarm_class'], 'topology' => 'sequential'];
+
+    // The window start() leaves open: it commits the run row inside a transaction and
+    // enqueues the job later, at PendingDispatch destruct — so an exception on the way
+    // out lands in the catch with the row already persisted. Burying that child as
+    // `failed` would kill a run recovery can still drive.
+    app()->bind($intent['child_swarm_class'], function () use ($runRow): never {
+        DB::table('swarm_durable_runs')->insert($runRow + [
+            'execution_mode' => 'durable',
+            'coordination_profile' => 'step_durable',
+            'status' => 'pending',
+            'next_step_index' => 0,
+            'total_steps' => 1,
+            'completed_node_ids' => json_encode([]),
+            'timeout_at' => CarbonImmutable::now('UTC')->addHour(),
+            'step_timeout_seconds' => 300,
+            'attempts' => 0,
+            'recovery_count' => 0,
+            'retry_attempt' => 0,
+            'created_at' => CarbonImmutable::now('UTC'),
+            'updated_at' => CarbonImmutable::now('UTC'),
+        ]);
+
+        throw new RuntimeException('threw after the run was committed');
+    });
+
+    $manager->recover(runId: $response->runId);
+
+    app()->bind($intent['child_swarm_class'], fn (): object => new ($intent['child_swarm_class']));
+
+    // Left for recoverable() to drive, NOT marked failed.
+    expect(app(DurableRunStore::class)->childRunForChild($childRunId)['status'])->toBe('pending')
+        ->and(DB::table('swarm_durable_runs')->where('run_id', $childRunId)->count())->toBe(1);
+});
+
+test('durable child failure write cannot overwrite a child that already finished', function () {
+    FakeResearcher::fake(['parent-step']);
+
+    $response = ChildDispatchingSwarm::make()->dispatchDurable('parent-task');
+    (new AdvanceDurableSwarm($response->runId, 0))->handle(app(DurableSwarmManager::class));
+
+    $store = app(DurableRunStore::class);
+    $childRunId = $store->childRuns($response->runId)[0]['child_run_id'];
+
+    // The window: a sweep selects a pending child, the child completes under another
+    // worker, then the sweep's own dispatch throws and it writes 'failed'. Unguarded,
+    // that write buries a completed child and reconciles the parent on a lie.
+    expect($store->updateChildRun($childRunId, 'completed', 'child-output'))->toBeTrue();
+
+    expect($store->updateChildRun($childRunId, 'failed', null, ['class' => SwarmException::class], ['pending']))->toBeFalse()
+        ->and($store->childRunForChild($childRunId)['status'])->toBe('completed');
 });
 
 test('durable child terminal reconciliation emits one terminal event', function () {

--- a/tests/ProcessConcurrency/DurableChildDispatchConcurrencyTest.php
+++ b/tests/ProcessConcurrency/DurableChildDispatchConcurrencyTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+use BuiltByBerry\LaravelSwarm\Contracts\DurableRunStore;
+use BuiltByBerry\LaravelSwarm\SwarmServiceProvider;
+use Illuminate\Concurrency\ConcurrencyManager;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Process-concurrency coverage for the child-swarm dispatch claim in
+ * DurableChildSwarmCoordinator::dispatchChildIntent() (issue #431).
+ *
+ * The race needs no infrastructure fault. The `withoutOverlapping()` the installer
+ * scaffolds for `swarm:recover` never serialises a sweep against the parent's
+ * INLINE dispatch — it serialises sweep against sweep, and only when the schedule
+ * mutex's cache store is shared and lock-capable; a manual
+ * `php artisan swarm:recover` is outside it entirely. So a recovery sweep can
+ * select a child the parent is inline-dispatching right now — or two sweeps can
+ * select the same child. Before the fix both workers saw `find() === null`, both called
+ * dispatchDurable(), and the loser caught the unique-key QueryException and wrote
+ * `failed` over the WINNER's live child, releasing the parent's wait with
+ * `child_failed` while the child executed normally.
+ *
+ * The fix makes the CLAIM authoritative rather than the error classifier: only the
+ * worker that wins the conditional `status IN (pending,running) AND dispatched_at
+ * IS NULL` update may dispatch. That is what this lane proves, at the only layer
+ * where it is provable — two real OS processes contending for one row.
+ *
+ * Scenario: N workers race markChildRunDispatched() against the same child.
+ * The invariants:
+ *   - exactly ONE worker wins the claim, so a duplicate start() is unreachable;
+ *   - the losers' stamps never overwrite the winner's `dispatched_at`;
+ *   - a loser cannot release the winner's claim, because releaseChildRunDispatch()
+ *     matches the stamped timestamp rather than merely "not null".
+ *
+ * That last invariant is the second line of defence, not the first: the guarantee
+ * rests on the conditional claim, since only the claim's winner ever calls the
+ * release and it calls it once. The stamp match is second-granular (the column is
+ * `timestamp(0)`), so it distinguishes claims taken in different seconds, not
+ * concurrent claims within one.
+ */
+// Tagged `skip-locked-real-db` so the CI lane (`test:process-concurrency:ci`)
+// excludes it under `--fail-on-skipped`: it requires a shared MySQL/Postgres
+// connection and skips on the default in-memory SQLite, which is per-process and
+// cannot be reached by the child processes the concurrency driver spawns.
+pest()->group('process-concurrency', 'skip-locked-real-db');
+
+/**
+ * True if the configured testing connection is a real, shared DB engine the
+ * process concurrency driver can reach from child processes. Mirrors the
+ * exclusions in DurableRunStateConcurrencyTest.
+ */
+function durableChildDispatchConcurrencyDriverSupported(): bool
+{
+    return ! in_array(
+        DB::connection()->getDriverName(),
+        ['sqlite', 'sqlsrv'],
+        true,
+    );
+}
+
+/**
+ * Worker closure racing for one child's dispatch claim, then attempting to
+ * release it with its OWN stamped timestamp.
+ *
+ * Built by a free function so its scope class is null and it serializes cleanly
+ * to the child PHP process, which runs `php artisan invoke-serialized-closure`
+ * against bare testbench (no Pest runtime, no this test file). Everything the
+ * child needs is bootstrapped inline; only FQCN class references (resolved via
+ * the composer autoloader) and framework globals are used.
+ *
+ * @return Closure(): array{claimed: bool, released: bool, stamp: string}
+ */
+function durableChildDispatchClaimWorker(string $childRunId, string $stamp, bool $release): Closure
+{
+    return static function () use ($childRunId, $stamp, $release): array {
+        config()->set('swarm.persistence.driver', 'database');
+        config()->set('swarm.persistence.encrypt_at_rest', false);
+
+        if (! app()->providerIsLoaded(SwarmServiceProvider::class)) {
+            app()->register(SwarmServiceProvider::class);
+        }
+
+        $store = app(DurableRunStore::class);
+        $at = Carbon::parse($stamp)->utc();
+
+        $claimed = $store->markChildRunDispatched($childRunId, $at);
+
+        // Every worker attempts a release with its own stamp — the losers included.
+        // A loser's release MUST no-op: it never held the claim.
+        $released = $release ? $store->releaseChildRunDispatch($childRunId, $at) : false;
+
+        return [
+            'claimed' => $claimed,
+            'released' => $released,
+            'stamp' => $at->toDateTimeString('microsecond'),
+        ];
+    };
+}
+
+/**
+ * Seed a parent durable run and one pending, unclaimed child intent.
+ */
+function durableChildDispatchRaceSeed(string $parentRunId, string $childRunId): void
+{
+    $now = Carbon::now('UTC');
+
+    DB::table('swarm_durable_runs')->insert([
+        'run_id' => $parentRunId,
+        'swarm_class' => 'ExampleSwarm',
+        'topology' => 'sequential',
+        'execution_mode' => 'durable',
+        'coordination_profile' => 'step_durable',
+        'status' => 'waiting',
+        'next_step_index' => 0,
+        'total_steps' => 1,
+        'completed_node_ids' => json_encode([]),
+        'timeout_at' => $now->copy()->addHour(),
+        'step_timeout_seconds' => 300,
+        'attempts' => 0,
+        'recovery_count' => 0,
+        'retry_attempt' => 0,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    DB::table('swarm_durable_child_runs')->insert([
+        'parent_run_id' => $parentRunId,
+        'child_run_id' => $childRunId,
+        'child_swarm_class' => 'ExampleChildSwarm',
+        'wait_name' => 'child:'.$childRunId,
+        'context_payload' => json_encode(['run_id' => $childRunId]),
+        'status' => 'pending',
+        'output' => null,
+        'failure' => null,
+        'dispatched_at' => null,
+        'terminal_event_dispatched_at' => null,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+}
+
+test('exactly one worker wins a child dispatch claim under real process concurrency', function () {
+    if (! durableChildDispatchConcurrencyDriverSupported()) {
+        $this->markTestSkipped('Requires a shared MySQL/Postgres connection; SQLite is per-process.');
+    }
+
+    $parentRunId = 'parent-'.bin2hex(random_bytes(8));
+    $childRunId = 'child-'.bin2hex(random_bytes(8));
+    durableChildDispatchRaceSeed($parentRunId, $childRunId);
+
+    $base = Carbon::now('UTC')->startOfSecond();
+
+    // Distinct stamps per worker, so the winner is identifiable from the row and a
+    // loser's release provably targets a timestamp that was never persisted.
+    $workers = [];
+    for ($i = 0; $i < 4; $i++) {
+        $workers[] = durableChildDispatchClaimWorker(
+            $childRunId,
+            $base->copy()->addSeconds($i)->toDateTimeString('microsecond'),
+            release: false,
+        );
+    }
+
+    /** @var array<int, array{claimed: bool, released: bool, stamp: string}> $results */
+    $results = app(ConcurrencyManager::class)->driver('process')->run($workers);
+
+    $winners = array_values(array_filter($results, fn (array $r): bool => $r['claimed']));
+
+    expect($winners)->toHaveCount(1);
+
+    $row = DB::table('swarm_durable_child_runs')->where('child_run_id', $childRunId)->first();
+
+    // The winner's stamp is the one on the row: no loser overwrote it.
+    expect(Carbon::parse($row->dispatched_at)->utc()->toDateTimeString('microsecond'))
+        ->toBe($winners[0]['stamp'])
+        ->and($row->status)->toBe('pending');
+});
+
+test('a losing worker cannot release the winning claim', function () {
+    if (! durableChildDispatchConcurrencyDriverSupported()) {
+        $this->markTestSkipped('Requires a shared MySQL/Postgres connection; SQLite is per-process.');
+    }
+
+    $parentRunId = 'parent-'.bin2hex(random_bytes(8));
+    $childRunId = 'child-'.bin2hex(random_bytes(8));
+    durableChildDispatchRaceSeed($parentRunId, $childRunId);
+
+    $base = Carbon::now('UTC')->startOfSecond();
+
+    $workers = [];
+    for ($i = 0; $i < 4; $i++) {
+        $workers[] = durableChildDispatchClaimWorker(
+            $childRunId,
+            $base->copy()->addSeconds($i)->toDateTimeString('microsecond'),
+            release: true,
+        );
+    }
+
+    /** @var array<int, array{claimed: bool, released: bool, stamp: string}> $results */
+    $results = app(ConcurrencyManager::class)->driver('process')->run($workers);
+
+    // The invariant is released === claimed, per worker. Were the release written as
+    // `whereNotNull('dispatched_at')`, a worker that LOST the claim would still free
+    // it — freeing a child another worker is genuinely dispatching, so the next sweep
+    // would run it a second time.
+    //
+    // Note this scenario deliberately does NOT assert a single winner: each worker
+    // hands its claim straight back, so a later worker can legitimately take the
+    // now-free claim. Single-winner exclusivity is the previous test's job, where no
+    // worker releases.
+    foreach ($results as $result) {
+        expect($result['released'])->toBe($result['claimed']);
+    }
+
+    expect(array_filter($results, fn (array $r): bool => $r['claimed']))->not->toBeEmpty();
+
+    // Every claimer released, so the child ends selectable again — the claim is a
+    // lease, not a brand.
+    $row = DB::table('swarm_durable_child_runs')->where('child_run_id', $childRunId)->first();
+
+    expect($row->dispatched_at)->toBeNull()
+        ->and($row->status)->toBe('pending');
+});

--- a/tests/Unit/DocumentationReferenceTest.php
+++ b/tests/Unit/DocumentationReferenceTest.php
@@ -1,0 +1,656 @@
+<?php
+
+declare(strict_types=1);
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * Validates the package's own documentation REFERENCES against the shipped code.
+ *
+ * Nothing checked this before. `src/` carries ~600 `{@see}` references plus file
+ * paths, Artisan command names and stated requirements quoted in prose, and
+ * PHPStan has no phpdoc reference rules. v0.23.0 showed the cost: `AGENTS.md`
+ * pointed every agent at a review skill that is not installed, listed 8 of 24
+ * Artisan commands, and carried three stale dependency pins — all mechanically
+ * checkable, none checked.
+ *
+ * SCOPE IS REFERENTIAL ONLY. This suite answers "does the thing this sentence
+ * points at exist?" — nothing more. It CANNOT catch a semantic claim that was
+ * false when written: "X does not support Y", "both modes re-resolve from the
+ * container", "shields you from upstream churn". Every one of those was a real
+ * v0.23.0 defect and none of them would fail here. A green run means the
+ * references resolve, NOT that the documentation is true. Do not read it as
+ * broader coverage than that, and do not widen these checks into semantic
+ * territory — that is a separate control (the docblock cross-component rule).
+ *
+ * Each check is deliberately NARROW. An over-eager reference check produces
+ * false positives, gets suppressed, and then reports green while testing
+ * nothing — which is the failure this package has already shipped once, in a
+ * nightly lane that passed 30 consecutive times while masking its own
+ * resolution failure. Precision is the point: every case below that is skipped
+ * is skipped with a stated reason, and every failure names its offender
+ * individually rather than asserting a count. A corpus-total assertion is
+ * insufficient — a `>= 11` floor once passed in this repo while every
+ * generator stub underneath it was broken.
+ */
+function docRefRepoRoot(): string
+{
+    return dirname(__DIR__, 2);
+}
+
+/**
+ * @return array<int, string>
+ */
+function docRefSourceFiles(): array
+{
+    $found = [];
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator(docRefRepoRoot().'/src', FilesystemIterator::SKIP_DOTS)
+    );
+
+    foreach ($iterator as $file) {
+        if ($file->isFile() && $file->getExtension() === 'php') {
+            $found[] = $file->getPathname();
+        }
+    }
+
+    sort($found);
+
+    return $found;
+}
+
+/**
+ * Markdown the package ships and is responsible for.
+ *
+ * CHANGELOG.md and UPGRADING.md are deliberately excluded from the requirement
+ * check below — both are historical by nature, and a changelog entry naming the
+ * version something changed in is correct precisely because it does not track
+ * the current manifest. They ARE included in the path check, where a dead link
+ * is a defect regardless of the file's age.
+ *
+ * @return array<int, string>
+ */
+function docRefMarkdownFiles(): array
+{
+    $found = glob(docRefRepoRoot().'/docs/*.md') ?: [];
+
+    foreach (['README.md', 'AGENTS.md', 'CONTRIBUTING.md', 'UPGRADING.md', 'CHANGELOG.md'] as $name) {
+        $path = docRefRepoRoot().'/'.$name;
+
+        if (is_file($path)) {
+            $found[] = $path;
+        }
+    }
+
+    sort($found);
+
+    return $found;
+}
+
+function docRefRelative(string $path): string
+{
+    return str_replace(docRefRepoRoot().'/', '', $path);
+}
+
+/**
+ * Namespace, use-alias map and enclosing type for one source file.
+ *
+ * Regex rather than an AST parser: this package ships no parser dependency, and
+ * the shapes involved (one namespace, plain `use` statements, one top-level
+ * type per PSR-4 file) are unambiguous enough that a parser would be cost
+ * without benefit. If a file ever declares two top-level types the enclosing
+ * type resolves to the first, which can only cause a false NEGATIVE — a missed
+ * bad reference, never a spurious failure.
+ *
+ * @return array{namespace: string, uses: array<string, string>, enclosing: string|null}
+ */
+function docRefFileContext(string $contents): array
+{
+    $namespace = '';
+    if (preg_match('/^namespace\s+([^;]+);/m', $contents, $m) === 1) {
+        $namespace = trim($m[1]);
+    }
+
+    $uses = [];
+    if (preg_match_all('/^use\s+(?!function\s|const\s)([^;]+);/m', $contents, $matches) > 0) {
+        foreach ($matches[1] as $clause) {
+            $clause = trim($clause);
+
+            if (preg_match('/^(.+?)\s+as\s+(\w+)$/i', $clause, $aliased) === 1) {
+                $uses[$aliased[2]] = ltrim(trim($aliased[1]), '\\');
+
+                continue;
+            }
+
+            $segments = explode('\\', $clause);
+            $uses[end($segments)] = ltrim($clause, '\\');
+        }
+    }
+
+    $enclosing = null;
+    if (preg_match('/^(?:final\s+|abstract\s+|readonly\s+)*(?:class|interface|trait|enum)\s+(\w+)/m', $contents, $m) === 1) {
+        $enclosing = $namespace !== '' ? $namespace.'\\'.$m[1] : $m[1];
+    }
+
+    return ['namespace' => $namespace, 'uses' => $uses, 'enclosing' => $enclosing];
+}
+
+/**
+ * Short class name => FQCN, for every type this package declares.
+ *
+ * A `{@see Foo}` naming a package type that the file does not import does not
+ * resolve under PHP's name-resolution rules, but it is unambiguous to a reader
+ * and points at something real. Flagging those would bury the handful of
+ * references that point at NOTHING under dozens that merely lack an import —
+ * and a check whose signal is mostly noise gets suppressed. Resolving them here
+ * keeps this lane pointed at dead references.
+ *
+ * @return array<string, string>
+ */
+function docRefPackageClassMap(): array
+{
+    static $map = null;
+
+    if ($map !== null) {
+        return $map;
+    }
+
+    $map = [];
+
+    foreach (docRefSourceFiles() as $file) {
+        $contents = (string) file_get_contents($file);
+        $context = docRefFileContext($contents);
+
+        if ($context['enclosing'] === null) {
+            continue;
+        }
+
+        $segments = explode('\\', $context['enclosing']);
+        $map[end($segments)] = $context['enclosing'];
+    }
+
+    return $map;
+}
+
+/**
+ * A facade resolves its members through `__callStatic` to an instance this
+ * check cannot reach, so member existence is unverifiable rather than false.
+ */
+function docRefIsFacade(string $fqcn): bool
+{
+    try {
+        return is_subclass_of($fqcn, Facade::class);
+    } catch (Throwable) {
+        return false;
+    }
+}
+
+function docRefTypeExists(string $fqcn): bool
+{
+    $fqcn = ltrim($fqcn, '\\');
+
+    if ($fqcn === '') {
+        return false;
+    }
+
+    try {
+        return class_exists($fqcn) || interface_exists($fqcn) || trait_exists($fqcn) || enum_exists($fqcn);
+    } catch (Throwable) {
+        // A class whose own dependencies cannot autoload is a different defect
+        // from a dead reference; do not report it as one.
+        return true;
+    }
+}
+
+/**
+ * Resolve a docblock type name to the FQCN it means in this file.
+ *
+ * @param  array<string, string>  $uses
+ */
+function docRefResolveType(string $name, string $namespace, array $uses): string
+{
+    if (str_starts_with($name, '\\')) {
+        return ltrim($name, '\\');
+    }
+
+    $head = explode('\\', $name)[0];
+
+    if (isset($uses[$head])) {
+        return $uses[$head].substr($name, strlen($head));
+    }
+
+    $sameNamespace = $namespace !== '' ? $namespace.'\\'.$name : $name;
+
+    if (docRefTypeExists($sameNamespace)) {
+        return $sameNamespace;
+    }
+
+    return $name;
+}
+
+function docRefMemberExists(string $fqcn, string $member): bool
+{
+    $member = rtrim($member, '()');
+
+    if (str_starts_with($member, '$')) {
+        return property_exists($fqcn, substr($member, 1));
+    }
+
+    if (method_exists($fqcn, $member) || property_exists($fqcn, $member)) {
+        return true;
+    }
+
+    try {
+        return (new ReflectionClass($fqcn))->hasConstant($member);
+    } catch (Throwable) {
+        return false;
+    }
+}
+
+/**
+ * @param  array{namespace: string, uses: array<string, string>, enclosing: string|null}  $context
+ * @return string|null a human-readable reason the reference does not resolve, or null when it does
+ */
+function docRefUnresolvedReason(string $reference, array $context): ?string
+{
+    // `{@see $foo}` names a property or a parameter. Distinguishing the two
+    // needs the enclosing signature, so a parameter reference would be reported
+    // as a dead property. Skipped deliberately rather than guessed at.
+    if (str_starts_with($reference, '$')) {
+        return null;
+    }
+
+    // Bare URLs in `{@see}` are links, not symbols.
+    if (str_starts_with($reference, 'http://') || str_starts_with($reference, 'https://')) {
+        return null;
+    }
+
+    if (str_contains($reference, '::')) {
+        [$left, $right] = explode('::', $reference, 2);
+
+        $owner = in_array($left, ['self', 'static', '$this'], true)
+            ? $context['enclosing']
+            : docRefResolveOwner($left, $context);
+
+        if ($owner === null) {
+            return 'refers to `'.$left.'` but the file declares no enclosing type';
+        }
+
+        if (! docRefTypeExists($owner)) {
+            // A NAMESPACED external type that is not installed here — an
+            // optional or suggested dependency — cannot be verified either way.
+            // A bare name that resolved to nothing is not that: it names no
+            // type in this package, no imported type, and no global type, so it
+            // is a dead reference and must be reported. Without the
+            // `str_contains` guard this arm silently swallows every unresolvable
+            // short name, which is how an earlier revision of this check passed
+            // against a deliberately injected `{@see NoSuchClass::nope()}`.
+            return docRefIsPackageType($owner) || ! str_contains($owner, '\\')
+                ? 'type `'.$owner.'` does not exist'
+                : null;
+        }
+
+        if (docRefIsFacade($owner)) {
+            return null;
+        }
+
+        return docRefMemberExists($owner, $right)
+            ? null
+            : 'type `'.$owner.'` has no member `'.rtrim($right, '()').'`';
+    }
+
+    // `{@see method()}` — a member of the type this docblock lives in, or a
+    // global PHP function such as `{@see strtr()}`.
+    if (str_ends_with($reference, '()')) {
+        $bare = rtrim($reference, '()');
+
+        if (function_exists($bare)) {
+            return null;
+        }
+
+        $owner = $context['enclosing'];
+
+        if ($owner === null) {
+            return 'refers to `'.$reference.'` but the file declares no enclosing type';
+        }
+
+        return docRefMemberExists($owner, $reference)
+            ? null
+            : 'type `'.$owner.'` has no member `'.$bare.'`';
+    }
+
+    // A bare name is usually a type, but may be a constant or a parenless
+    // member of the enclosing type. Accept any of the three.
+    $resolved = docRefResolveOwner($reference, $context);
+
+    if ($resolved !== null && docRefTypeExists($resolved)) {
+        return null;
+    }
+
+    if ($context['enclosing'] !== null && docRefMemberExists($context['enclosing'], $reference)) {
+        return null;
+    }
+
+    if ($resolved !== null && ! docRefIsPackageType($resolved) && str_contains($resolved, '\\')) {
+        // Resolved to an external type that is not installed — see above.
+        return null;
+    }
+
+    return 'does not resolve to a type (tried `'.$resolved.'`), a constant, or a member of the enclosing type';
+}
+
+function docRefIsPackageType(string $fqcn): bool
+{
+    return str_starts_with(ltrim($fqcn, '\\'), 'BuiltByBerry\\LaravelSwarm\\');
+}
+
+/**
+ * Resolve a docblock type name, falling back to this package's own class map
+ * for an unimported short name.
+ *
+ * @param  array{namespace: string, uses: array<string, string>, enclosing: string|null}  $context
+ */
+function docRefResolveOwner(string $name, array $context): ?string
+{
+    $resolved = docRefResolveType($name, $context['namespace'], $context['uses']);
+
+    if (docRefTypeExists($resolved)) {
+        return $resolved;
+    }
+
+    if (! str_contains($name, '\\') && ! str_starts_with($name, '\\')) {
+        $map = docRefPackageClassMap();
+
+        if (isset($map[$name])) {
+            return $map[$name];
+        }
+    }
+
+    return $resolved;
+}
+
+/**
+ * Every Artisan command this package registers.
+ *
+ * Read from BOTH `$signature` and `$name`: the generators declare `$name`, and
+ * a scan of only one property silently halves the real set — the shape of the
+ * v0.23.0 defect where AGENTS.md listed 8 of 24 commands.
+ *
+ * @return array<int, string>
+ */
+function docRefPackageCommands(): array
+{
+    $names = [];
+
+    foreach (docRefSourceFiles() as $file) {
+        $contents = (string) file_get_contents($file);
+
+        if (preg_match('/\$signature\s*=\s*\'([^\'\s]+)/', $contents, $m) === 1) {
+            $names[] = $m[1];
+        }
+
+        if (preg_match('/\$name\s*=\s*\'([^\']+)\'/', $contents, $m) === 1) {
+            $names[] = $m[1];
+        }
+    }
+
+    $names = array_values(array_unique(array_filter($names)));
+    sort($names);
+
+    return $names;
+}
+
+test('every {@see} reference in src resolves to a real symbol', function () {
+    $scanned = 0;
+    $offenders = [];
+
+    foreach (docRefSourceFiles() as $file) {
+        $contents = (string) file_get_contents($file);
+
+        if (! str_contains($contents, '{@see')) {
+            continue;
+        }
+
+        $context = docRefFileContext($contents);
+        $lines = explode("\n", $contents);
+
+        foreach ($lines as $index => $line) {
+            if (preg_match_all('/\{@see\s+([^}]+)\}/', $line, $matches) === 0) {
+                continue;
+            }
+
+            foreach ($matches[1] as $raw) {
+                // `{@see Thing some trailing prose}` — the reference is the
+                // first token; the rest is the human description.
+                $reference = trim(explode(' ', trim($raw))[0]);
+
+                if ($reference === '') {
+                    continue;
+                }
+
+                $scanned++;
+                $reason = docRefUnresolvedReason($reference, $context);
+
+                if ($reason !== null) {
+                    $offenders[] = sprintf(
+                        '%s:%d  {@see %s} — %s',
+                        docRefRelative($file),
+                        $index + 1,
+                        $reference,
+                        $reason
+                    );
+                }
+            }
+        }
+    }
+
+    // An empty scan must fail rather than pass vacuously: a refactor that
+    // changed the reference syntax would otherwise turn this into a green lane
+    // that checks nothing.
+    expect($scanned)->toBeGreaterThan(400, 'The {@see} scan found almost nothing — the check is probably broken, not the docs.');
+
+    expect($offenders)->toBe([], "Unresolvable {@see} references:\n".implode("\n", $offenders));
+});
+
+test('every repository path referenced in source comments and docs exists', function () {
+    $scanned = 0;
+    $offenders = [];
+
+    // `config/` is deliberately absent. This package ships exactly one config
+    // file (config/swarm.php); every other `config/*.php` named in prose —
+    // queue.php, horizon.php, octane.php — is the CONSUMING application's, and
+    // asserting those exist here would fail on files this repo never owned.
+    $pathPattern = '#(?<![\\w/.-])((?:src|tests|docs|database|resources|stubs|examples|bin|tools|\\.github)/[A-Za-z0-9_./*-]+\\.(?:php|md|json|ya?ml|neon|xml|stub))#';
+
+    foreach (docRefSourceFiles() as $file) {
+        $lines = explode("\n", (string) file_get_contents($file));
+
+        foreach ($lines as $index => $line) {
+            // Source paths only appear in comments; a match in code is a string
+            // literal the runtime already proves.
+            if (! str_contains($line, '*') && ! str_contains($line, '//')) {
+                continue;
+            }
+
+            if (preg_match_all($pathPattern, $line, $matches) === 0) {
+                continue;
+            }
+
+            foreach ($matches[1] as $path) {
+                // Globs name a shape, not a file.
+                if (str_contains($path, '*')) {
+                    continue;
+                }
+
+                $scanned++;
+
+                if (! file_exists(docRefRepoRoot().'/'.$path)) {
+                    $offenders[] = sprintf('%s:%d  %s', docRefRelative($file), $index + 1, $path);
+                }
+            }
+        }
+    }
+
+    // Relative markdown links, which is where a dead pointer actually reaches a
+    // reader. External links and pure anchors are out of scope.
+    foreach (docRefMarkdownFiles() as $file) {
+        $lines = explode("\n", (string) file_get_contents($file));
+
+        foreach ($lines as $index => $line) {
+            if (preg_match_all('/\]\(([^)\s]+)\)/', $line, $matches) === 0) {
+                continue;
+            }
+
+            foreach ($matches[1] as $target) {
+                if (str_starts_with($target, 'http') || str_starts_with($target, '#') || str_starts_with($target, 'mailto:')) {
+                    continue;
+                }
+
+                $path = explode('#', $target)[0];
+
+                if ($path === '') {
+                    continue;
+                }
+
+                $scanned++;
+                $resolved = str_starts_with($path, '/')
+                    ? docRefRepoRoot().$path
+                    : dirname($file).'/'.$path;
+
+                if (! file_exists($resolved)) {
+                    $offenders[] = sprintf('%s:%d  %s', docRefRelative($file), $index + 1, $target);
+                }
+            }
+        }
+    }
+
+    expect($scanned)->toBeGreaterThan(50, 'The path scan found almost nothing — the check is probably broken.');
+
+    expect($offenders)->toBe([], "Referenced paths that do not exist:\n".implode("\n", $offenders));
+});
+
+test('every documented artisan command this package owns is registered', function () {
+    $registered = docRefPackageCommands();
+
+    // Commands registered under a dynamic prefix: the concrete name is built at
+    // runtime from a user's own swarm/example class, so only the prefix is
+    // knowable here.
+    $dynamicPrefixes = ['swarm:run:', 'swarm:example:'];
+
+    // Commands that belong to a COMPANION package rather than core, each with
+    // the package that owns it. Documenting them here is correct — a reader who
+    // installs the companion runs exactly these — but core cannot register
+    // them, so an existence check against src/ would be wrong.
+    $companionCommands = [
+        'swarm:install:pulse' => 'builtbyberry/laravel-swarm-pulse',
+    ];
+
+    $scanned = 0;
+    $offenders = [];
+
+    $files = array_merge(docRefSourceFiles(), docRefMarkdownFiles());
+
+    foreach ($files as $file) {
+        $lines = explode("\n", (string) file_get_contents($file));
+
+        foreach ($lines as $index => $line) {
+            if (preg_match_all('/php artisan ([a-z][a-z0-9:._-]*)/', $line, $matches) === 0) {
+                continue;
+            }
+
+            foreach ($matches[1] as $command) {
+                // Only commands in this package's own namespaces. Framework and
+                // third-party commands (migrate, queue:work, vendor:publish,
+                // boost:install) are not ours to verify, and asserting on them
+                // would make this lane fail on someone else's rename.
+                $owned = str_starts_with($command, 'swarm:')
+                    || str_starts_with($command, 'make:swarm')
+                    || $command === 'make:memory-tool';
+
+                if (! $owned) {
+                    continue;
+                }
+
+                $scanned++;
+
+                if (in_array($command, $registered, true) || isset($companionCommands[$command])) {
+                    continue;
+                }
+
+                foreach ($dynamicPrefixes as $prefix) {
+                    if (str_starts_with($command, $prefix)) {
+                        continue 2;
+                    }
+                }
+
+                $offenders[] = sprintf('%s:%d  php artisan %s', docRefRelative($file), $index + 1, $command);
+            }
+        }
+    }
+
+    expect(count($registered))->toBeGreaterThanOrEqual(24, 'Command discovery found fewer commands than this package is known to ship; the scan, not the docs, is probably wrong.');
+    expect($scanned)->toBeGreaterThan(30, 'The artisan-command scan found almost nothing — the check is probably broken.');
+
+    expect($offenders)->toBe([], "Documented commands this package does not register:\n".implode("\n", $offenders));
+});
+
+test('the stated requirements match composer.json', function () {
+    /** @var array{require: array<string, string>} $manifest */
+    $manifest = json_decode((string) file_get_contents(docRefRepoRoot().'/composer.json'), true, 512, JSON_THROW_ON_ERROR);
+    $require = $manifest['require'];
+
+    // ONLY the "## Requirements" block. Prose elsewhere legitimately names old
+    // versions — "the MCP tools added in `laravel/ai` 0.8" is a true statement
+    // about history, not a stale pin, and flagging it is exactly the kind of
+    // false positive that gets a check switched off.
+    $readme = (string) file_get_contents(docRefRepoRoot().'/README.md');
+
+    expect($readme)->toContain('## Requirements');
+
+    $section = explode('## Requirements', $readme, 2)[1];
+    $section = explode("\n## ", $section, 2)[0];
+
+    $scanned = 0;
+    $offenders = [];
+
+    foreach (explode("\n", $section) as $line) {
+        if (! str_starts_with(trim($line), '- ')) {
+            continue;
+        }
+
+        if (preg_match('/`?(php|laravel\/ai|illuminate\/[a-z*-]+)`?[^`]*\*\*\^?([0-9]+\.[0-9]+)\*\*/i', $line, $m) !== 1) {
+            continue;
+        }
+
+        $package = strtolower($m[1]);
+        $stated = $m[2];
+
+        $constraint = $require[$package] ?? ($package === 'illuminate/*' ? null : null);
+
+        // The README names `illuminate/*` collectively; compare against any one
+        // of the illuminate requirements, which the manifest keeps in lockstep.
+        if ($constraint === null && str_starts_with($package, 'illuminate/')) {
+            $constraint = $require['illuminate/support'] ?? null;
+        }
+
+        if ($constraint === null) {
+            $offenders[] = sprintf('README.md  states a requirement on `%s`, which composer.json does not require', $package);
+
+            continue;
+        }
+
+        $scanned++;
+
+        if (! str_contains($constraint, $stated)) {
+            $offenders[] = sprintf(
+                'README.md  states `%s` %s but composer.json requires %s',
+                $package,
+                $stated,
+                $constraint
+            );
+        }
+    }
+
+    expect($scanned)->toBeGreaterThan(2, 'The requirements scan found almost nothing — the check is probably broken.');
+
+    expect($offenders)->toBe([], "Stated requirements that disagree with composer.json:\n".implode("\n", $offenders));
+});


### PR DESCRIPTION
Release branch for **v0.24.0** — _Durable-execution correctness and documentation integrity._

Carries the work deferred from v0.23.0: the child-swarm dispatch race and the operational-input question underneath it, encrypt-at-rest coverage for the JSON payload columns, overlap protection for the two commands the package tells you to schedule, a `laravel/ai` compatibility policy with a nightly `0.x-dev` lane, CI merge gates, and PR-time validation of the package's own documentation references.

## Components

| Issue | Scope |
| --- | --- |
| #431 | Race-safe child-swarm dispatch — claim-as-lease, claim-authoritative |
| #433 | Graduate audit + mutation CI lanes into merge gates |
| #434 | Gate JSON payload columns behind encrypt-at-rest |
| #435 | `laravel/ai` compatibility policy + nightly `0.x-dev` lane |
| #449 | `make:swarm:swarm` can hang under `Artisan::call` |
| #450 | Validate documentation references as a PR-time test |
| #452 | Definition of Done rule — docblocks must not assert facts about other components |
| #454 | `swarm:recover` and `swarm:relay` have no overlap protection |
| #455 | Child-swarm recovery re-dispatches a `[redacted]` input |

## How to contribute to this release

**Topic branches target `release/v0.24.0`, not `main`.** Open each component's PR against this branch. This PR merges to `main` once the release is wrapped and ready to tag.

## Wrap status

- [ ] All topic PRs merged
- [ ] Multi-expert review run
- [ ] CHANGELOG filled
- [ ] Readiness review run
- [ ] Ready for merge + tag

---

Release state lives in the Marshall store (project `laravel-swarm`, release `v0.24.0`), not in this repository. Use `/marshall:release-next` for what to pick up.
