### PR TITLE
docs(agents): add cross-component docblock review rule (#452)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,9 @@ A feature or fix is complete only when all of the following are true. Reviewers 
 - **Test coverage** — new behavior has deterministic Pest tests; concurrency-sensitive paths have a `test:process-concurrency` lane entry.
 - **CHANGELOG.md** — every PR includes a changelog entry. Breaking changes also require an `UPGRADING.md` section.
 - **Docs parity** — public surface changes update the relevant file in `docs/` or `README.md` in the same PR, not a follow-up.
+- **Docblock truth boundary** — a docblock may describe the code in its own file and explain why that code is shaped that way. At review, ask: “Does this docblock assert something about a file it isn’t in?” If it restates another component's API, behavior, or infrastructure, replace the duplicated claim with a link to the owning source. Fine: [`ScriptedAgent`](src/Testing/ScriptedAgent.php) explains why it retains its own deprecated marker. Not fine: [`VendorOnlySequentialSwarm`](tests/Fixtures/Swarms/VendorOnlySequentialSwarm.php) claiming that [`PendingRun`](src/Support/PendingRun.php) requires a declared class for streaming; that duplicates another component's API and is false because `PendingRun::stream()` exists.
+
+  [`DocumentationReferenceTest`](tests/Unit/DocumentationReferenceTest.php), shipped for #450, checks only that references resolve. It cannot validate semantic claims. A green run means the links exist, not that the documentation is true; this rule is a manual review reminder, not an automated truth check.
 
 If a gap is deferred, it must be recorded as a named follow-up with an owner, not silently dropped.
 
@@ -138,7 +141,7 @@ Default review lenses:
 - Engineering manager: blast radius, cohesion, rollback safety, and delivery slicing.
 - Security specialist: redaction/capture behavior, sensitive surfaces, and failure paths.
 - QA specialist: deterministic regression coverage, edge cases, and assertion resilience.
-- Docs engineer: behavior/docs/changelog parity and configuration clarity.
+- Docs engineer: behavior/docs/changelog parity and configuration clarity; apply the Definition of Done's **Docblock truth boundary** to cross-component docblock assertions.
 - Systems integrator: migration/config compatibility and deployment/runtime wiring risk.
 - Regulatory specialist: auditability, provenance requirements, and compliance evidence quality.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,15 @@ the package's own documentation references.
 
 ### Changed
 
+- **Cross-component docblock claims are now an explicit review blocker (#452).**
+  `AGENTS.md` asks reviewers whether a docblock asserts something about a file
+  it is not in, permits comments that explain their own code, and directs
+  duplicated claims about another component's API, behavior, or infrastructure
+  back to the owning source. The Docs engineer review lens now applies the same
+  check. This is deliberately a manual reminder: the documentation-reference
+  test added in #450 proves that references resolve, not that semantic claims
+  are true.
+
 - **Five dead `{@see}` references in `src/` corrected**, all found by the new
   check on its first run. `DatabaseDurableRunStore` pointed at
   `openForDisplay()` twice as though it owned the method (it is on


### PR DESCRIPTION
## Summary

- add the named Definition of Done truth-boundary question for docblocks
- distinguish own-file explanation from cross-component claims and link worked examples to the owning source
- state that the #450 reference test proves target existence, not semantic truth, and wire the rule into the Docs engineer lens
- record the governance change in the v0.25.0 changelog

## Verification

- deliberate-red proof: `tests/Unit/DocumentationReferenceTest.php` passed 4/4, failed when the `ScriptedAgent` link was temporarily pointed at a missing path, then passed 4/4 after restoration
- `composer format`
- `composer lint`
- `composer analyse`
- `composer test` — 2,003 tests, 8,007 assertions
- fresh exact-head reference suite — 4 tests, 11 assertions

## Review

- 15 applicable Marshall change-review lenses approved; 12 path-scoped lenses skipped
- zero high, medium, or low findings
- fresh independent final verification: ready

## Intentional boundary

This is a manual semantic-review rule. It does not claim that the referential test can automate cross-component truth validation.

Closes #452