### PR TITLE
release: v0.24.1 — correct the laravel/ai floor stated in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v0.24.1 - unreleased
+
+Documentation-only correction. No code, configuration, or dependency changes —
+v0.24.1 is byte-identical to v0.24.0 outside `README.md`.
+
+### Fixed
+
+- **README stated the wrong `laravel/ai` floor.** v0.24.0 raised the requirement
+  to `^0.10.3` but the `## Requirements` block still read `^0.9`, so the page
+  rendered on GitHub and Packagist understated a hard constraint and pointed
+  readers at the v0.20.0 changelog entry for adoption notes that now live under
+  v0.24.0. The surrounding prose about which `laravel/ai` lines are supported,
+  and about stability configuration, is corrected to the 0.10 line alongside it.
+
+  The check that catches this class of drift — `DocumentationReferenceTest`,
+  added for the next release — is not on `main` yet, which is why v0.24.0 could
+  ship with the mismatch in the first place.
+
 ## v0.24.0 - 2026-08-14
 
 Compatibility-only upgrade of `laravel/ai` from `^0.9` to `^0.10.3`. The bump

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.24.1 - unreleased
+## v0.24.1 - 2026-08-24
 
 Documentation-only correction. No code, configuration, or dependency changes —
 v0.24.1 is byte-identical to v0.24.0 outside `README.md`.

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ For background execution, streaming, and durable workflows, see [Choosing an Exe
 
 - PHP **^8.5**
 - Laravel **13** (`illuminate/*` **^13.0**)
-- `laravel/ai` **^0.9**
+- `laravel/ai` **^0.10.3**
 
-The PHP **^8.5** floor is a deliberate requirement — the package builds on 8.5 language features. As of **v0.20.0** the `laravel/ai` floor is **^0.9**; support for **0.8** was dropped (0.6 / 0.7 were dropped earlier, in v0.13.0). Consumers pinned below `laravel/ai` 0.9 must upgrade. See the [changelog](CHANGELOG.md#v0200---2026-07-13) for what the 0.9 adoption changes.
+The PHP **^8.5** floor is a deliberate requirement — the package builds on 8.5 language features. As of **v0.24.0** the `laravel/ai` floor is **^0.10.3**; support for **0.9** was dropped then (0.8 was dropped in v0.20.0, and 0.6 / 0.7 earlier still, in v0.13.0). Consumers pinned below `laravel/ai` 0.10.3 must upgrade — and because 0.10 widens the `Agent` contract's prompt-family signatures, agents implementing that contract directly need a one-line change. See the [changelog](CHANGELOG.md#v0240---2026-08-14) and [UPGRADING.md](UPGRADING.md#upgrading-to-v0240) for what the 0.10 adoption changes.
 
-**No special stability configuration is required.** `laravel/ai` ships stable tags on the 0.9 line, so this package declares `"minimum-stability": "stable"` and installs cleanly into an application that does the same.
+**No special stability configuration is required.** `laravel/ai` ships stable tags on the 0.10 line, so this package declares `"minimum-stability": "stable"` and installs cleanly into an application that does the same.
 
 Earlier versions of this document asked you to set `"minimum-stability": "dev"` in your application's `composer.json`. That is no longer necessary, and as of **v0.23.0** it is no longer recommended — it loosens the resolution floor for your *entire* dependency tree, not just for Swarm. If you added those keys solely to install this package, you can remove them.
 


### PR DESCRIPTION
Documentation-only patch release. No code, configuration, or dependency changes — this branch is byte-identical to `v0.24.0` outside `README.md` and the changelog entry describing it.

## The defect

v0.24.0 raised the requirement from `laravel/ai` `^0.9` to `^0.10.3`. `README.md`'s `## Requirements` block was never updated, so `main` — and therefore the page GitHub and Packagist render — has been stating a floor lower than the package actually accepts.

Two follow-on inaccuracies in the same block are corrected alongside it:

- the prose still described `^0.9` as the current floor and pointed readers at the **v0.20.0** changelog entry for adoption notes, when the notes that matter now are under v0.24.0;
- the stability paragraph still said `laravel/ai` "ships stable tags on the 0.9 line".

The corrected text also names the one thing a consumer has to *do*: 0.10 widens the `Agent` contract's prompt-family signatures, so an agent implementing that contract directly needs a one-line change.

## Why this shipped

The check that catches exactly this — `DocumentationReferenceTest`, which compares README's stated requirements against `composer.json` — was written for the next release and lives on that release branch. It has never been merged into `main`, so v0.24.0 was cut without it existing.

It caught this the moment `main` was merged forward into the next release branch. That branch also carries a fix to the check itself: its version pattern accepted only two segments, so `**^0.10.3**` did not match at all and the line was silently skipped rather than compared. Only the scanned-count floor caught that.

## Scope

Deliberately not included: the validator fix, and everything else queued for the next release. This branch is the minimum needed to make the published README true.

## Tagging

Whether this warrants a `v0.24.1` Composer tag is a judgement call. Packagist re-reads the README from the default branch on push, so merging alone fixes what users see; the tag only matters if you want the correction reflected in a released version. Happy either way — say the word and I'll tag it after merge, or leave `main` a docs commit ahead until v0.25.0.