### PR TITLE
feat(compat): support PHP 8.4 across the ecosystem (#493)

### DIFF
--- a/.github/workflows/tests-real-db.yml
+++ b/.github/workflows/tests-real-db.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   tests-real-db-mysql:
-    name: PHP 8.5 - real DB (mysql-8)
+    name: PHP 8.4 - real DB (mysql-8)
     runs-on: ubuntu-24.04
 
     services:
@@ -61,7 +61,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.5'
+          php-version: '8.4'
           tools: composer:v2
           extensions: pdo, pdo_mysql
           coverage: none
@@ -102,7 +102,7 @@ jobs:
         run: composer test:process-concurrency:real-db
 
   tests-real-db-postgres:
-    name: PHP 8.5 - real DB (postgres-16)
+    name: PHP 8.4 - real DB (postgres-16)
     runs-on: ubuntu-24.04
 
     services:
@@ -135,7 +135,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.5'
+          php-version: '8.4'
           tools: composer:v2
           extensions: pdo, pdo_pgsql
           coverage: none

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,12 +9,15 @@ on:
 
 jobs:
   tests:
-    name: PHP 8.5 - Laravel 13 (${{ matrix.dependencies }})
+    name: PHP ${{ matrix.php }} - Laravel 13 (${{ matrix.dependencies }})
     runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
       matrix:
+        php:
+          - '8.4'
+          - '8.5'
         dependencies:
           - stable-latest
           - lowest
@@ -26,7 +29,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.5'
+          php-version: ${{ matrix.php }}
           tools: composer:v2
           coverage: pcov
           ini-values: memory_limit=1G

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ Durable-execution correctness and documentation integrity, carrying the work
 deferred from v0.23.0: the child-swarm dispatch race, overlap protection for the
 two commands the package tells you to schedule, an explicit `laravel/ai`
 pre-1.0 compatibility policy, PR-time validation of the package's own
-documentation references, and a companion vector-memory compatibility release.
+documentation references, a companion vector-memory compatibility release, and
+PHP 8.4 support across core and the first-party companion ecosystem.
 The child operational-input question and dispatch strand moved to v0.26.0 on
 2026-07-29; CI quality gates moved to v0.26.0 on 2026-09-02.
 
@@ -48,6 +49,15 @@ The child operational-input question and dispatch strand moved to v0.26.0 on
   against a deliberately broken reference of its own kind.
 
 ### Changed
+
+- **PHP 8.4 is now supported across Laravel Swarm and its first-party
+  companions (#493).** Core lowers its runtime requirement from `^8.5` to
+  `^8.4`, removes the inaccurate claim that it depends on PHP 8.5 language
+  features, and tests PHP 8.4 and 8.5 against latest and lowest supported
+  dependency sets. The minimum-runtime database and process-concurrency lanes
+  run on PHP 8.4. Compatibility patch releases for the installer testkit, MCP,
+  Filament, Pulse, and vector-memory companions carry the same runtime matrix.
+  PHP 8.3 is not part of the supported range.
 
 - **Composer's `dev-main` branch alias now identifies the v0.25 development
   line.** It previously remained on `0.23.x-dev`, so consumers testing the main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,14 +44,17 @@ composer lint
 composer analyse
 ```
 
-Continuous integration runs the same checks on **stable-latest** and **lowest**
-Composer resolutions: `composer test:coverage`, `composer test:process-concurrency:ci`,
-and `composer analyse`; plus `composer lint` and `composer test:compliance` (the
-scope-isolation/propagation + replay-determinism `compliance` Pest group, a discrete
-re-runnable evidence lane) on **stable-latest** only. Install PCOV for PHP locally when you want to
-match CI or debug coverage failures; otherwise `composer test` remains the default
-fast path without coverage. If workflow runtime becomes prohibitive, maintainers may
-split **lowest**-resolution lint, coverage, or process-concurrency into a nightly job;
+Continuous integration runs the same checks on PHP **8.4** and **8.5**, each on
+**stable-latest** and **lowest** Composer resolutions:
+`composer test:coverage:ci`, `composer test:process-concurrency:ci`, and
+`composer analyse`; plus `composer lint` and `composer test:compliance` (the
+scope-isolation/propagation + replay-determinism `compliance` Pest group, a
+discrete re-runnable evidence lane) on **stable-latest** only. The real MySQL
+and PostgreSQL process-concurrency jobs run on PHP **8.4**, the minimum supported
+runtime. Install PCOV for PHP locally when you want to match CI or debug coverage
+failures; otherwise `composer test` remains the default fast path without
+coverage. If workflow runtime becomes prohibitive, maintainers may split
+**lowest**-resolution lint, coverage, or process-concurrency into a nightly job;
 until then, pull requests validate both matrices equally.
 
 **Dependency advisories** — a separate `audit` workflow runs `composer audit` on

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ For background execution, streaming, and durable workflows, see [Choosing an Exe
 
 ## Requirements
 
-- PHP **^8.5**
+- PHP **^8.4**
 - Laravel **13** (`illuminate/*` **^13.0**)
 - `laravel/ai` **^0.10.3**
 
-The PHP **^8.5** floor is a deliberate requirement — the package builds on 8.5 language features. As of **v0.24.0** the `laravel/ai` floor is **^0.10.3**; support for **0.9** was dropped then (0.8 was dropped in v0.20.0, and 0.6 / 0.7 earlier still, in v0.13.0). Consumers pinned below `laravel/ai` 0.10.3 must upgrade — and because 0.10 widens the `Agent` contract's prompt-family signatures, agents implementing that contract directly need a one-line change. See the [changelog](CHANGELOG.md#v0240---2026-08-14) and [UPGRADING.md](UPGRADING.md#upgrading-to-v0240) for what the 0.10 adoption changes.
+PHP **^8.4** is supported alongside PHP 8.5. As of **v0.24.0** the `laravel/ai` floor is **^0.10.3**; support for **0.9** was dropped then (0.8 was dropped in v0.20.0, and 0.6 / 0.7 earlier still, in v0.13.0). Consumers pinned below `laravel/ai` 0.10.3 must upgrade — and because 0.10 widens the `Agent` contract's prompt-family signatures, agents implementing that contract directly need a one-line change. See the [changelog](CHANGELOG.md#v0240---2026-08-14) and [UPGRADING.md](UPGRADING.md#upgrading-to-v0240) for what the 0.10 adoption changes.
 
 **No special stability configuration is required.** `laravel/ai` ships stable tags on the 0.10 line, so this package declares `"minimum-stability": "stable"` and installs cleanly into an application that does the same.
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^8.5",
+        "php": "^8.4",
         "illuminate/bus": "^13.0",
         "illuminate/cache": "^13.0",
         "illuminate/concurrency": "^13.0",
@@ -34,7 +34,7 @@
         "laravel/ai": "^0.10.3"
     },
     "require-dev": {
-        "builtbyberry/laravel-swarm-installer-testkit": "^0.1.0",
+        "builtbyberry/laravel-swarm-installer-testkit": "^0.1.3",
         "larastan/larastan": "^3.10",
         "laravel/pint": "^1.29",
         "orchestra/testbench": "^11.1",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,16 +14,17 @@ the manual equivalent of every step the installer performs.
 
 ## Prerequisites
 
-- PHP **^8.5** (a deliberate floor — the package builds on 8.5 language features)
+- PHP **^8.4**
 - Laravel **13** (`illuminate/*` **^13.0**)
-- `laravel/ai` **^0.9** (a transitive dependency, installed by Composer)
+- `laravel/ai` **^0.10.3** (a transitive dependency, installed by Composer)
 
-As of **v0.20.0** the `laravel/ai` floor is **^0.9**; support for **0.8** was
-dropped (0.6 / 0.7 were dropped earlier, in v0.13.0). Applications pinned below
-`laravel/ai` 0.9 must upgrade before taking this release.
+PHP **^8.4** is supported alongside PHP 8.5. As of **v0.24.0** the
+`laravel/ai` floor is **^0.10.3**; support for **0.9** was dropped then (0.8 was
+dropped in v0.20.0, and 0.6 / 0.7 earlier still, in v0.13.0). Applications
+pinned below `laravel/ai` 0.10.3 must upgrade before taking this release.
 
 **No special stability configuration is required.** `laravel/ai` ships stable
-tags on the 0.9 line, so this package declares `"minimum-stability": "stable"`
+tags on the 0.10 line, so this package declares `"minimum-stability": "stable"`
 and installs cleanly into an application that does the same.
 
 Before **v0.23.0** this page asked you to set `"minimum-stability": "dev"` in


### PR DESCRIPTION
## Summary

- lower Laravel Swarm core runtime support to PHP ^8.4 while retaining PHP 8.5
- test PHP 8.4 and 8.5 against stable-latest and lowest dependency sets
- run minimum-runtime real-database lanes on PHP 8.4
- align requirements, contributor guidance, getting-started docs, and v0.25.0 changelog
- consume the published installer-testkit v0.1.3 compatibility release

## Proof

- four fresh Packagist dependency solves on PHP 8.4/8.5 latest/lowest
- full suite in every lane: 2,020 tests / 8,092 assertions
- PHPStan, strict Composer validation, and platform checks in every lane
- compliance and lint on both stable-latest runtimes
- process-concurrency on all four lanes: 7 tests / 23 assertions
- PHP-floor negative control fails under the deliberate ^8.5 mismatch and passes after restoration

## Ecosystem sequencing

This core topic lands first on `release/v0.25.0`. Companion PRs then prove their PHP 8.4 lanes against immutable core candidate `97bf2267ca347ce3886c81c9d72d3e6ac05ddb89`. Final Packagist-only PHP 8.4 proof remains a release-deploy gate after core v0.25.0 is tagged. Published recovery is forward-fix, not tag mutation.

Tracks #493