### PR TITLE
fix(streaming): triage laravel/ai 0.10 ToolApprovalRequest as ignored (#470)

### DIFF
--- a/tests/Unit/Streaming/LaravelAiStreamEventSetTest.php
+++ b/tests/Unit/Streaming/LaravelAiStreamEventSetTest.php
@@ -41,11 +41,23 @@ const HANDLED_AI_STREAM_EVENTS = [
 ];
 
 /**
- * Event types the runners deliberately do NOT map: provider lifecycle and
- * non-content-bearing markers that carry nothing the snapshot needs. They flow
- * through the breadcrumb `else` today without loss of durable content. Listed
- * here so the set is triaged, not ignored — promote one to HANDLED if a future
- * release starts capturing it.
+ * Event types the runners deliberately do NOT map; they flow through the
+ * breadcrumb `else` today. Two kinds live here:
+ *
+ *  - Provider lifecycle and non-content-bearing markers (Citation,
+ *    ProviderToolEvent, ReasoningStart, StreamStart, TextStart) that carry
+ *    nothing the durable snapshot needs.
+ *  - ToolApprovalRequest — laravel/ai 0.10's human-in-the-loop control event.
+ *    Unlike the markers above it DOES carry state (pending approvals plus raw
+ *    provider replay blocks), but Swarm does not adopt HITL in this release, so
+ *    it neither acts on nor snapshots the approval pause. The breadcrumb records
+ *    only the class name, never the payload, so nothing escapes SwarmCapture
+ *    redaction. When Swarm adopts human-in-the-loop, move it to HANDLED and map
+ *    it in SequentialRunner + StaticHierarchicalStreamRunner with redaction of
+ *    the approval and provider-content state.
+ *
+ * Listed here so the set is triaged, not ignored — promote one to HANDLED if a
+ * future release starts capturing it.
  *
  * @var array<int, string>
  */
@@ -55,6 +67,7 @@ const IGNORED_AI_STREAM_EVENTS = [
     'ReasoningStart',
     'StreamStart',
     'TextStart',
+    'ToolApprovalRequest',
 ];
 
 test('laravel/ai stream event set stays in lock-step with the runners triage', function (): void {


### PR DESCRIPTION
Component of release **v0.23.1** — targets `release/v0.23.1`, not `main`. Closes #470. Follows #469 (now merged).

## What

laravel/ai 0.10 adds `Streaming\Events\ToolApprovalRequest` (human-in-the-loop). The `LaravelAiStreamEventSetTest` guard pins the upstream event set against the runners' triage, so it failed until this new class was classified.

**Triaged as IGNORED.** Swarm does not adopt HITL in this compat-only release, so it neither acts on nor snapshots the approval pause. The event flows through the runners' existing log-once breadcrumb (class name only — no payload, no `SwarmCapture` bypass), so **no runner code changed**. Unlike the other ignored markers it *does* carry state (pending approvals + raw provider replay blocks), so the list comment now says so explicitly and records the migration path: move it to HANDLED and map it with redaction when Swarm adopts HITL.

## Gates
- Guard test: **green**
- Full suite: **1988 passed** (fully green with #469 + #470)
- PHPStan + `composer lint`: **clean**

## Review
Change-review: **approve** (no component findings; guard proven can-fail). Independently verified (PASS): IGNORE is the correct/safe triage, breadcrumb paths confirmed class-name-only, comment accurate.

One **release-scoped** readiness finding recorded (R1, low): swarms containing laravel/ai agents with approval-gated tools are unsupported until HITL is adopted (an approval-gated turn pauses with no resume path). Not a defect in this change — for the readiness/wrap review to consider documenting.
