### PR TITLE
docs: document Laravel AI compatibility policy (#435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 Durable-execution correctness and documentation integrity, carrying the work
 deferred from v0.23.0: the child-swarm dispatch race, overlap protection for the
 two commands the package tells you to schedule, a `laravel/ai` compatibility
-policy with a nightly `0.x-dev` lane, CI merge gates, and PR-time validation of
-the package's own documentation references.
+policy, CI merge gates, and PR-time validation of the package's own
+documentation references.
 
 ### Added
 
@@ -46,6 +46,15 @@ the package's own documentation references.
   against a deliberately broken reference of its own kind.
 
 ### Changed
+
+- **Laravel AI compatibility is now an explicit, single-minor-line policy
+  (#435).** Because `laravel/ai` is pre-1.0, every patch and minor dependency
+  update is an integration-test event, but testing does not expand the declared
+  Composer range. Laravel Swarm supports one validated Laravel AI minor line at
+  a time; a new breaking minor becomes supported only when a later Swarm release
+  explicitly adopts it after validation. v0.25.0 remains on
+  `laravel/ai ^0.10.3`; Laravel AI 0.11 is a separate architectural adoption,
+  not a dual-version compatibility promise.
 
 - **Cross-component docblock claims are now an explicit review blocker (#452).**
   `AGENTS.md` asks reviewers whether a docblock asserts something about a file

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ Earlier versions of this document asked you to set `"minimum-stability": "dev"` 
 
 Laravel Swarm orchestrates the same Laravel AI agents, providers, and streams as your application. Treat Composer updates to Laravel or `laravel/ai` as integration-test events: run your test suite and any queued, streamed, or durable swarm smoke paths after dependency changes. This package's [changelog](CHANGELOG.md) covers Swarm-owned changes; it does not replace verification against upstream Laravel or Laravel AI releases.
 
+Because Laravel AI is pre-1.0, Laravel Swarm intentionally validates and
+supports one Laravel AI minor line at a time. A patch within the declared range
+still needs integration testing; a new minor is unsupported until a later Swarm
+release explicitly adopts it after validation. Application test results do not
+expand the Composer range declared by the package. See the
+[Laravel AI compatibility policy](UPGRADING.md#laravel-ai-compatibility-policy).
+
 ## Installation
 
 Require the package with Composer, then run the interactive installer:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -244,6 +244,20 @@ was dropped; 0.8 was dropped in v0.20.0; 0.6 / 0.7 earlier, in v0.13.0) and is
 contracts, streaming behavior, and provider integrations can change between
 releases without the stability guarantees of a stable major line.
 
+### Laravel AI compatibility policy
+
+Laravel Swarm intentionally validates and supports one pre-1.0 Laravel AI minor
+line at a time. Every Laravel AI patch or minor update is an integration-test
+event: run the automated suite and the queued, streamed, and durable paths your
+application uses before deploying the resolved version.
+
+Integration testing is not a compatibility grant. A patch is supported only
+when it remains inside the `laravel/ai` range declared by the installed Laravel
+Swarm release. A new minor outside that range is unsupported until a later
+Laravel Swarm release explicitly adopts that minor line after validation. Do
+not widen the application constraint or infer official support only because a
+local smoke test passes.
+
 When upgrading PHP, Laravel, or Laravel AI alongside Swarm:
 
 1. Note the currently resolved versions with `php -v` and `composer show laravel/framework laravel/ai builtbyberry/laravel-swarm`.
@@ -256,7 +270,7 @@ You may pin `laravel/ai` to an exact or narrower range in your application’s
 `composer.json` when you need reproducible builds or a slower upgrade cadence:
 
 ```bash
-composer require laravel/ai:0.9.0
+composer require laravel/ai:0.10.3
 ```
 
 That pins your application’s dependency resolution. It does not change the semver
@@ -275,6 +289,14 @@ interface change for maintainers who implement `DurableRunStore` themselves, and
 a console-prompt behaviour change for anyone piping answers into Artisan
 commands. One known limitation is also worth reading if you use durable child
 swarms.
+
+### Laravel AI compatibility in v0.25.0
+
+v0.25.0 remains on `laravel/ai ^0.10.3`. Laravel AI 0.11 is outside this
+release's declared support range and is being handled as a separate
+architectural adoption. Do not broaden the dependency to `^0.10 || ^0.11` on
+the assumption that application-level tests establish package compatibility;
+wait for a Laravel Swarm release that explicitly adopts the 0.11 minor line.
 
 ### Relay and recovery now own finite overlap leases (#454)
 


### PR DESCRIPTION
Closes #435.

Documents the pre-1.0 Laravel AI compatibility policy: Laravel Swarm supports one validated minor line at a time, patch and minor updates are integration-test events, and testing does not expand the declared Composer range. v0.25.0 remains on laravel/ai ^0.10.3; Laravel AI 0.11 remains a separate architectural adoption.

Scope:
- README policy summary and upgrade-guide link
- authoritative policy and v0.25-specific guidance in UPGRADING.md
- truthful v0.25 changelog entry with the deferred nightly-lane claim removed
- no Composer constraint or workflow changes

Verification:
- composer format
- composer lint
- composer analyse
- COMPOSER_PROCESS_TIMEOUT=1200 composer test (2016 tests, 8065 assertions)
- vendor/bin/pest tests/Unit/DocumentationReferenceTest.php (4 tests, 11 assertions)
- git diff --check

Independent review:
- initial verdict changes-required for one stale 0.9.0 pinning example
- corrected to 0.10.3 in exact commit 6315b58
- separate independent verifier verdict: approve