### PR TITLE
release: v0.24.0 — Upgrade laravel/ai ^0.9 → ^0.10.3 (compatibility-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.23.1 - unreleased
+
+Compatibility-only upgrade of `laravel/ai` from `^0.9` to `^0.10.3`. The bump
+widens the `Contracts\Agent` prompt-family signatures to laravel/ai's new
+`Approvals\Decisions|string` first parameter (the human-in-the-loop resume path)
+and triages the new `ToolApprovalRequest` streaming event; adopting 0.10's
+additive features and its human-in-the-loop approval flow is deliberately out of
+scope.
+
+### Changed
+
+_To be filled in during release wrap-up._
+
+### Fixed
+
+_To be filled in during release wrap-up._
+
 ## v0.23.0 - 2026-07-20
 
 Compatibility and correctness: `laravel/ai` agents drop in unchanged, plus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ scope.
 
 ### Changed
 
-- **Requires `laravel/ai` `^0.10.3`** (previously `^0.9`). laravel/ai 0.10 widens the
+- **BREAKING: Requires `laravel/ai` `^0.10.3`** (previously `^0.9`). laravel/ai 0.10 widens the
   `Agent` contract's prompt-family methods — `prompt()`, `stream()`, `queue()`,
   `broadcast()`, `broadcastNow()`, `broadcastOnQueue()` — so their first parameter is
   now `Laravel\Ai\Approvals\Decisions|string` (the human-in-the-loop approval-resume
@@ -23,7 +23,12 @@ scope.
 
 ### Fixed
 
-_To be filled in during release wrap-up._
+- **Triaged laravel/ai 0.10's new `ToolApprovalRequest` streaming event.** The upstream
+  event set that the streaming runners' triage is pinned against grew, so the
+  `LaravelAiStreamEventSetTest` guard failed until the new class was classified. It is
+  triaged as *ignored*: Swarm does not adopt human-in-the-loop in this release, so the
+  event flows through the runners' existing log-once breadcrumb (class name only, no
+  payload) and needs no runner change.
 
 ## v0.23.0 - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,15 @@ scope.
 
 ### Changed
 
-_To be filled in during release wrap-up._
+- **Requires `laravel/ai` `^0.10.3`** (previously `^0.9`). laravel/ai 0.10 widens the
+  `Agent` contract's prompt-family methods — `prompt()`, `stream()`, `queue()`,
+  `broadcast()`, `broadcastNow()`, `broadcastOnQueue()` — so their first parameter is
+  now `Laravel\Ai\Approvals\Decisions|string` (the human-in-the-loop approval-resume
+  path). Because `BuiltByBerry\LaravelSwarm\Contracts\Agent` extends the vendor
+  contract, any agent implementing it directly — or overriding those methods on a
+  `ScriptedAgent` subclass — must widen its own first parameter to match. Agents that
+  subclass `ScriptedAgent` and override only `reply(string)` are unaffected. See
+  `UPGRADING.md` for details.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.23.1 - unreleased
+## v0.24.0 - unreleased
 
 Compatibility-only upgrade of `laravel/ai` from `^0.9` to `^0.10.3`. The bump
 widens the `Contracts\Agent` prompt-family signatures to laravel/ai's new

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -284,6 +284,13 @@ behaves exactly as before; the `Decisions` case is only reached on the approval
 continuation path, which Swarm does not itself model in this release. Agents that
 subclass `ScriptedAgent` and override only `reply(string): string` need no change.
 
+**Human-in-the-loop is not supported inside swarms yet.** Because Swarm does not
+model laravel/ai's approval-resume path in this release, a swarm built from an
+agent whose tools are *approval-gated* cannot complete: the agent pauses on a
+`ToolApprovalRequest` that Swarm has no way to approve or resume. Until swarm-level
+human-in-the-loop is adopted, keep approval-gated agents out of swarms (invoke them
+directly through laravel/ai instead).
+
 ## Upgrading to v0.23.0
 
 **Plain `laravel/ai` agents now work with Swarm unchanged.** Swarm type-hints

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -238,7 +238,7 @@ changes even when the application-facing swarm API stays the same.
 
 ## Dependency Upgrades
 
-`laravel/ai` is required in the **^0.10** range as of v0.23.1 (support for 0.9
+`laravel/ai` is required in the **^0.10** range as of v0.24.0 (support for 0.9
 was dropped; 0.8 was dropped in v0.20.0; 0.6 / 0.7 earlier, in v0.13.0) and is
 **pre-1.0**. Public
 contracts, streaming behavior, and provider integrations can change between
@@ -267,7 +267,7 @@ with `"prefer-stable": true`. Your application needs no special Composer
 stability settings to install Swarm — see
 [Composer minimum-stability](#composer-minimum-stability).
 
-## Upgrading to v0.23.1
+## Upgrading to v0.24.0
 
 **`laravel/ai` moves to `^0.10.3`.** laravel/ai 0.10 widens the `Agent` contract's
 prompt-family methods so their first parameter accepts an approval continuation as

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -238,8 +238,8 @@ changes even when the application-facing swarm API stays the same.
 
 ## Dependency Upgrades
 
-`laravel/ai` is required in the **^0.9** range as of v0.20.0 (support for 0.8
-was dropped; support for 0.6 / 0.7 was dropped earlier, in v0.13.0) and is
+`laravel/ai` is required in the **^0.10** range as of v0.23.1 (support for 0.9
+was dropped; 0.8 was dropped in v0.20.0; 0.6 / 0.7 earlier, in v0.13.0) and is
 **pre-1.0**. Public
 contracts, streaming behavior, and provider integrations can change between
 releases without the stability guarantees of a stable major line.
@@ -266,6 +266,23 @@ As of v0.23.0 this package’s `composer.json` uses `"minimum-stability": "stabl
 with `"prefer-stable": true`. Your application needs no special Composer
 stability settings to install Swarm — see
 [Composer minimum-stability](#composer-minimum-stability).
+
+## Upgrading to v0.23.1
+
+**`laravel/ai` moves to `^0.10.3`.** laravel/ai 0.10 widens the `Agent` contract's
+prompt-family methods so their first parameter accepts an approval continuation as
+well as a prompt string: `prompt()`, `stream()`, `queue()`, `broadcast()`,
+`broadcastNow()`, and `broadcastOnQueue()` now take
+`Laravel\Ai\Approvals\Decisions|string` as their first argument (the
+human-in-the-loop approval-resume path).
+
+Swarm's `BuiltByBerry\LaravelSwarm\Contracts\Agent` extends the vendor contract, so
+the change flows through. **If your application implements the `Agent` contract
+directly, or overrides any of those six methods on a `ScriptedAgent` subclass,
+widen the first parameter to `Decisions|string` to match.** A plain string prompt
+behaves exactly as before; the `Decisions` case is only reached on the approval
+continuation path, which Swarm does not itself model in this release. Agents that
+subclass `ScriptedAgent` and override only `reply(string): string` need no change.
 
 ## Upgrading to v0.23.0
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "illuminate/queue": "^13.0",
         "illuminate/support": "^13.0",
         "illuminate/view": "^13.0",
-        "laravel/ai": "^0.9"
+        "laravel/ai": "^0.10.3"
     },
     "require-dev": {
         "builtbyberry/laravel-swarm-installer-testkit": "^0.1.0",

--- a/src/Testing/ScriptedAgent.php
+++ b/src/Testing/ScriptedAgent.php
@@ -79,12 +79,17 @@ abstract class ScriptedAgent implements Agent
         ?string $model = null,
         ?int $timeout = null,
     ): AgentResponse {
+        if (! is_string($prompt)) {
+            // An approval continuation (Decisions) has no scripted reply.
+            // ScriptedAgent does not model human-in-the-loop, so fail loud like
+            // the other unsupported modes rather than silently replying to an
+            // empty prompt.
+            throw new RuntimeException(static::class.': ScriptedAgent does not support human-in-the-loop; prompt() requires a string, not an approval continuation (Decisions).');
+        }
+
         return new AgentResponse(
             invocationId: 'scripted-'.Str::random(8),
-            // A Decisions object is an approval-continuation, not fresh text; mirror
-            // laravel/ai's own narrowing (Promptable::extractPromptInput) and treat it
-            // as an empty prompt. ScriptedAgent does not model human-in-the-loop.
-            text: $this->reply(is_string($prompt) ? $prompt : ''),
+            text: $this->reply($prompt),
             usage: new Usage,
             meta: new Meta('scripted-agent', static::class),
         );

--- a/src/Testing/ScriptedAgent.php
+++ b/src/Testing/ScriptedAgent.php
@@ -7,6 +7,7 @@ namespace BuiltByBerry\LaravelSwarm\Testing;
 use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Support\Str;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
@@ -72,7 +73,7 @@ abstract class ScriptedAgent implements Agent
      * @param  LaravelAiAgentProvider  $provider
      */
     public function prompt(
-        string $prompt,
+        Decisions|string $prompt,
         array $attachments = [],
         Lab|array|string|null $provider = null,
         ?string $model = null,
@@ -80,7 +81,10 @@ abstract class ScriptedAgent implements Agent
     ): AgentResponse {
         return new AgentResponse(
             invocationId: 'scripted-'.Str::random(8),
-            text: $this->reply($prompt),
+            // A Decisions object is an approval-continuation, not fresh text; mirror
+            // laravel/ai's own narrowing (Promptable::extractPromptInput) and treat it
+            // as an empty prompt. ScriptedAgent does not model human-in-the-loop.
+            text: $this->reply(is_string($prompt) ? $prompt : ''),
             usage: new Usage,
             meta: new Meta('scripted-agent', static::class),
         );
@@ -91,7 +95,7 @@ abstract class ScriptedAgent implements Agent
      * @param  LaravelAiAgentProvider  $provider
      */
     public function stream(
-        string $prompt,
+        Decisions|string $prompt,
         array $attachments = [],
         Lab|array|string|null $provider = null,
         ?string $model = null,
@@ -105,7 +109,7 @@ abstract class ScriptedAgent implements Agent
      * @param  LaravelAiAgentProvider  $provider
      */
     public function queue(
-        string $prompt,
+        Decisions|string $prompt,
         array $attachments = [],
         Lab|array|string|null $provider = null,
         ?string $model = null,
@@ -119,7 +123,7 @@ abstract class ScriptedAgent implements Agent
      * @param  LaravelAiAgentProvider  $provider
      */
     public function broadcast(
-        string $prompt,
+        Decisions|string $prompt,
         Channel|array $channels,
         array $attachments = [],
         bool $now = false,
@@ -135,7 +139,7 @@ abstract class ScriptedAgent implements Agent
      * @param  LaravelAiAgentProvider  $provider
      */
     public function broadcastNow(
-        string $prompt,
+        Decisions|string $prompt,
         Channel|array $channels,
         array $attachments = [],
         Lab|array|string|null $provider = null,
@@ -150,7 +154,7 @@ abstract class ScriptedAgent implements Agent
      * @param  LaravelAiAgentProvider  $provider
      */
     public function broadcastOnQueue(
-        string $prompt,
+        Decisions|string $prompt,
         Channel|array $channels,
         array $attachments = [],
         Lab|array|string|null $provider = null,

--- a/stubs/examples/durable-streaming-digest/app/Ai/Agents/DurableStreamingDigest/ScriptedStreamingEditor.php
+++ b/stubs/examples/durable-streaming-digest/app/Ai/Agents/DurableStreamingDigest/ScriptedStreamingEditor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace {{ rootNamespace }}\Ai\Agents\DurableStreamingDigest;
 
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Contracts\Agent;
 use Generator;
 use Illuminate\Broadcasting\Channel;
@@ -57,7 +58,7 @@ class ScriptedStreamingEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    public function prompt(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
     {
         return new AgentResponse(
             invocationId: 'digest-'.$this->label,
@@ -71,7 +72,7 @@ class ScriptedStreamingEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
         $label = $this->label;
         $chunks = $this->chunks;
@@ -92,7 +93,7 @@ class ScriptedStreamingEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function queue(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Queueing is not supported by this scripted streaming agent.');
     }
@@ -102,7 +103,7 @@ class ScriptedStreamingEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcast(Decisions|string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported by this scripted streaming agent.');
     }
@@ -112,7 +113,7 @@ class ScriptedStreamingEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcastNow(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported by this scripted streaming agent.');
     }
@@ -122,7 +123,7 @@ class ScriptedStreamingEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function broadcastOnQueue(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Broadcast queueing is not supported by this scripted streaming agent.');
     }

--- a/tests/Fixtures/Agents/ConfigurableOutputAgent.php
+++ b/tests/Fixtures/Agents/ConfigurableOutputAgent.php
@@ -6,6 +6,7 @@ namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents;
 
 use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use Illuminate\Broadcasting\Channel;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
@@ -35,7 +36,7 @@ class ConfigurableOutputAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    public function prompt(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
     {
         return new AgentResponse(
             invocationId: 'configurable-output-agent',
@@ -49,7 +50,7 @@ class ConfigurableOutputAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
         throw new RuntimeException('Streaming is not supported in this test fixture.');
     }
@@ -58,7 +59,7 @@ class ConfigurableOutputAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function queue(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Queueing is not supported in this test fixture.');
     }
@@ -68,7 +69,7 @@ class ConfigurableOutputAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcast(Decisions|string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -78,7 +79,7 @@ class ConfigurableOutputAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcastNow(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -88,7 +89,7 @@ class ConfigurableOutputAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function broadcastOnQueue(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Broadcast queueing is not supported in this test fixture.');
     }

--- a/tests/Fixtures/Agents/CountingPrimerAgent.php
+++ b/tests/Fixtures/Agents/CountingPrimerAgent.php
@@ -6,6 +6,7 @@ namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents;
 
 use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use Illuminate\Broadcasting\Channel;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
@@ -53,7 +54,7 @@ class CountingPrimerAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    public function prompt(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
     {
         self::$invocations++;
         self::$sideEffects++;
@@ -72,7 +73,7 @@ class CountingPrimerAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
         throw new RuntimeException('Streaming is not supported in this test fixture.');
     }
@@ -81,7 +82,7 @@ class CountingPrimerAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function queue(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Queueing is not supported in this test fixture.');
     }
@@ -91,7 +92,7 @@ class CountingPrimerAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcast(Decisions|string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -101,7 +102,7 @@ class CountingPrimerAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcastNow(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -111,7 +112,7 @@ class CountingPrimerAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function broadcastOnQueue(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Broadcast queueing is not supported in this test fixture.');
     }

--- a/tests/Fixtures/Agents/EchoStreamingAgent.php
+++ b/tests/Fixtures/Agents/EchoStreamingAgent.php
@@ -6,6 +6,7 @@ namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents;
 
 use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use Illuminate\Broadcasting\Channel;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
@@ -44,8 +45,10 @@ class EchoStreamingAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    public function prompt(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
     {
+        $prompt = is_string($prompt) ? $prompt : '';
+
         return new AgentResponse(
             invocationId: 'echo-streaming',
             text: $prompt,
@@ -58,8 +61,10 @@ class EchoStreamingAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
+        $prompt = is_string($prompt) ? $prompt : '';
+
         return new StreamableAgentResponse('echo-streaming-invocation', function () use ($prompt): \Generator {
             $timestamp = 1_710_000_000;
 
@@ -73,7 +78,7 @@ class EchoStreamingAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function queue(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Queueing is not supported in this test fixture.');
     }
@@ -83,7 +88,7 @@ class EchoStreamingAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcast(Decisions|string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -93,7 +98,7 @@ class EchoStreamingAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcastNow(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -103,7 +108,7 @@ class EchoStreamingAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function broadcastOnQueue(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Broadcast queueing is not supported in this test fixture.');
     }

--- a/tests/Fixtures/Agents/ErrorStreamEditor.php
+++ b/tests/Fixtures/Agents/ErrorStreamEditor.php
@@ -6,6 +6,7 @@ namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents;
 
 use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use Illuminate\Broadcasting\Channel;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
@@ -33,7 +34,7 @@ class ErrorStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    public function prompt(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
     {
         return new AgentResponse(
             invocationId: 'error-stream-editor',
@@ -47,7 +48,7 @@ class ErrorStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
         return new StreamableAgentResponse('error-stream-invocation', function (): \Generator {
             yield new TextDelta('delta-1', 'message-1', 'partial', 1_710_000_000);
@@ -70,7 +71,7 @@ class ErrorStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function queue(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Queueing is not supported in this test fixture.');
     }
@@ -80,7 +81,7 @@ class ErrorStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcast(Decisions|string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -90,7 +91,7 @@ class ErrorStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcastNow(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -100,7 +101,7 @@ class ErrorStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function broadcastOnQueue(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Broadcast queueing is not supported in this test fixture.');
     }

--- a/tests/Fixtures/Agents/FailingPromptAgent.php
+++ b/tests/Fixtures/Agents/FailingPromptAgent.php
@@ -6,6 +6,7 @@ namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents;
 
 use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use Illuminate\Broadcasting\Channel;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\QueuedAgentResponse;
@@ -29,7 +30,7 @@ class FailingPromptAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    public function prompt(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
     {
         throw new RuntimeException('Queued swarm failed.');
     }
@@ -38,7 +39,7 @@ class FailingPromptAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
         throw new RuntimeException('Streaming is not supported in this test fixture.');
     }
@@ -47,7 +48,7 @@ class FailingPromptAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function queue(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Queueing is not supported in this test fixture.');
     }
@@ -57,7 +58,7 @@ class FailingPromptAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcast(Decisions|string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -67,7 +68,7 @@ class FailingPromptAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcastNow(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -77,7 +78,7 @@ class FailingPromptAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function broadcastOnQueue(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Broadcast queueing is not supported in this test fixture.');
     }

--- a/tests/Fixtures/Agents/FailingStreamEditor.php
+++ b/tests/Fixtures/Agents/FailingStreamEditor.php
@@ -6,6 +6,7 @@ namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents;
 
 use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use Illuminate\Broadcasting\Channel;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
@@ -32,7 +33,7 @@ class FailingStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    public function prompt(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
     {
         return new AgentResponse(
             invocationId: 'failing-stream-editor',
@@ -46,7 +47,7 @@ class FailingStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
         return new StreamableAgentResponse('failing-stream-invocation', function (): \Generator {
             yield new TextDelta('delta-1', 'message-1', 'partial', time());
@@ -59,7 +60,7 @@ class FailingStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function queue(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Queueing is not supported in this test fixture.');
     }
@@ -69,7 +70,7 @@ class FailingStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcast(Decisions|string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -79,7 +80,7 @@ class FailingStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcastNow(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -89,7 +90,7 @@ class FailingStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function broadcastOnQueue(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Broadcast queueing is not supported in this test fixture.');
     }

--- a/tests/Fixtures/Agents/FlakyDurableAgent.php
+++ b/tests/Fixtures/Agents/FlakyDurableAgent.php
@@ -6,6 +6,7 @@ namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents;
 
 use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use Illuminate\Broadcasting\Channel;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
@@ -44,7 +45,7 @@ class FlakyDurableAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    public function prompt(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
     {
         self::$attempts++;
 
@@ -65,7 +66,7 @@ class FlakyDurableAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
         throw new RuntimeException('Streaming is not supported in this test fixture.');
     }
@@ -74,7 +75,7 @@ class FlakyDurableAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function queue(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Queueing is not supported in this test fixture.');
     }
@@ -84,7 +85,7 @@ class FlakyDurableAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcast(Decisions|string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -94,7 +95,7 @@ class FlakyDurableAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcastNow(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -104,7 +105,7 @@ class FlakyDurableAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function broadcastOnQueue(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Broadcast queueing is not supported in this test fixture.');
     }

--- a/tests/Fixtures/Agents/FlakyHierarchicalCoordinator.php
+++ b/tests/Fixtures/Agents/FlakyHierarchicalCoordinator.php
@@ -7,6 +7,7 @@ namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents;
 use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Contracts\HasStructuredOutput;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\AgentResponse;
@@ -67,7 +68,7 @@ class FlakyHierarchicalCoordinator implements Agent, HasStructuredOutput
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    public function prompt(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
     {
         $attempt = ++self::$attempts;
 
@@ -111,7 +112,7 @@ class FlakyHierarchicalCoordinator implements Agent, HasStructuredOutput
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
         throw new RuntimeException('Streaming is not supported in this test fixture; the coordinator ships structural-only.');
     }
@@ -120,7 +121,7 @@ class FlakyHierarchicalCoordinator implements Agent, HasStructuredOutput
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function queue(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Queueing is not supported in this test fixture.');
     }
@@ -130,7 +131,7 @@ class FlakyHierarchicalCoordinator implements Agent, HasStructuredOutput
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcast(Decisions|string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -140,7 +141,7 @@ class FlakyHierarchicalCoordinator implements Agent, HasStructuredOutput
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcastNow(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -150,7 +151,7 @@ class FlakyHierarchicalCoordinator implements Agent, HasStructuredOutput
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function broadcastOnQueue(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Broadcast queueing is not supported in this test fixture.');
     }

--- a/tests/Fixtures/Agents/FlakyStreamEditor.php
+++ b/tests/Fixtures/Agents/FlakyStreamEditor.php
@@ -7,6 +7,7 @@ namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents;
 use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use Generator;
 use Illuminate\Broadcasting\Channel;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
@@ -54,7 +55,7 @@ class FlakyStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    public function prompt(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
     {
         return new AgentResponse('flaky-stream', 'unused', new Usage, new Meta('fake', 'test'));
     }
@@ -63,7 +64,7 @@ class FlakyStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
         $attempt = ++self::$attempts;
         $fails = $attempt <= self::$failuresBeforeSuccess;
@@ -89,7 +90,7 @@ class FlakyStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function queue(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Queueing is not supported in this test fixture.');
     }
@@ -99,7 +100,7 @@ class FlakyStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcast(Decisions|string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -109,7 +110,7 @@ class FlakyStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcastNow(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -119,7 +120,7 @@ class FlakyStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function broadcastOnQueue(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Broadcast queueing is not supported in this test fixture.');
     }

--- a/tests/Fixtures/Agents/McpStreamEditor.php
+++ b/tests/Fixtures/Agents/McpStreamEditor.php
@@ -6,6 +6,7 @@ namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents;
 
 use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use Illuminate\Broadcasting\Channel;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
@@ -59,7 +60,7 @@ class McpStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    public function prompt(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
     {
         return new AgentResponse(
             invocationId: 'mcp-stream-editor',
@@ -73,7 +74,7 @@ class McpStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
         return new StreamableAgentResponse('mcp-stream-invocation', function (): \Generator {
             $timestamp = 1_710_000_000;
@@ -103,7 +104,7 @@ class McpStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function queue(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Queueing is not supported in this test fixture.');
     }
@@ -113,7 +114,7 @@ class McpStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcast(Decisions|string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -123,7 +124,7 @@ class McpStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcastNow(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -133,7 +134,7 @@ class McpStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function broadcastOnQueue(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Broadcast queueing is not supported in this test fixture.');
     }

--- a/tests/Fixtures/Agents/MemorySpyFlakyAgent.php
+++ b/tests/Fixtures/Agents/MemorySpyFlakyAgent.php
@@ -8,6 +8,7 @@ use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use BuiltByBerry\LaravelSwarm\Contracts\SwarmMemory;
 use BuiltByBerry\LaravelSwarm\Enums\MemoryScope;
 use Illuminate\Broadcasting\Channel;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
@@ -54,7 +55,7 @@ class MemorySpyFlakyAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    public function prompt(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
     {
         self::$attempts++;
 
@@ -78,7 +79,7 @@ class MemorySpyFlakyAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
         throw new RuntimeException('Streaming is not supported in this test fixture.');
     }
@@ -87,7 +88,7 @@ class MemorySpyFlakyAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function queue(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Queueing is not supported in this test fixture.');
     }
@@ -97,7 +98,7 @@ class MemorySpyFlakyAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcast(Decisions|string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -107,7 +108,7 @@ class MemorySpyFlakyAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcastNow(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -117,7 +118,7 @@ class MemorySpyFlakyAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function broadcastOnQueue(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Broadcast queueing is not supported in this test fixture.');
     }

--- a/tests/Fixtures/Agents/PlainStreamEditor.php
+++ b/tests/Fixtures/Agents/PlainStreamEditor.php
@@ -7,6 +7,7 @@ namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents;
 use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use Generator;
 use Illuminate\Broadcasting\Channel;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
@@ -43,7 +44,7 @@ class PlainStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    public function prompt(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
     {
         return new AgentResponse(
             invocationId: 'plain-'.$this->label,
@@ -57,7 +58,7 @@ class PlainStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
         $label = $this->label;
 
@@ -74,7 +75,7 @@ class PlainStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function queue(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Queueing is not supported in this test fixture.');
     }
@@ -84,7 +85,7 @@ class PlainStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcast(Decisions|string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -94,7 +95,7 @@ class PlainStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcastNow(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -104,7 +105,7 @@ class PlainStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function broadcastOnQueue(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Broadcast queueing is not supported in this test fixture.');
     }

--- a/tests/Fixtures/Agents/PromptRecallAgent.php
+++ b/tests/Fixtures/Agents/PromptRecallAgent.php
@@ -8,6 +8,7 @@ use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use BuiltByBerry\LaravelSwarm\Tools\Recall;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Container\Container;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
@@ -39,7 +40,7 @@ abstract class PromptRecallAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    public function prompt(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
     {
         $result = Container::getInstance()->make(Recall::class)->handle(new Request([
             'key' => 'finding',
@@ -58,7 +59,7 @@ abstract class PromptRecallAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
         throw new RuntimeException('Streaming is not supported in this test fixture.');
     }
@@ -67,7 +68,7 @@ abstract class PromptRecallAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function queue(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Queueing is not supported in this test fixture.');
     }
@@ -77,7 +78,7 @@ abstract class PromptRecallAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcast(Decisions|string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -87,7 +88,7 @@ abstract class PromptRecallAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcastNow(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -97,7 +98,7 @@ abstract class PromptRecallAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function broadcastOnQueue(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Broadcast queueing is not supported in this test fixture.');
     }

--- a/tests/Fixtures/Agents/RememberingPrimerAgent.php
+++ b/tests/Fixtures/Agents/RememberingPrimerAgent.php
@@ -8,6 +8,7 @@ use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use BuiltByBerry\LaravelSwarm\Tools\Remember;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Container\Container;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
@@ -46,7 +47,7 @@ class RememberingPrimerAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    public function prompt(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
     {
         self::$invocations++;
 
@@ -68,7 +69,7 @@ class RememberingPrimerAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
         throw new RuntimeException('Streaming is not supported in this test fixture.');
     }
@@ -77,7 +78,7 @@ class RememberingPrimerAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function queue(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Queueing is not supported in this test fixture.');
     }
@@ -87,7 +88,7 @@ class RememberingPrimerAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcast(Decisions|string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -97,7 +98,7 @@ class RememberingPrimerAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcastNow(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -107,7 +108,7 @@ class RememberingPrimerAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function broadcastOnQueue(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Broadcast queueing is not supported in this test fixture.');
     }

--- a/tests/Fixtures/Agents/RememberingWriter.php
+++ b/tests/Fixtures/Agents/RememberingWriter.php
@@ -7,6 +7,7 @@ namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents;
 use BuiltByBerry\LaravelSwarm\Concerns\RemembersRunContext;
 use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use Illuminate\Support\Facades\Context;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Contracts\Conversational;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Messages\Message;
@@ -52,7 +53,7 @@ class RememberingWriter implements Agent, Conversational
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    public function prompt(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
     {
         $this->capture();
 
@@ -63,7 +64,7 @@ class RememberingWriter implements Agent, Conversational
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
         $this->capture();
 

--- a/tests/Fixtures/Agents/RichStreamEditor.php
+++ b/tests/Fixtures/Agents/RichStreamEditor.php
@@ -6,6 +6,7 @@ namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents;
 
 use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use Illuminate\Broadcasting\Channel;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
@@ -40,7 +41,7 @@ class RichStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    public function prompt(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
     {
         return new AgentResponse(
             invocationId: 'rich-stream-editor',
@@ -54,7 +55,7 @@ class RichStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
         return new StreamableAgentResponse('rich-stream-invocation', function (): \Generator {
             $timestamp = 1_710_000_000;
@@ -88,7 +89,7 @@ class RichStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function queue(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Queueing is not supported in this test fixture.');
     }
@@ -98,7 +99,7 @@ class RichStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcast(Decisions|string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -108,7 +109,7 @@ class RichStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcastNow(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -118,7 +119,7 @@ class RichStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function broadcastOnQueue(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Broadcast queueing is not supported in this test fixture.');
     }

--- a/tests/Fixtures/Agents/SerializationBoundaryAgent.php
+++ b/tests/Fixtures/Agents/SerializationBoundaryAgent.php
@@ -7,6 +7,7 @@ namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents;
 use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use Closure;
 use Illuminate\Broadcasting\Channel;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
@@ -39,8 +40,10 @@ class SerializationBoundaryAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    public function prompt(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
     {
+        $prompt = is_string($prompt) ? $prompt : '';
+
         return new AgentResponse(
             invocationId: 'serialization-boundary-agent',
             text: 'serialization-boundary:'.$prompt.':'.($this->runtimeOnlyState)(),
@@ -53,7 +56,7 @@ class SerializationBoundaryAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
         throw new RuntimeException('Streaming is not supported in this test fixture.');
     }
@@ -62,7 +65,7 @@ class SerializationBoundaryAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function queue(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Queueing is not supported in this test fixture.');
     }
@@ -72,7 +75,7 @@ class SerializationBoundaryAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcast(Decisions|string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -82,7 +85,7 @@ class SerializationBoundaryAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcastNow(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -92,7 +95,7 @@ class SerializationBoundaryAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function broadcastOnQueue(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Broadcast queueing is not supported in this test fixture.');
     }

--- a/tests/Fixtures/Agents/StreamingConversationRecallAgent.php
+++ b/tests/Fixtures/Agents/StreamingConversationRecallAgent.php
@@ -8,6 +8,7 @@ use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use BuiltByBerry\LaravelSwarm\Tools\Recall;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Container\Container;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
@@ -48,7 +49,7 @@ class StreamingConversationRecallAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    public function prompt(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
     {
         return new AgentResponse(
             invocationId: 'streaming-conversation-recall',
@@ -62,7 +63,7 @@ class StreamingConversationRecallAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
         return new StreamableAgentResponse('streaming-conversation-recall-invocation', function (): \Generator {
             $timestamp = 1_710_000_000;
@@ -99,7 +100,7 @@ class StreamingConversationRecallAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function queue(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Queueing is not supported in this test fixture.');
     }
@@ -109,7 +110,7 @@ class StreamingConversationRecallAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcast(Decisions|string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -119,7 +120,7 @@ class StreamingConversationRecallAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcastNow(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -129,7 +130,7 @@ class StreamingConversationRecallAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function broadcastOnQueue(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Broadcast queueing is not supported in this test fixture.');
     }

--- a/tests/Fixtures/Agents/StreamingRecallAgent.php
+++ b/tests/Fixtures/Agents/StreamingRecallAgent.php
@@ -8,6 +8,7 @@ use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use BuiltByBerry\LaravelSwarm\Tools\Recall;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Container\Container;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
@@ -46,7 +47,7 @@ class StreamingRecallAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    public function prompt(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
     {
         return new AgentResponse(
             invocationId: 'streaming-recall',
@@ -60,7 +61,7 @@ class StreamingRecallAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
         return new StreamableAgentResponse('streaming-recall-invocation', function (): \Generator {
             $timestamp = 1_710_000_000;
@@ -96,7 +97,7 @@ class StreamingRecallAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function queue(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Queueing is not supported in this test fixture.');
     }
@@ -106,7 +107,7 @@ class StreamingRecallAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcast(Decisions|string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -116,7 +117,7 @@ class StreamingRecallAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcastNow(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -126,7 +127,7 @@ class StreamingRecallAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function broadcastOnQueue(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Broadcast queueing is not supported in this test fixture.');
     }

--- a/tests/Fixtures/Agents/StreamingRememberAgent.php
+++ b/tests/Fixtures/Agents/StreamingRememberAgent.php
@@ -8,6 +8,7 @@ use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use BuiltByBerry\LaravelSwarm\Tools\Remember;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Container\Container;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
@@ -52,7 +53,7 @@ class StreamingRememberAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    public function prompt(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
     {
         return new AgentResponse(
             invocationId: 'streaming-remember',
@@ -66,7 +67,7 @@ class StreamingRememberAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
         return new StreamableAgentResponse('streaming-remember-invocation', function (): \Generator {
             $timestamp = 1_710_000_000;
@@ -102,7 +103,7 @@ class StreamingRememberAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function queue(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Queueing is not supported in this test fixture.');
     }
@@ -112,7 +113,7 @@ class StreamingRememberAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcast(Decisions|string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -122,7 +123,7 @@ class StreamingRememberAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcastNow(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -132,7 +133,7 @@ class StreamingRememberAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function broadcastOnQueue(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Broadcast queueing is not supported in this test fixture.');
     }

--- a/tests/Fixtures/Agents/StreamingUnpairedToolCallAgent.php
+++ b/tests/Fixtures/Agents/StreamingUnpairedToolCallAgent.php
@@ -6,6 +6,7 @@ namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents;
 
 use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use Illuminate\Broadcasting\Channel;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
@@ -44,7 +45,7 @@ class StreamingUnpairedToolCallAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    public function prompt(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
     {
         return new AgentResponse(
             invocationId: 'streaming-unpaired',
@@ -58,7 +59,7 @@ class StreamingUnpairedToolCallAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
         return new StreamableAgentResponse('streaming-unpaired-invocation', function (): \Generator {
             $timestamp = 1_710_000_000;
@@ -84,7 +85,7 @@ class StreamingUnpairedToolCallAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function queue(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Queueing is not supported in this test fixture.');
     }
@@ -94,7 +95,7 @@ class StreamingUnpairedToolCallAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcast(Decisions|string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -104,7 +105,7 @@ class StreamingUnpairedToolCallAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcastNow(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -114,7 +115,7 @@ class StreamingUnpairedToolCallAgent implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function broadcastOnQueue(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Broadcast queueing is not supported in this test fixture.');
     }

--- a/tests/Fixtures/Agents/UnencodableMcpStreamEditor.php
+++ b/tests/Fixtures/Agents/UnencodableMcpStreamEditor.php
@@ -6,6 +6,7 @@ namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents;
 
 use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use Illuminate\Broadcasting\Channel;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
@@ -59,7 +60,7 @@ class UnencodableMcpStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    public function prompt(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
     {
         return new AgentResponse(
             invocationId: 'unencodable-mcp-stream-editor',
@@ -73,7 +74,7 @@ class UnencodableMcpStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
         return new StreamableAgentResponse('unencodable-mcp-stream-invocation', function (): \Generator {
             $timestamp = 1_710_000_000;
@@ -103,7 +104,7 @@ class UnencodableMcpStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function queue(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Queueing is not supported in this test fixture.');
     }
@@ -113,7 +114,7 @@ class UnencodableMcpStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcast(Decisions|string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -123,7 +124,7 @@ class UnencodableMcpStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcastNow(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -133,7 +134,7 @@ class UnencodableMcpStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function broadcastOnQueue(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Broadcast queueing is not supported in this test fixture.');
     }

--- a/tests/Fixtures/Agents/UnknownEventStreamEditor.php
+++ b/tests/Fixtures/Agents/UnknownEventStreamEditor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents;
 
 use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Streaming\UnknownStreamEvent;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\Usage;
@@ -23,7 +24,7 @@ class UnknownEventStreamEditor extends RichStreamEditor
     /**
      * @param  array<int, mixed>  $attachments
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
         return new StreamableAgentResponse('unknown-event-invocation', function (): \Generator {
             $timestamp = 1_710_000_000;

--- a/tests/Fixtures/Agents/UnknownThenErrorStreamEditor.php
+++ b/tests/Fixtures/Agents/UnknownThenErrorStreamEditor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents;
 
 use BuiltByBerry\LaravelSwarm\Tests\Fixtures\Streaming\UnknownStreamEvent;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\StreamableAgentResponse;
@@ -23,7 +24,7 @@ class UnknownThenErrorStreamEditor extends RichStreamEditor
     /**
      * @param  array<int, mixed>  $attachments
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
         return new StreamableAgentResponse('unknown-then-error-invocation', function (): \Generator {
             $timestamp = 1_710_000_000;

--- a/tests/Fixtures/Agents/ZdrStreamEditor.php
+++ b/tests/Fixtures/Agents/ZdrStreamEditor.php
@@ -6,6 +6,7 @@ namespace BuiltByBerry\LaravelSwarm\Tests\Fixtures\Agents;
 
 use BuiltByBerry\LaravelSwarm\Contracts\Agent;
 use Illuminate\Broadcasting\Channel;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
@@ -46,7 +47,7 @@ class ZdrStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function prompt(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
+    public function prompt(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): AgentResponse
     {
         return new AgentResponse(
             invocationId: 'zdr-stream-editor',
@@ -60,7 +61,7 @@ class ZdrStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function stream(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
+    public function stream(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null, ?int $timeout = null): StreamableAgentResponse
     {
         return new StreamableAgentResponse('zdr-stream-invocation', function (): \Generator {
             $timestamp = 1_710_000_500;
@@ -97,7 +98,7 @@ class ZdrStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function queue(Decisions|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Queueing is not supported in this test fixture.');
     }
@@ -107,7 +108,7 @@ class ZdrStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcast(Decisions|string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -117,7 +118,7 @@ class ZdrStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcastNow(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         throw new RuntimeException('Broadcasting is not supported in this test fixture.');
     }
@@ -127,7 +128,7 @@ class ZdrStreamEditor implements Agent
      * @param  LaravelAiAgentAttachments  $attachments
      * @param  LaravelAiAgentProvider  $provider
      */
-    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function broadcastOnQueue(Decisions|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
         throw new RuntimeException('Broadcast queueing is not supported in this test fixture.');
     }

--- a/tests/Unit/Streaming/LaravelAiStreamEventSetTest.php
+++ b/tests/Unit/Streaming/LaravelAiStreamEventSetTest.php
@@ -41,11 +41,23 @@ const HANDLED_AI_STREAM_EVENTS = [
 ];
 
 /**
- * Event types the runners deliberately do NOT map: provider lifecycle and
- * non-content-bearing markers that carry nothing the snapshot needs. They flow
- * through the breadcrumb `else` today without loss of durable content. Listed
- * here so the set is triaged, not ignored — promote one to HANDLED if a future
- * release starts capturing it.
+ * Event types the runners deliberately do NOT map; they flow through the
+ * breadcrumb `else` today. Two kinds live here:
+ *
+ *  - Provider lifecycle and non-content-bearing markers (Citation,
+ *    ProviderToolEvent, ReasoningStart, StreamStart, TextStart) that carry
+ *    nothing the durable snapshot needs.
+ *  - ToolApprovalRequest — laravel/ai 0.10's human-in-the-loop control event.
+ *    Unlike the markers above it DOES carry state (pending approvals plus raw
+ *    provider replay blocks), but Swarm does not adopt HITL in this release, so
+ *    it neither acts on nor snapshots the approval pause. The breadcrumb records
+ *    only the class name, never the payload, so nothing escapes SwarmCapture
+ *    redaction. When Swarm adopts human-in-the-loop, move it to HANDLED and map
+ *    it in SequentialRunner + StaticHierarchicalStreamRunner with redaction of
+ *    the approval and provider-content state.
+ *
+ * Listed here so the set is triaged, not ignored — promote one to HANDLED if a
+ * future release starts capturing it.
  *
  * @var array<int, string>
  */
@@ -55,6 +67,7 @@ const IGNORED_AI_STREAM_EVENTS = [
     'ReasoningStart',
     'StreamStart',
     'TextStart',
+    'ToolApprovalRequest',
 ];
 
 test('laravel/ai stream event set stays in lock-step with the runners triage', function (): void {


### PR DESCRIPTION
Release branch for **v0.24.0** — a compatibility-only upgrade of `laravel/ai` from `^0.9` to `^0.10.3`.

**Renumbered from v0.23.1 → v0.24.0.** The upgrade is a breaking change to public surfaces (the `Agent` contract prompt-family signatures widen), so per the package's pre-1.0 semver policy it must ship as a **minor**, not a patch. The in-flight v0.24.0/v0.25.0/v0.26.0 releases each shifted up by one; this PR supersedes the old #471.

Milestone: [v0.24.0](https://github.com/builtbyberry/laravel-swarm/milestone/31)

## Scope (both components merged)

- **#469** `chore` — Bump `laravel/ai` to `^0.10.3` and widen the six `Contracts\Agent` prompt-family signatures to `Approvals\Decisions|string` (ScriptedAgent + fixtures + example stub). **BREAKING** for consumers implementing `Agent` directly or overriding ScriptedAgent's prompt-family methods; `reply(string)`-only subclasses unaffected.
- **#470** `fix` — Triage the new `Streaming\Events\ToolApprovalRequest` event → IGNORED for this compat-only release (breadcrumb handles it, no runner change).

Suite fully green (1988 passing), PHPStan + lint clean. CHANGELOG + UPGRADING document the breaking change.

## Out of scope
- 0.10's additive features (summarize, multimodal embeddings, raw-HTTP, custom headers) — tracked in the Prymer project `laravelai-010-feature-adoption`.
- 0.10's human-in-the-loop / Approvals API — its own effort (see readiness finding R1).

## Wrap status (tag mode)
- [x] All topic PRs merged
- [x] Change-review run (per component)
- [x] CHANGELOG filled
- [x] Readiness review run
- [ ] Ready for merge + tag — heading intentionally undated; the ship's `dating` step stamps it
