### PR TITLE
docs(release): refresh PHP 8.4 readiness evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,9 +102,12 @@ The child operational-input question and dispatch strand moved to v0.26.0 on
 - **Vector-backed memory remains installable with the current core release.**
   Companion package `builtbyberry/laravel-swarm-memory-vector` v0.1.2 widens its
   core constraint through `^0.25` while retaining Laravel AI support through
-  `^0.10.3`. Its full suite passes against every supported published core line
-  from v0.20 through v0.24. Its final compatibility proof is rerun against the
-  exact v0.25 wrap commit and records that core SHA before release handoff.
+  `^0.10.3`; v0.1.3 adds PHP 8.4 support while preserving that compatibility.
+  The published v0.1.3 suite passes against every supported published core line
+  from v0.20 through v0.24, and its PHP 8.4 candidate proof passed against
+  immutable core commit `97bf2267ca347ce3886c81c9d72d3e6ac05ddb89`
+  before release handoff. A final Packagist-only proof follows the core v0.25.0
+  tag, as tracked by #493.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,8 +103,8 @@ The child operational-input question and dispatch strand moved to v0.26.0 on
   Companion package `builtbyberry/laravel-swarm-memory-vector` v0.1.2 widens its
   core constraint through `^0.25` while retaining Laravel AI support through
   `^0.10.3`; v0.1.3 adds PHP 8.4 support while preserving that compatibility.
-  The published v0.1.3 suite passes against every supported published core line
-  from v0.20 through v0.24, and its PHP 8.4 candidate proof passed against
+  The published v0.1.3 suite passes against the supported range endpoints,
+  core v0.20.0 and v0.24.1, and its PHP 8.4 candidate proof passed against
   immutable core commit `97bf2267ca347ce3886c81c9d72d3e6ac05ddb89`
   before release handoff. A final Packagist-only proof follows the core v0.25.0
   tag, as tracked by #493.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1016,4 +1016,4 @@ For aggregate Pulse internals — period selectors, recorder enable flag, troubl
 - [Durable Execution](durable-execution.md) — checkpointing, crash-resume, and replay
 - [Configuration](configuration.md) — `swarm.memory.replay_mode` and all memory config keys
 - [Public Surface](public-surface.md) — `SwarmMemory`, `MemoryEntry`, `MemoryScope`, `MemorySnapshot`, `ReplayMode`, `#[MemoryReplay]` in the public surface matrix
-- [laravel-swarm-memory-vector](https://github.com/builtbyberry/laravel-swarm-memory-vector#requirements) — vector-backed recall companion package; v0.1.2 supports Laravel Swarm ^0.20–^0.25 and Laravel AI ^0.9 or ^0.10.3. Let Composer select a compatible tagged release.
+- [laravel-swarm-memory-vector](https://github.com/builtbyberry/laravel-swarm-memory-vector#requirements) — vector-backed recall companion package; v0.1.3 supports PHP ^8.4, Laravel Swarm ^0.20–^0.25, and Laravel AI ^0.9 or ^0.10.3. Let Composer select a compatible tagged release.


### PR DESCRIPTION
## Summary

- distinguish the vector-memory v0.1.2 core-range widening from v0.1.3 PHP 8.4 support
- cite the immutable core candidate used by the PHP 8.4 proof
- keep the final Packagist-only proof explicit as the post-tag #493 gate
- update the memory guide to the current published companion release

## Verification

- `composer test -- --filter=DocumentationReferenceTest`
- `composer lint`
- `git diff --check`

Addresses Marshall readiness finding RR14.